### PR TITLE
minor: shorter oneliner

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Open your terminal and paste this command
 ```bash
-curl -fsSL https://github.com/ChrisTitusTech/linutil/releases/latest/download/start.sh | sh
+bash <(wget -qO- https://christitus.com/linux)
 ```
 
 ## Credits

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Open your terminal and paste this command
 ```bash
-bash <(wget -qO- https://christitus.com/linux)
+curl -fsSL https://christitus.com/linux | sh
 ```
 
 ## Credits


### PR DESCRIPTION
This the the current one-liner:

```bash
curl -fsSL https://github.com/ChrisTitusTech/linutil/releases/latest/download/start.sh | sh
```

But this one looks better :D

```bash
bash <(wget -qO- https://christitus.com/linux)
```

I know the URL does not point to the script yet, but would be awesome to see this one go live!

closes #22 