### PR TITLE
chore: Move binaries to shorter path

### DIFF
--- a/.github/workflows/linutil.yml
+++ b/.github/workflows/linutil.yml
@@ -39,8 +39,12 @@ jobs:
         run: cargo build --target-dir=build --release --verbose --target=x86_64-unknown-linux-musl
       - name: Build aarch64 binary
         run: cross build --target-dir=build --release --verbose --target=aarch64-unknown-linux-musl
+      - name: Move binaries to build directory
+        run: |
+          mv build/x86_64-unknown-linux-musl/release/linutil build/linutil
+          mv build/aarch64-unknown-linux-musl/release/linutil build/linutil-aarch64
       - uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: Commit Linutil
-          file_pattern: "build/x86_64-unknown-linux-musl/release/linutil build/aarch64-unknown-linux-musl/release/linutil"
+          file_pattern: "build/linutil build/linutil-aarch64"
         if: success()

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -21,9 +21,6 @@ jobs:
           echo "version=$version" >> $GITHUB_ENV
         shell: bash
 
-      - name: Rename aarch64 binary for release
-        run: mv ./build/aarch64-unknown-linux-musl/release/linutil ./build/aarch64-unknown-linux-musl/release/linutil-aarch64
-
       - name: Create and Upload Release
         id: create_release
         uses: softprops/action-gh-release@v2
@@ -33,8 +30,8 @@ jobs:
           body: "![GitHub Downloads (specific asset, specific tag)](https://img.shields.io/github/downloads/ChrisTitusTech/linutil/${{ env.version }}/linutil)"
           append_body: false
           files: |
-            ./build/x86_64-unknown-linux-musl/release/linutil
-            ./build/aarch64-unknown-linux-musl/release/linutil-aarch64
+            ./build/linutil
+            ./build/linutil-aarch64
           prerelease: true
           generate_release_notes: true
         env:


### PR DESCRIPTION
# Pull Request

## Title
Move linutil binaries directly to the build directory

## Type of Change
- [x] Refactoring

## Description
As was mentioned on stream, the binary is built in a rather nested path. This change will make workflows, such as the prerelease workflow, easier to maintain, as well as simplifying navigation of the repository.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no errors/warnings/merge conflicts.
