### PR TITLE
chore: Remove duplicate cargo check workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,53 +2,39 @@ name: Rust Checks
 
 on:
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  cargo_check:
-    name: Cargo Check
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Checkout sources
-      uses: actions/checkout@v4
-
-    - name: Cache Cargo registry
-      uses: actions/cache@v4
-      with:
-        path: ~/.cargo/registry
-        key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-        restore-keys: ${{ runner.os }}-cargo-registry-
-
-    - name: Cache Cargo index
-      uses: actions/cache@v4
-      with:
-        path: ~/.cargo/git
-        key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
-        restore-keys: ${{ runner.os }}-cargo-index-
-
-    - name: Install Rust
-      uses: dtolnay/rust-toolchain@stable
-
-    - name: Build
-      run: cargo check
-
   lints:
     name: Lints
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout sources
-      uses: actions/checkout@v4
+      - name: Checkout sources
+        uses: actions/checkout@v4
 
-    - name: Install Rust
-      uses: dtolnay/rust-toolchain@stable
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
 
-    - name: Run cargo fmt
-      run: cargo fmt --all --check
+      - name: Cache Cargo registry
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-registry-
 
-    - name: Run cargo clippy
-      run: cargo clippy
+      - name: Cache Cargo index
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-index-
+
+      - name: Run cargo clippy
+        run: cargo clippy
+
+      - name: Run cargo fmt
+        run: cargo fmt --all --check


### PR DESCRIPTION
# Pull Request

## Title
Remove cargo check workflow

## Type of Change
- [x] Refactoring

## Description
`cargo clippy` runs an instance of `cargo check` by default (https://github.com/rust-lang/rust-clippy/blob/master/src/main.rs#L62). There is no need for an extra workflow to run cargo check on the side. Issues which `cargo check` will flag will also be caught by clippy.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no errors/warnings/merge conflicts.
