### PR TITLE
fixed pkg manager checks

### DIFF
--- a/src/commands/system-setup/1-compile-setup.sh
+++ b/src/commands/system-setup/1-compile-setup.sh
@@ -53,7 +53,7 @@ installDepend() {
             fi
             "$AUR_HELPER" --noconfirm -S "$DEPENDENCIES"
             ;;
-        apt|apt-get|nala)
+        apt-get|nala)
             COMPILEDEPS='build-essential'
             sudo "$PACKAGER" update
             sudo dpkg --add-architecture i386

--- a/src/commands/system-setup/1-compile-setup.sh
+++ b/src/commands/system-setup/1-compile-setup.sh
@@ -53,12 +53,12 @@ installDepend() {
             fi
             "$AUR_HELPER" --noconfirm -S "$DEPENDENCIES"
             ;;
-        apt)
+        apt|apt-get|nala)
             COMPILEDEPS='build-essential'
             sudo "$PACKAGER" update
             sudo dpkg --add-architecture i386
             sudo "$PACKAGER" update
-            sudo "$PACKAGER" install -y "$DEPENDENCIES" $COMPILEDEPS 
+            sudo "$PACKAGER" install -y $DEPENDENCIES $COMPILEDEPS 
             ;;
         dnf)
             COMPILEDEPS='@development-tools'
@@ -74,7 +74,7 @@ installDepend() {
             sudo "$PACKAGER" --non-interactive install libgcc_s1-gcc7-32bit glibc-devel-32bit
             ;;
         *)
-            sudo "$PACKAGER" install -y "$DEPENDENCIES"
+            sudo "$PACKAGER" install -y $DEPENDENCIES # Fixed bug where no packages found on debian-based
             ;;
     esac
 }


### PR DESCRIPTION
# Pull Request

## Package manager detection bug
Hello, this is my first contribution, I was using your script and saw that when using
the Build Prerequisites feature, APT was not finding the packages on my kubuntu install.
It would spit out a error saying that the packages were not found (even though they exist). I found out that it was because of a formatting issue on $DEPENDICIES.
The way I fixed this was I removed the quotes around the $DEPENDENCIES variable
which made the package manager (apt) detect them. I also added a optional fix where
instead of just detecting "apt" it also detects apt-get and nala and executes the main
install function.

Lastly I also added the same patch to the other package manager function. 

## Type of Change
- [ ] New feature
- [X] Bug fix
- [ ] Documentation Update (Due to be added!)
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
I did these changes to make apt detect the packages so it could install them.

## Testing
I have tested it on my kubuntu 24.04 install and when I used the script before the changes, it would spit out a
error saying that the packages couldn't be found. After applying my patch it works.

I use Chris-Titus bash prompt, dwm, and his neovim so it should be the same.

This problem occurs on debian-based using APT package manager.

## Impact
This patch simply makes apt find the packages.

## Issue related to PR
There is not a PR that I know of that is related to this issue.
My apologies if so.

## Additional Information
If you don't want the check for apt-get or nala you can remove it but I think it is 
necessary since it runs additional commands like installing "COMPILEDEPS"

## Checklist
- [X] My code adheres to the coding and style guidelines of the project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [X] My changes generate no errors/warnings/merge conflicts.
