### PR TITLE
chore: Build linutil against musl libc

### DIFF
--- a/.github/workflows/linutil.yml
+++ b/.github/workflows/linutil.yml
@@ -2,7 +2,7 @@ name: LinUtil Release
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
 
 permissions:
   contents: write
@@ -16,25 +16,27 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Cache Cargo registry
-      uses: actions/cache@v4
-      with:
-        path: ~/.cargo/registry
-        key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-        restore-keys: ${{ runner.os }}-cargo-registry-
-    - name: Cache Cargo index
-      uses: actions/cache@v4
-      with:
-        path: ~/.cargo/git
-        key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
-        restore-keys: ${{ runner.os }}-cargo-index-
-    - name: Install Rust
-      uses: dtolnay/rust-toolchain@stable
-    - name: Build
-      run: cargo build --target-dir=build --release --verbose
-    - uses: stefanzweifel/git-auto-commit-action@v5
-      with:
-        commit_message: Commit Linutil
-        file_pattern: 'build/release/linutil'
-      if: success()
+      - uses: actions/checkout@v4
+      - name: Cache Cargo registry
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-registry-
+      - name: Cache Cargo index
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-index-
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-unknown-linux-musl
+      - name: Build
+        run: cargo build --target-dir=build --release --verbose --target=x86_64-unknown-linux-musl
+      - uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: Commit Linutil
+          file_pattern: "build/x86_64-unknown-linux-musl/release/linutil"
+        if: success()

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -1,8 +1,8 @@
 name: Pre-Release LinUtil
 
 permissions:
-  contents: write  # Grant write permissions to contents
-  packages: write  # Grant write permissions to packages
+  contents: write # Grant write permissions to contents
+  packages: write # Grant write permissions to packages
 
 on:
   workflow_dispatch: # Manual trigger added
@@ -30,7 +30,7 @@ jobs:
           body: "![GitHub Downloads (specific asset, specific tag)](https://img.shields.io/github/downloads/ChrisTitusTech/linutil/${{ env.version }}/linutil)"
           append_body: false
           files: |
-            ./build/release/linutil
+            ./build/x86_64-unknown-linux-musl/release/linutil
           prerelease: true
           generate_release_notes: true
         env:


### PR DESCRIPTION
# Pull Request

## Title
Statically link linutil binary against musl libc 

## Type of Change
- [x] Bug fix

## Description
Modify GitHub workflows to build the linutil binary against the x86_64-unknown-linux-musl target. This leads to the binary being statically linked against the musl libc, removing the glibc dependency. This will improve compatibility on distros which include a different libc or a build of glibc which isn't supported by rust's x86_64-unknown-linux-gnu target in the current toolchain version. 

## Testing
The TUI successfully builds against the musl target, and successfully launches.

## Impact
The size of the binary increases by a small amount (~100KB) due to static linking. The performance impact should be negligible.

## Issue related to PR
- Resolves #37

## Additional Information
Other changes to the workflow files are from format on save

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no errors/warnings/merge conflicts.
