### PR TITLE
very minor init script changes

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,31 +1,34 @@
 #!/bin/sh
 
-RC='\033[0m'
-RED='\033[0;31m'
+rc='\033[0m'
+red='\033[0;31m'
 
-linutil="https://github.com/ChrisTitusTech/linutil/releases/latest/download/linutil"
+binary_url="https://github.com/ChrisTitusTech/linutil/releases/latest/download/linutil"
 
 check() {
-    local exit_code=$1
-    local message=$2
+    exit_code=$1
+    message=$2
 
-    if [ $exit_code -ne 0 ]; then
-        echo -e "${RED}ERROR: $message${RC}"
+    if [ "$exit_code" -ne 0 ]; then
+        printf '%sERROR: %s%s\n' "$red" "$message" "$rc"
         exit 1
     fi
+
+	unset exit_code
+	unset message
 }
 
-TMPFILE=$(mktemp)
+temp_file=$(mktemp)
 check $? "Creating the temporary file"
 
-curl -fsL $linutil -o $TMPFILE
+curl -fsL "$binary_url" -o "$temp_file"
 check $? "Downloading linutil"
 
-chmod +x $TMPFILE
+chmod +x "$temp_file"
 check $? "Making linutil executable"
 
-"$TMPFILE"
+"$temp_file"
 check $? "Executing linutil"
 
-rm -f $TMPFILE
+rm -f "$temp_file"
 check $? "Deleting the temporary file"


### PR DESCRIPTION
* fix shellcheck warnings
* rename variables to be consistent
* use printf instead of echo (printf is a shell builtin)

i'd like to add that `local` is a bashism, and won't run on POSIX shells like dash. i've opted to just use `unset` after the function does its check, which works fine in this scenario. if not, you can also just change the shebang to `#!/usr/bin/env bash`.

the shellcheck warnings that were fixed can be found here:

* https://www.shellcheck.net/wiki/SC3037
* https://www.shellcheck.net/wiki/SC3043
* https://www.shellcheck.net/wiki/SC2086