### PR TITLE
DWM-Titus Install Option

### DIFF
--- a/src/commands/dotfiles/dwmtitus-setup.sh
+++ b/src/commands/dotfiles/dwmtitus-setup.sh
@@ -1,0 +1,24 @@
+#!/bin/sh -e
+
+setupDWM() {
+    echo "Installing DWM-Titus if not already installed"
+    if ! command_exists dwm; then
+        case "$PACKAGER" in
+            pacman)
+                sudo "$PACKAGER" -S --noconfirm --needed base-devel libx11 libxinerama libxft imlib2
+                ;;
+            *)
+                sudo "$PACKAGER" install -y build-essential libx11-dev libxinerama-dev libxft-dev libimblib2-dev
+                ;;
+        esac
+    else
+        echo "DWM is already installed."
+    fi
+   cd $HOME && git clone https://github.com/ChrisTitusTech/dwm-titus.git
+   cd dwm-titus/
+   sudo ./setup.sh
+   sudo make clean install
+}
+
+checkEnv
+setupDWM

--- a/src/commands/dotfiles/dwmtitus-setup.sh
+++ b/src/commands/dotfiles/dwmtitus-setup.sh
@@ -2,22 +2,19 @@
 
 setupDWM() {
     echo "Installing DWM-Titus if not already installed"
-    if ! command_exists dwm; then
-        case "$PACKAGER" in
-            pacman)
-                sudo "$PACKAGER" -S --noconfirm --needed base-devel libx11 libxinerama libxft imlib2
-                ;;
-            *)
-                sudo "$PACKAGER" install -y build-essential libx11-dev libxinerama-dev libxft-dev libimblib2-dev
-                ;;
-        esac
-    else
-        echo "DWM is already installed."
-    fi
-   cd $HOME && git clone https://github.com/ChrisTitusTech/dwm-titus.git
-   cd dwm-titus/
-   sudo ./setup.sh
-   sudo make clean install
+    case "$PACKAGER" in # Install pre-Requisites
+        pacman)
+            sudo "$PACKAGER" -S --noconfirm --needed base-devel libx11 libxinerama libxft imlib2
+            ;;
+        *)
+            sudo "$PACKAGER" install -y build-essential libx11-dev libxinerama-dev libxft-dev libimblib2-dev
+            ;;
+    esac
+   cd $HOME && git clone https://github.com/ChrisTitusTech/dwm-titus.git # CD to Home directory to install dwm-titus
+   # This path can be changed (e.g. to linux-toolbox directory)
+   cd dwm-titus/ # Hardcoded path, maybe not the best.
+   sudo ./setup.sh # Run setup
+   sudo make clean install # Run make clean install
 }
 
 checkEnv

--- a/src/commands/dotfiles/dwmtitus-setup.sh
+++ b/src/commands/dotfiles/dwmtitus-setup.sh
@@ -7,7 +7,7 @@ setupDWM() {
             sudo "$PACKAGER" -S --noconfirm --needed base-devel libx11 libxinerama libxft imlib2
             ;;
         *)
-            sudo "$PACKAGER" install -y build-essential libx11-dev libxinerama-dev libxft-dev libimblib2-dev
+            sudo "$PACKAGER" install -y build-essential libx11-dev libxinerama-dev libxft-dev libimlib2-dev
             ;;
     esac
    cd $HOME && git clone https://github.com/ChrisTitusTech/dwm-titus.git # CD to Home directory to install dwm-titus

--- a/src/commands/system-setup/1-compile-setup.sh
+++ b/src/commands/system-setup/1-compile-setup.sh
@@ -53,7 +53,7 @@ installDepend() {
             fi
             "$AUR_HELPER" --noconfirm -S "$DEPENDENCIES"
             ;;
-        apt|apt-get|nala)
+        apt-get|nala)
             COMPILEDEPS='build-essential'
             sudo "$PACKAGER" update
             sudo dpkg --add-architecture i386

--- a/src/commands/system-setup/1-compile-setup.sh
+++ b/src/commands/system-setup/1-compile-setup.sh
@@ -53,12 +53,12 @@ installDepend() {
             fi
             "$AUR_HELPER" --noconfirm -S "$DEPENDENCIES"
             ;;
-        apt)
+        apt|apt-get|nala)
             COMPILEDEPS='build-essential'
             sudo "$PACKAGER" update
             sudo dpkg --add-architecture i386
             sudo "$PACKAGER" update
-            sudo "$PACKAGER" install -y "$DEPENDENCIES" $COMPILEDEPS 
+            sudo "$PACKAGER" install -y $DEPENDENCIES $COMPILEDEPS 
             ;;
         dnf)
             COMPILEDEPS='@development-tools'
@@ -74,7 +74,7 @@ installDepend() {
             sudo "$PACKAGER" --non-interactive install libgcc_s1-gcc7-32bit glibc-devel-32bit
             ;;
         *)
-            sudo "$PACKAGER" install -y "$DEPENDENCIES"
+            sudo "$PACKAGER" install -y $DEPENDENCIES # Fixed bug where no packages found on debian-based
             ;;
     esac
 }

--- a/src/list.rs
+++ b/src/list.rs
@@ -115,6 +115,10 @@ impl CustomList {
                     name: "Rofi Setup",
                     command: with_common_script!("commands/dotfiles/rofi-setup.sh"),
                 },
+                ListNode {
+                    name: "DWM-Titus Setup (Install)",
+                    command: with_common_script!("commands/dotfiles/dwmtitus-setup.sh"),
+                },
             }
         });
         // We don't get a reference, but rather an id, because references are siginficantly more


### PR DESCRIPTION
# Pull Request

## Title
Added install DWM-Titus feature in dot files category

## Type of Change
- [X] New feature
- [X] Bug fix
- [ ] Documentation Update (Due to be added!)
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
Hello, here I have added a feature to install DWM-Titus using linutil.
To do this I created a new script called dwmtitus-setup.sh where it runs
the commands intended from the original repository.
I also added the option to the lists in the TUI.

Note: I have included my patches from my other PR.
This patch simply fixed a bug on debian based issues with APT
and is easily readable and only changes 1 - 2 lines in (src/commands/system-setup/1-compile-setup.sh).

If you do not want this patch then simply use the original setup script. (src/commands/system-setup/1-compile-setup.sh).

However, it fixes the issue of packages not found which otherwise would fail the task.
## Testing
I have tested my commits on Kubuntu 24.04 with DWM-Titus already installed.
I have not tested this on any arch based distros yet.

The commands work fine on my end.
The code is easily readable and can be adapted to work if there is any bugs that I do not know about.

## Impact
This feature can help people who want Chris Titus's workflow with DWM and automates installing it.

This feature falls under Chris-Titus's DotFiles and is optional.

Therefore people can now have his bash prompt, neovim, terminals, and DWM workflow.

## Issue related to PR
[What issue/discussion is related to this PR (if any)]
- Resolves #92 

## Additional Information
My test results may be different since I already had DWM-Titus installed.
**Also note that the script changes to the Home directory and clones DWM-Titus there.**

If you would want it to be cloned somewhere else (e.g. linuxtoolbox directory) then change the path.

## Checklist
- [X] My code adheres to the coding and style guidelines of the project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [X] My changes generate no errors/warnings/merge conflicts.
