### PR TITLE
Changed zypper update

### DIFF
--- a/src/commands/system-update.sh
+++ b/src/commands/system-update.sh
@@ -102,8 +102,8 @@ fastUpdate() {
             sudo ${PACKAGER} update -y
             ;;
         zypper)
-            sudo ${PACKAGER} refresh
-            sudo ${PACKAGER} update -y
+            sudo ${PACKAGER} ref
+            sudo ${PACKAGER} --non-interactive dup
             ;;
         yum)
             sudo ${PACKAGER} update -y
@@ -131,8 +131,8 @@ updateSystem() {
             sudo ${PACKAGER} -Syu --noconfirm
             ;;
         zypper)
-            sudo ${PACKAGER} refresh
-            sudo ${PACKAGER} update -y
+            sudo ${PACKAGER} ref
+            sudo ${PACKAGER} --non-interactive dup
             ;;
         *)
             printf "${RED}Unsupported package manager: ${PACKAGER}${RC}\n"


### PR DESCRIPTION
- Changed to use zypper dup, because that's the way to update openSUSE Tumbleweed and Slowroll installs