### PR TITLE
feat: Build aarch64 binaries

### DIFF
--- a/.github/workflows/linutil.yml
+++ b/.github/workflows/linutil.yml
@@ -33,10 +33,14 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: x86_64-unknown-linux-musl
-      - name: Build
+      - name: Install cross-rs for cross-compilation
+        run: cargo install cross
+      - name: Build x86_64 binary
         run: cargo build --target-dir=build --release --verbose --target=x86_64-unknown-linux-musl
+      - name: Build aarch64 binary
+        run: cross build --target-dir=build --release --verbose --target=aarch64-unknown-linux-musl
       - uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: Commit Linutil
-          file_pattern: "build/x86_64-unknown-linux-musl/release/linutil"
+          file_pattern: "build/x86_64-unknown-linux-musl/release/linutil build/aarch64-unknown-linux-musl/release/linutil"
         if: success()

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -21,6 +21,9 @@ jobs:
           echo "version=$version" >> $GITHUB_ENV
         shell: bash
 
+      - name: Rename aarch64 binary for release
+        run: mv ./build/aarch64-unknown-linux-musl/release/linutil ./build/aarch64-unknown-linux-musl/release/linutil-aarch64
+
       - name: Create and Upload Release
         id: create_release
         uses: softprops/action-gh-release@v2
@@ -31,6 +34,7 @@ jobs:
           append_body: false
           files: |
             ./build/x86_64-unknown-linux-musl/release/linutil
+            ./build/aarch64-unknown-linux-musl/release/linutil-aarch64
           prerelease: true
           generate_release_notes: true
         env:

--- a/start.sh
+++ b/start.sh
@@ -3,8 +3,6 @@
 rc='\033[0m'
 red='\033[0;31m'
 
-binary_url="https://github.com/ChrisTitusTech/linutil/releases/latest/download/linutil"
-
 check() {
     exit_code=$1
     message=$2
@@ -18,10 +16,26 @@ check() {
 	unset message
 }
 
+findArch() {
+    case "$(uname -m)" in
+        x86_64|amd64) arch="x86_64" ;;
+        aarch64|arm64) arch="aarch64" ;;
+        *) check 1 "Unsupported architecture"
+    esac
+}
+
+getUrl() {
+    case "${arch}" in
+        x86_64) echo "https://github.com/ChrisTitusTech/linutil/releases/latest/download/linutil";;
+        *) echo "https://github.com/ChrisTitusTech/linutil/releases/latest/download/linutil-${arch}";;
+    esac
+}
+
+findArch
 temp_file=$(mktemp)
 check $? "Creating the temporary file"
 
-curl -fsL "$binary_url" -o "$temp_file"
+curl -fsL "$(getUrl)" -o "$temp_file"
 check $? "Downloading linutil"
 
 chmod +x "$temp_file"

--- a/startdev.sh
+++ b/startdev.sh
@@ -24,6 +24,7 @@ redirect_to_latest_pre_release() {
     echo "Using latest Full Release"
     url="https://github.com/ChrisTitusTech/linutil/releases/latest/download/linutil"
   fi
+  addArch
   echo "Using URL: $url"  # Log the URL being used
 }
 
@@ -37,6 +38,22 @@ check() {
     fi
 }
 
+addArch() {
+    case "${arch}" in
+        x86_64);;
+        *) url="${url}-${arch}";;
+    esac
+}
+
+findArch() {
+    case "$(uname -m)" in
+        x86_64|amd64) arch="x86_64" ;;
+        aarch64|arm64) arch="aarch64" ;;
+        *) check 1 "Unsupported architecture"
+    esac
+}
+
+findArch
 redirect_to_latest_pre_release
 
 TMPFILE=$(mktemp)


### PR DESCRIPTION
# Pull Request

## Title
Build aarch64 binaries

## Type of Change
- [x] New feature

## Description
Build aarch64 binaries using cross-rs, which allows for automated cross compilation using docker images. Update start.sh and startdev.sh to link to them. 

## Testing
I locally tested the build command, along with the start scripts to ensure they reach the correct URLs.

## Additional Information
Note that releases without aarch64 binaries will throw an error on download for users on aarch64 systems, but they aren't able to launch the current x86_64 binaries regardless.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no errors/warnings/merge conflicts.
