### PR TITLE
refactor: Handle `source` and `.` in scripts during build

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -55,7 +55,7 @@ fn replace_source(file: &Path) -> String {
         .map(|line| {
             if line.starts_with(". ") || line.starts_with("source ") {
                 let (_, sourced_file) = line.split_once(' ').unwrap();
-                let sourced_file = filedir.join(sourced_file);
+                let sourced_file = filedir.join(sourced_file.trim_start());
                 if !(sourced_file.exists() && has_shell_ext(&sourced_file)) {
                     return line.to_string();
                 }

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,65 @@
+use std::{
+    env, fs,
+    io::Write,
+    path::{Path, PathBuf},
+};
+
+const SCRIPT_PATH: &str = "src/commands/";
+
+fn main() {
+    let out_dir = env::var("OUT_DIR").unwrap();
+    let file_list = get_script_list(Path::new(SCRIPT_PATH));
+    replace_source(file_list, out_dir.into());
+}
+
+fn get_script_list(path: &Path) -> Vec<PathBuf> {
+    let paths = path.read_dir().unwrap();
+    paths
+        .into_iter()
+        .flatten()
+        .filter_map(|entry| {
+            let path = entry.path();
+            // Recursively iterate through directories
+            if entry.file_type().map_or(false, |f| f.is_dir()) {
+                get_script_list(&path).into()
+            } else {
+                let is_script = fs::read_to_string(&path).map_or(false, |f| f.starts_with("#!"));
+                is_script.then_some(vec![path])
+            }
+        })
+        .flatten()
+        .collect()
+}
+
+fn replace_source(files: Vec<PathBuf>, out_dir: PathBuf) {
+    for file in files {
+        println!("cargo:rerun-if-changed={}", file.display());
+
+        let mut out_file = create_out_file(&file, out_dir.clone());
+        let contents = fs::read_to_string(&file).unwrap();
+        let filedir = file.parent().unwrap();
+
+        let new_file = contents
+            .lines()
+            .map(|line| {
+                if line.starts_with(". ") || line.starts_with("source ") {
+                    let (_, sourced_file) = line.split_once(' ').unwrap();
+                    let sourced_file = filedir.join(sourced_file);
+                    std::fs::read_to_string(&sourced_file).unwrap()
+                } else {
+                    line.to_string()
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        out_file.write_all(new_file.as_bytes()).unwrap()
+    }
+}
+
+fn create_out_file(file: &Path, out_dir: PathBuf) -> fs::File {
+    let out_file = out_dir.clone().join(&file);
+    let out_file_parent = out_file.parent().unwrap();
+    std::fs::create_dir_all(out_file_parent).unwrap();
+    fs::File::create(out_file).unwrap()
+}

--- a/build.rs
+++ b/build.rs
@@ -56,7 +56,7 @@ fn replace_source(file: &Path) -> String {
             if line.starts_with(". ") || line.starts_with("source ") {
                 let (_, sourced_file) = line.split_once(' ').unwrap();
                 let sourced_file = filedir.join(sourced_file);
-                if !(sourced_file.exists() && is_script(&sourced_file)) {
+                if !(sourced_file.exists() && has_shell_ext(&sourced_file)) {
                     return line.to_string();
                 }
                 replace_source(&sourced_file)

--- a/build.rs
+++ b/build.rs
@@ -1,12 +1,15 @@
 use std::{
     env, fs,
-    io::Write,
+    io::{Read, Write},
     path::{Path, PathBuf},
 };
 
 const SCRIPT_PATH: &str = "src/commands/";
 
 fn main() {
+    // Rerun build step if the build script is modified
+    println!("cargo:rerun-if-changed=build.rs");
+
     let out_dir = env::var("OUT_DIR").unwrap();
     let file_list = get_script_list(Path::new(SCRIPT_PATH));
     replace_source(file_list, out_dir.into());
@@ -23,7 +26,7 @@ fn get_script_list(path: &Path) -> Vec<PathBuf> {
             if entry.file_type().map_or(false, |f| f.is_dir()) {
                 get_script_list(&path).into()
             } else {
-                let is_script = fs::read_to_string(&path).map_or(false, |f| f.starts_with("#!"));
+                let is_script = has_shell_ext(&path) && starts_with_shebang(&path);
                 is_script.then_some(vec![path])
             }
         })
@@ -33,6 +36,7 @@ fn get_script_list(path: &Path) -> Vec<PathBuf> {
 
 fn replace_source(files: Vec<PathBuf>, out_dir: PathBuf) {
     for file in files {
+        // Rerun build step if any script is modified
         println!("cargo:rerun-if-changed={}", file.display());
 
         let mut out_file = create_out_file(&file, out_dir.clone());
@@ -58,8 +62,19 @@ fn replace_source(files: Vec<PathBuf>, out_dir: PathBuf) {
 }
 
 fn create_out_file(file: &Path, out_dir: PathBuf) -> fs::File {
-    let out_file = out_dir.clone().join(&file);
+    let out_file = out_dir.clone().join(file);
     let out_file_parent = out_file.parent().unwrap();
     std::fs::create_dir_all(out_file_parent).unwrap();
     fs::File::create(out_file).unwrap()
+}
+
+fn has_shell_ext(file: &Path) -> bool {
+    file.extension().map_or(true, |ext| ext == "sh")
+}
+
+fn starts_with_shebang(file: &Path) -> bool {
+    fs::File::open(file).map_or(false, |mut file| {
+        let mut two_byte_buffer = [0; 2];
+        file.read_exact(&mut two_byte_buffer).is_ok() && two_byte_buffer == *b"#!"
+    })
 }

--- a/src/commands/dotfiles/alacritty-setup.sh
+++ b/src/commands/dotfiles/alacritty-setup.sh
@@ -1,5 +1,7 @@
 #!/bin/sh -e
 
+. ../common-script.sh
+
 setupAlacritty() {
     echo "Install Alacritty if not already installed..."
     if ! command_exists alacritty; then

--- a/src/commands/dotfiles/kitty-setup.sh
+++ b/src/commands/dotfiles/kitty-setup.sh
@@ -1,5 +1,7 @@
 #!/bin/sh -e
 
+. ../common-script.sh
+
 setupKitty() {
     echo "Install Kitty if not already installed..."
     if ! command_exists kitty; then

--- a/src/commands/dotfiles/rofi-setup.sh
+++ b/src/commands/dotfiles/rofi-setup.sh
@@ -1,5 +1,7 @@
 #!/bin/sh -e
 
+. ../common-script.sh
+
 setupRofi() {
     echo "Install Rofi if not already installed..."
     if ! command_exists rofi; then

--- a/src/commands/system-setup/1-compile-setup.sh
+++ b/src/commands/system-setup/1-compile-setup.sh
@@ -1,5 +1,7 @@
 #!/bin/sh -e
 
+. ../common-script.sh
+
 # Check if the home directory and linuxtoolbox folder exist, create them if they don't
 LINUXTOOLBOXDIR="$HOME/linuxtoolbox"
 
@@ -58,7 +60,7 @@ installDepend() {
             sudo "$PACKAGER" update
             sudo dpkg --add-architecture i386
             sudo "$PACKAGER" update
-            sudo "$PACKAGER" install -y "$DEPENDENCIES" $COMPILEDEPS 
+            sudo "$PACKAGER" install -y "$DEPENDENCIES" $COMPILEDEPS
             ;;
         dnf)
             COMPILEDEPS='@development-tools'
@@ -69,7 +71,7 @@ installDepend() {
             ;;
         zypper)
             COMPILEDEPS='patterns-devel-base-devel_basis'
-            sudo "$PACKAGER" refresh 
+            sudo "$PACKAGER" refresh
             sudo "$PACKAGER" --non-interactive install "$DEPENDENCIES" $COMPILEDEPS
             sudo "$PACKAGER" --non-interactive install libgcc_s1-gcc7-32bit glibc-devel-32bit
             ;;

--- a/src/commands/system-setup/2-gaming-setup.sh
+++ b/src/commands/system-setup/2-gaming-setup.sh
@@ -1,5 +1,7 @@
 #!/bin/sh -e
 
+. ../common-script.sh
+
 installDepend() {
     ## Check for dependencies.
     echo -e "${YELLOW}Installing dependencies...${RC}"
@@ -70,7 +72,7 @@ install_additional_dependencies() {
                 #Enable i386 repos
                 sudo dpkg --add-architecture i386
                 # Install software-properties-common to be able to add repos
-                sudo apt-get install -y software-properties-common 
+                sudo apt-get install -y software-properties-common
                 # Add repos necessary for installing steam
                 sudo apt-add-repository contrib -y
                 sudo apt-add-repository non-free -y
@@ -82,16 +84,16 @@ install_additional_dependencies() {
             fi
             ;;
         *zypper)
-            
+
             ;;
         *dnf)
-            
+
             ;;
         *pacman)
-            
+
             ;;
         *)
-            
+
             ;;
     esac
 }

--- a/src/commands/system-setup/3-global-theme.sh
+++ b/src/commands/system-setup/3-global-theme.sh
@@ -1,5 +1,7 @@
 #!/bin/sh -e
 
+. ../common-script.sh
+
 # Check if the home directory and linuxtoolbox folder exist, create them if they don't
 LINUXTOOLBOXDIR="$HOME/linuxtoolbox"
 

--- a/src/commands/system-update.sh
+++ b/src/commands/system-update.sh
@@ -1,5 +1,7 @@
 #!/bin/sh -e
 
+. common-script.sh
+
 fastUpdate() {
     case ${PACKAGER} in
         pacman)
@@ -23,7 +25,7 @@ fastUpdate() {
             if [ -s /etc/pacman.d/mirrorlist ]; then
                 sudo cp /etc/pacman.d/mirrorlist /etc/pacman.d/mirrorlist.bak
             fi
-            
+
             # If for some reason DTYPE is still unknown use always arch so the rate-mirrors does not fail
             dtype_local=${DTYPE}
             if [ "${DTYPE}" = "unknown" ]; then

--- a/src/list.rs
+++ b/src/list.rs
@@ -9,12 +9,9 @@ use ratatui::{
     Frame,
 };
 
-macro_rules! with_common_script {
+macro_rules! include_script {
     ($command:expr) => {
-        concat!(
-            include_str!("commands/common-script.sh"),
-            include_str!($command)
-        )
+        include_str!(concat!(env!("OUT_DIR"), "/src/", $command))
     };
 }
 
@@ -64,7 +61,7 @@ impl CustomList {
         } => {
             ListNode {
                 name: "Full System Update",
-                command: with_common_script!("commands/system-update.sh"),
+                command: include_script!("commands/system-update.sh"),
             },
             ListNode {
                 name: "Setup Bash Prompt",
@@ -84,15 +81,15 @@ impl CustomList {
             } => {
                 ListNode {
                     name: "Build Prerequisites",
-                    command: with_common_script!("commands/system-setup/1-compile-setup.sh"),
+                    command: include_script!("commands/system-setup/1-compile-setup.sh"),
                 },
                 ListNode {
                     name: "Gaming Dependencies",
-                    command: with_common_script!("commands/system-setup/2-gaming-setup.sh"),
+                    command: include_script!("commands/system-setup/2-gaming-setup.sh"),
                 },
                 ListNode {
                     name: "Global Theme",
-                    command: with_common_script!("commands/system-setup/3-global-theme.sh"),
+                    command: include_script!("commands/system-setup/3-global-theme.sh"),
                 },
                 ListNode {
                     name: "Recursion?",
@@ -105,15 +102,15 @@ impl CustomList {
             } => {
                 ListNode {
                     name: "Alacritty Setup",
-                    command: with_common_script!("commands/dotfiles/alacritty-setup.sh"),
+                    command: include_script!("commands/dotfiles/alacritty-setup.sh"),
                 },
                 ListNode {
                     name: "Kitty Setup",
-                    command: with_common_script!("commands/dotfiles/kitty-setup.sh"),
+                    command: include_script!("commands/dotfiles/kitty-setup.sh"),
                 },
                 ListNode {
                     name: "Rofi Setup",
-                    command: with_common_script!("commands/dotfiles/rofi-setup.sh"),
+                    command: include_script!("commands/dotfiles/rofi-setup.sh"),
                 },
             }
         });


### PR DESCRIPTION
# Pull Request

## Title
Handle `source` and `.` invocations in scripts during the build process.

## Type of Change
- [x] New feature
- [x] Refactoring

## Description
Remove macro to concatenate common-script with the given script. Instead, create a build script which recursively iterates through the src/commands/ directory and gathers a list of scripts (identified based on the beginning shebang). Each script is then modified (only in the build directory, not the actual repository) to replace lines of `source $file` or `. $file` with a copy of that file. A macro is then added to list.rs (include_script) in order to source the modified scripts from the build directory, rather than the unmodified scripts from the repository.

#82 attempts to implement this same feature, but it goes about it in a different way. Instead of modifying the files in the build step which will reliably include a copy of the script in the program, it uses 2 extra crates, one of which being unmaintained for the last 6 years, to include an entire directory in the build process, and create a temporary directory including those files at runtime.

- Closes #82 

## Testing
I've tested multiple scripts, including those in directories other than the same directory as common script. 

## Impact
Scripts can be used outside of linutil, and any file in the repository can be sourced if necessary, rather than just the common script. Scripts are also launched with the shebang contained within them, rather than the one in common-script, so if some script requires bash or another shell rather than a generic posix shell, it would be fully respected.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no errors/warnings/merge conflicts.
