### PR TITLE
Fix colors with echo commands

### DIFF
--- a/src/commands/common-script.sh
+++ b/src/commands/common-script.sh
@@ -14,7 +14,7 @@ checkEnv() {
     REQUIREMENTS='curl groups sudo'
     for req in ${REQUIREMENTS}; do
         if ! command_exists ${req}; then
-            echo "${RED}To run me, you need: ${REQUIREMENTS}${RC}"
+            echo -e "${RED}To run me, you need: ${REQUIREMENTS}${RC}"
             exit 1
         fi
     done
@@ -30,7 +30,7 @@ checkEnv() {
     done
 
     if [ -z "${PACKAGER}" ]; then
-        echo "${RED}Can't find a supported package manager${RC}"
+        echo -e "${RED}Can't find a supported package manager${RC}"
         exit 1
     fi
 
@@ -46,7 +46,7 @@ checkEnv() {
 
     ## Check if member of the sudo group.
     if ! groups | grep -q ${SUGROUP}; then
-        echo "${RED}You need to be a member of the sudo group to run me!${RC}"
+        echo -e "${RED}You need to be a member of the sudo group to run me!${RC}"
         exit 1
     fi
 

--- a/src/commands/dotfiles/alacritty-setup.sh
+++ b/src/commands/dotfiles/alacritty-setup.sh
@@ -14,7 +14,7 @@ checkEnv() {
     REQUIREMENTS='curl groups sudo'
     for req in ${REQUIREMENTS}; do
         if ! command_exists ${req}; then
-            echo "${RED}To run me, you need: ${REQUIREMENTS}${RC}"
+            echo -e "${RED}To run me, you need: ${REQUIREMENTS}${RC}"
             exit 1
         fi
     done
@@ -30,7 +30,7 @@ checkEnv() {
     done
 
     if [ -z "${PACKAGER}" ]; then
-        echo "${RED}Can't find a supported package manager${RC}"
+        echo -e "${RED}Can't find a supported package manager${RC}"
         exit 1
     fi
 
@@ -46,7 +46,7 @@ checkEnv() {
 
     ## Check if member of the sudo group.
     if ! groups | grep -q ${SUGROUP}; then
-        echo "${RED}You need to be a member of the sudo group to run me!${RC}"
+        echo -e "${RED}You need to be a member of the sudo group to run me!${RC}"
         exit 1
     fi
 

--- a/src/commands/dotfiles/kitty-setup.sh
+++ b/src/commands/dotfiles/kitty-setup.sh
@@ -14,7 +14,7 @@ checkEnv() {
     REQUIREMENTS='curl groups sudo'
     for req in ${REQUIREMENTS}; do
         if ! command_exists ${req}; then
-            echo "${RED}To run me, you need: ${REQUIREMENTS}${RC}"
+            echo -e "${RED}To run me, you need: ${REQUIREMENTS}${RC}"
             exit 1
         fi
     done
@@ -30,7 +30,7 @@ checkEnv() {
     done
 
     if [ -z "${PACKAGER}" ]; then
-        echo "${RED}Can't find a supported package manager${RC}"
+        echo -e "${RED}Can't find a supported package manager${RC}"
         exit 1
     fi
 
@@ -46,7 +46,7 @@ checkEnv() {
 
     ## Check if member of the sudo group.
     if ! groups | grep -q ${SUGROUP}; then
-        echo "${RED}You need to be a member of the sudo group to run me!${RC}"
+        echo -e "${RED}You need to be a member of the sudo group to run me!${RC}"
         exit 1
     fi
 

--- a/src/commands/dotfiles/rofi-setup.sh
+++ b/src/commands/dotfiles/rofi-setup.sh
@@ -14,7 +14,7 @@ checkEnv() {
     REQUIREMENTS='curl groups sudo'
     for req in $REQUIREMENTS; do
         if ! command_exists "$req"; then
-            printf "${RED}To run me, you need: %s${RC}\n" "$REQUIREMENTS"
+            echo -e "${RED}To run me, you need: ${REQUIREMENTS}${RC}"
             exit 1
         fi
     done
@@ -24,13 +24,13 @@ checkEnv() {
     for pgm in $PACKAGEMANAGER; do
         if command_exists "$pgm"; then
             PACKAGER="$pgm"
-            printf "Using %s\n" "$pgm"
+            echo "Using $pgm"
             break
         fi
     done
 
     if [ -z "$PACKAGER" ]; then
-        printf "${RED}Can't find a supported package manager${RC}\n"
+        echo -e "${RED}Can't find a supported package manager${RC}"
         exit 1
     fi
 
@@ -39,14 +39,14 @@ checkEnv() {
     for sug in $SUPERUSERGROUP; do
         if groups | grep -q "$sug"; then
             SUGROUP="$sug"
-            printf "Super user group %s\n" "$SUGROUP"
+            echo "Super user group $SUGROUP"
             break
         fi
     done
 
     ## Check if member of the sudo group.
     if ! groups | grep -q "$SUGROUP"; then
-        printf "${RED}You need to be a member of the sudo group to run me!${RC}\n"
+        echo -e "${RED}You need to be a member of the sudo group to run me!${RC}\n"
         exit 1
     fi
 

--- a/src/commands/system-setup/1-compile-setup.sh
+++ b/src/commands/system-setup/1-compile-setup.sh
@@ -9,18 +9,18 @@ GREEN='\033[32m'
 LINUXTOOLBOXDIR="$HOME/linuxtoolbox"
 
 if [ ! -d "$LINUXTOOLBOXDIR" ]; then
-    echo "${YELLOW}Creating linuxtoolbox directory: $LINUXTOOLBOXDIR${RC}"
+    echo -e "${YELLOW}Creating linuxtoolbox directory: $LINUXTOOLBOXDIR${RC}"
     mkdir -p "$LINUXTOOLBOXDIR"
-    echo "${GREEN}linuxtoolbox directory created: $LINUXTOOLBOXDIR${RC}"
+    echo -e "${GREEN}linuxtoolbox directory created: $LINUXTOOLBOXDIR${RC}"
 fi
 
 if [ ! -d "$LINUXTOOLBOXDIR/linux-setup" ]; then
-    echo "${YELLOW}Cloning linux-setup repository into: $LINUXTOOLBOXDIR/linux-setup${RC}"
+    echo -e "${YELLOW}Cloning linux-setup repository into: $LINUXTOOLBOXDIR/linux-setup${RC}"
     git clone https://github.com/ChrisTitusTech/linux-setup "$LINUXTOOLBOXDIR/linux-setup"
     if [ $? -eq 0 ]; then
-        echo "${GREEN}Successfully cloned linux-setup repository${RC}"
+        echo -e "${GREEN}Successfully cloned linux-setup repository${RC}"
     else
-        echo "${RED}Failed to clone linux-setup repository${RC}"
+        echo -e "${RED}Failed to clone linux-setup repository${RC}"
         exit 1
     fi
 fi
@@ -36,7 +36,7 @@ checkEnv() {
     REQUIREMENTS='curl groups sudo'
     for req in $REQUIREMENTS; do
         if ! command_exists "$req"; then
-            echo "${RED}To run me, you need: $REQUIREMENTS${RC}"
+            echo -e "${RED}To run me, you need: $REQUIREMENTS${RC}"
             exit 1
         fi
     done
@@ -52,14 +52,14 @@ checkEnv() {
     done
 
     if [ -z "$PACKAGER" ]; then
-        echo "${RED}Can't find a supported package manager${RC}"
+        echo -e "${RED}Can't find a supported package manager${RC}"
         exit 1
     fi
 
     ## Check if the current directory is writable.
     GITPATH="$(dirname "$(realpath "$0")")"
     if [ ! -w "$GITPATH" ]; then
-        echo "${RED}Can't write to $GITPATH${RC}"
+        echo -e "${RED}Can't write to $GITPATH${RC}"
         exit 1
     fi
 
@@ -75,7 +75,7 @@ checkEnv() {
 
     ## Check if member of the sudo group.
     if ! groups | grep -q "$SUGROUP"; then
-        echo "${RED}You need to be a member of the sudo group to run me!${RC}"
+        echo -e "${RED}You need to be a member of the sudo group to run me!${RC}"
         exit 1
     fi
 }
@@ -83,7 +83,7 @@ checkEnv() {
 installDepend() {
     ## Check for dependencies.
     DEPENDENCIES='tar tree multitail tldr trash-cli unzip cmake make jq'
-    echo "${YELLOW}Installing dependencies...${RC}"
+    echo -e "${YELLOW}Installing dependencies...${RC}"
     case $PACKAGER in
         pacman)
             if ! grep -q "^\s*\[multilib\]" /etc/pacman.conf; then

--- a/src/commands/system-setup/2-gaming-setup.sh
+++ b/src/commands/system-setup/2-gaming-setup.sh
@@ -22,7 +22,7 @@ checkEnv() {
     for pgm in ${PACKAGEMANAGER}; do
         if command_exists ${pgm}; then
             PACKAGER=${pgm}
-            echo -e "Using ${pgm}"
+            echo "Using ${pgm}"
         fi
     done
 
@@ -43,7 +43,7 @@ checkEnv() {
     for sug in ${SUPERUSERGROUP}; do
         if groups | grep ${sug}; then
             SUGROUP=${sug}
-            echo -e "Super user group ${SUGROUP}"
+            echo "Super user group ${SUGROUP}"
         fi
     done
 

--- a/src/commands/system-update.sh
+++ b/src/commands/system-update.sh
@@ -14,7 +14,7 @@ checkEnv() {
     REQUIREMENTS='curl groups sudo'
     for req in ${REQUIREMENTS}; do
         if ! command_exists ${req}; then
-            printf "${RED}To run me, you need: ${REQUIREMENTS}${RC}\n"
+            echo -e "${RED}To run me, you need: ${REQUIREMENTS}${RC}"
             exit 1
         fi
     done
@@ -23,13 +23,13 @@ checkEnv() {
     for pgm in ${PACKAGEMANAGER}; do
         if command_exists ${pgm}; then
             PACKAGER=${pgm}
-            printf "Using ${pgm}\n"
+            echo "Using ${pgm}"
             break
         fi
     done
 
     if [ -z "${PACKAGER}" ]; then
-        printf "${RED}Can't find a supported package manager${RC}\n"
+        echo -e "${RED}Can't find a supported package manager${RC}"
         exit 1
     fi
 
@@ -38,14 +38,14 @@ checkEnv() {
     for sug in ${SUPERUSERGROUP}; do
         if groups | grep ${sug} >/dev/null; then
             SUGROUP=${sug}
-            printf "Super user group ${SUGROUP}\n"
+            echo "Super user group ${SUGROUP}"
             break
         fi
     done
 
     ## Check if member of the sudo group.
     if ! groups | grep ${SUGROUP} >/dev/null; then
-        printf "${RED}You need to be a member of the sudo group to run me!${RC}\n"
+        echo -e "${RED}You need to be a member of the sudo group to run me!${RC}"
         exit 1
     fi
 
@@ -61,19 +61,19 @@ fastUpdate() {
     case ${PACKAGER} in
         pacman)
             if ! command_exists yay && ! command_exists paru; then
-                printf "Installing yay as AUR helper...\n"
-                sudo ${PACKAGER} --noconfirm -S base-devel || { printf "${RED}Failed to install base-devel${RC}\n"; exit 1; }
+                echo "Installing yay as AUR helper..."
+                sudo ${PACKAGER} --noconfirm -S base-devel || { echo -e "${RED}Failed to install base-devel${RC}"; exit 1; }
                 cd /opt && sudo git clone https://aur.archlinux.org/yay-git.git && sudo chown -R ${USER}:${USER} ./yay-git
-                cd yay-git && makepkg --noconfirm -si || { printf "${RED}Failed to install yay${RC}\n"; exit 1; }
+                cd yay-git && makepkg --noconfirm -si || { echo -e "${RED}Failed to install yay${RC}"; exit 1; }
             else
-                printf "Aur helper already installed\n"
+                echo "Aur helper already installed"
             fi
             if command_exists yay; then
                 AUR_HELPER="yay"
             elif command_exists paru; then
                 AUR_HELPER="paru"
             else
-                printf "No AUR helper found. Please install yay or paru.\n"
+                echo "No AUR helper found. Please install yay or paru."
                 exit 1
             fi
             ${AUR_HELPER} --noconfirm -S rate-mirrors-bin
@@ -89,7 +89,7 @@ fastUpdate() {
         apt-get|nala)
             sudo apt-get update
             if ! command_exists nala; then
-                sudo apt-get install -y nala || { printf "${YELLOW}Falling back to apt-get${RC}\n"; PACKAGER="apt-get"; }
+                sudo apt-get install -y nala || { echo -e "${YELLOW}Falling back to apt-get${RC}"; PACKAGER="apt-get"; }
             fi
             if [ "${PACKAGER}" = "nala" ]; then
                 sudo cp /etc/apt/sources.list /etc/apt/sources.list.bak
@@ -110,14 +110,14 @@ fastUpdate() {
             sudo ${PACKAGER} upgrade -y
             ;;
         *)
-            printf "${RED}Unsupported package manager: ${PACKAGER}${RC}\n"
+            echo -e "${RED}Unsupported package manager: $PACKAGER${RC}"
             exit 1
             ;;
     esac
 }
 
 updateSystem() {
-    printf "${GREEN}Updating system${RC}\n"
+    echo -e "${GREEN}Updating system${RC}"
     case ${PACKAGER} in
         nala|apt-get)
             sudo ${PACKAGER} update -y
@@ -135,7 +135,7 @@ updateSystem() {
             sudo ${PACKAGER} update -y
             ;;
         *)
-            printf "${RED}Unsupported package manager: ${PACKAGER}${RC}\n"
+            echo -e "${RED}Unsupported package manager: ${PACKAGER}${RC}"
             exit 1
             ;;
     esac

--- a/start.sh
+++ b/start.sh
@@ -10,7 +10,7 @@ check() {
     local message=$2
 
     if [ $exit_code -ne 0 ]; then
-        echo "${RED}ERROR: $message${RC}"
+        echo -e "${RED}ERROR: $message${RC}"
         exit 1
     fi
 }

--- a/startdev.sh
+++ b/startdev.sh
@@ -33,7 +33,7 @@ check() {
     local message=$2
 
     if [ $exit_code -ne 0 ]; then
-        echo "${RED}ERROR: $message${RC}"
+        echo -e "${RED}ERROR: $message${RC}"
         exit 1
     fi
 }


### PR DESCRIPTION
Use the `-e` option when using the `echo` command, as backslashes are not interpreted by default.  This causes `echo` to print color escape codes as-is.  This PR also replaces existing `printf` calls with `echo` for consistency.