### PR TITLE
CI: Add lint checks & change actions-rs/toolchain to dtolnay/rust-toolchain

### DIFF
--- a/.github/workflows/linutil.yml
+++ b/.github/workflows/linutil.yml
@@ -30,9 +30,7 @@ jobs:
         key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
         restore-keys: ${{ runner.os }}-cargo-index-
     - name: Install Rust
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
+      uses: dtolnay/rust-toolchain@stable
     - name: Build
       run: cargo build --target-dir=build --release --verbose
     - uses: stefanzweifel/git-auto-commit-action@v5

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,11 +9,12 @@ env:
 
 jobs:
   cargo_check:
+    name: Cargo Check
     runs-on: ubuntu-latest
 
     steps:
     - name: Checkout sources
-    - uses: actions/checkout@v4
+      uses: actions/checkout@v4
 
     - name: Cache Cargo registry
       uses: actions/cache@v4
@@ -36,11 +37,12 @@ jobs:
       run: cargo check
 
   lints:
+    name: Lints
     runs-on: ubuntu-latest
 
     steps:
     - name: Checkout sources
-    - uses: actions/checkout@v4
+      uses: actions/checkout@v4
 
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,20 +14,24 @@ jobs:
     steps:
     - name: Checkout sources
     - uses: actions/checkout@v4
+
     - name: Cache Cargo registry
       uses: actions/cache@v4
       with:
         path: ~/.cargo/registry
         key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
         restore-keys: ${{ runner.os }}-cargo-registry-
+
     - name: Cache Cargo index
       uses: actions/cache@v4
       with:
         path: ~/.cargo/git
         key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
         restore-keys: ${{ runner.os }}-cargo-index-
+
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable
+
     - name: Build
       run: cargo check
 
@@ -37,9 +41,12 @@ jobs:
     steps:
     - name: Checkout sources
     - uses: actions/checkout@v4
+
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable
+
     - name: Run cargo fmt
       run: cargo fmt --all --check
+
     - name: Run cargo clippy
       run: cargo clippy

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,4 @@
-name: Rust Check
+name: Rust Checks
 
 on:
   pull_request:
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Checkout sources
     - uses: actions/checkout@v4
     - name: Cache Cargo registry
       uses: actions/cache@v4
@@ -26,8 +27,19 @@ jobs:
         key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
         restore-keys: ${{ runner.os }}-cargo-index-
     - name: Install Rust
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
+      uses: dtolnay/rust-toolchain@stable
     - name: Build
       run: cargo check
+
+  lints:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout sources
+    - uses: actions/checkout@v4
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@stable
+    - name: Run cargo fmt
+      run: cargo --fmt --all check
+    - name: Run cargo clippy
+      run: cargo clippy

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -40,6 +40,6 @@ jobs:
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable
     - name: Run cargo fmt
-      run: cargo --fmt --all check
+      run: cargo fmt --all --check
     - name: Run cargo clippy
       run: cargo clippy


### PR DESCRIPTION
I added `cargo fmt --all --check`, `cargo clippy` and changed `actions-rs/toolchain` to `dtolnay/rust-toolchain` because [actions-rs/toolchain](https://github.com/actions-rs/toolchain) is no longer maintained.

[Rust FMT](https://github.com/rust-lang/rustfmt) is a tool for correctly formatting Rust code and [clippy](https://github.com/rust-lang/rust-clippy) is a lint-checker for improving Rust code ([docs](https://doc.rust-lang.org/clippy))