### PR TITLE
refactor: Small improvements to formatting of key handling

### DIFF
--- a/src/list.rs
+++ b/src/list.rs
@@ -259,10 +259,10 @@ impl CustomList {
                 // so the scroll does not happen in the main window as well
                 if self.preview_window_state.is_some() {
                     self.scroll_preview_window_down();
-                    return None;
+                } else {
+                    self.list_state.select_next();
                 }
 
-                self.list_state.select_next();
                 None
             }
             KeyCode::Char('k') | KeyCode::Up => {
@@ -270,10 +270,10 @@ impl CustomList {
                 // so the scroll does not happen in the main window as well
                 if self.preview_window_state.is_some() {
                     self.scroll_preview_window_up();
-                    return None;
+                } else {
+                    self.list_state.select_previous();
                 }
 
-                self.list_state.select_previous();
                 None
             }
             // The 'p' key toggles the preview on and off
@@ -281,14 +281,7 @@ impl CustomList {
                 self.toggle_preview_window(state);
                 None
             }
-
-            KeyCode::Enter => {
-                if self.preview_window_state.is_none() {
-                    self.handle_enter()
-                } else {
-                    None
-                }
-            }
+            KeyCode::Enter if self.preview_window_state.is_none() => self.handle_enter(),
             _ => None,
         }
     }


### PR DESCRIPTION
# Pull Request

## Title
Refactor key handling match statement. No changes to functionality.

## Type of Change
- [x] Refactoring

## Description
Remove unnecessary identical early returns. Move if statement in enter key handling into the match case to remove unnecessary else clause which returns the same as the default case.

## Testing
No changes to logic.

## Impact
Code is slightly more readable. 

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no errors/warnings/merge conflicts.
