### PR TITLE
Introduce Automatic Global Theming and some fixes

### DIFF
--- a/src/commands/system-setup/3-global-theme.sh
+++ b/src/commands/system-setup/3-global-theme.sh
@@ -2,17 +2,6 @@
 
 . ./common-script.sh
 
-# Check if the home directory and linuxtoolbox folder exist, create them if they don't
-LINUXTOOLBOXDIR="$HOME/linuxtoolbox"
-
-if [ ! -d "$LINUXTOOLBOXDIR" ]; then
-    printf "${YELLOW}Creating linuxtoolbox directory: %s${RC}\n" "$LINUXTOOLBOXDIR"
-    mkdir -p "$LINUXTOOLBOXDIR"
-    printf "${GREEN}linuxtoolbox directory created: %s${RC}\n" "$LINUXTOOLBOXDIR"
-fi
-
-cd "$LINUXTOOLBOXDIR" || exit
-
 install_theme_tools() {
     printf "${YELLOW}Installing theme tools (qt6ct and kvantum)...${RC}\n"
     case $PACKAGER in
@@ -38,39 +27,19 @@ install_theme_tools() {
             ;;
     esac
 }
-
-configure_qt6ct() {
-    printf "${YELLOW}Configuring qt6ct...${RC}\n"
-    mkdir -p "$HOME/.config/qt6ct"
-    cat <<EOF > "$HOME/.config/qt6ct/qt6ct.conf"
-[Appearance]
-style=kvantum
-color_scheme=default
-icon_theme=breeze
-EOF
-    printf "${GREEN}qt6ct configured successfully.${RC}\n"
-
+common_qt(){
     # Add QT_QPA_PLATFORMTHEME to /etc/environment
-    if ! grep -q "QT_QPA_PLATFORMTHEME=qt6ct" /etc/environment; then
-        printf "${YELLOW}Adding QT_QPA_PLATFORMTHEME to /etc/environment...${RC}\n"
-        echo "QT_QPA_PLATFORMTHEME=qt6ct" | sudo tee -a /etc/environment > /dev/null
-        printf "${GREEN}QT_QPA_PLATFORMTHEME added to /etc/environment.${RC}\n"
-    else
-        printf "${GREEN}QT_QPA_PLATFORMTHEME already set in /etc/environment.${RC}\n"
-    fi
+if ! grep -q "QT_QPA_PLATFORMTHEME=qt6ct" /etc/environment; then
+    printf "${YELLOW}Adding QT_QPA_PLATFORMTHEME to /etc/environment...${RC}\n"
+    echo "QT_QPA_PLATFORMTHEME=qt6ct" | sudo tee -a /etc/environment > /dev/null
+    printf "${GREEN}QT_QPA_PLATFORMTHEME added to /etc/environment.${RC}\n"
+else
+    printf "${GREEN}QT_QPA_PLATFORMTHEME already set in /etc/environment.${RC}\n"
+fi
+
 }
 
-configure_kvantum() {
-    printf "${YELLOW}Configuring Kvantum...${RC}\n"
-    mkdir -p "$HOME/.config/Kvantum"
-    cat <<EOF > "$HOME/.config/Kvantum/kvantum.kvconfig"
-[General]
-theme=Breeze
-EOF
-    printf "${GREEN}Kvantum configured successfully.${RC}\n"
-}
 
 checkEnv
 install_theme_tools
-configure_qt6ct
-configure_kvantum
+common_qt

--- a/src/commands/system-setup/global-themes/catppuccin.sh
+++ b/src/commands/system-setup/global-themes/catppuccin.sh
@@ -1,0 +1,124 @@
+#!/bin/sh
+set_qt(){
+printf "${YELLOW}Configuring qt6ct...${RC}\n"
+mkdir -p "$HOME/.config/qt6ct/"
+wget -O "${HOME}"/.config/qt6ct/"$1".conf https://raw.githubusercontent.com/catppuccin/qt5ct/main/themes/Catppuccin-"$1".conf
+
+cat <<EOF > "$HOME/.config/qt6ct/qt6ct.conf"
+[Appearance]
+style=kvantum
+color_scheme_path="$HOME/.config/qt6ct/$1.conf"
+icon_theme=breeze
+EOF
+printf "${YELLOW}Configured qt6ct...${RC}\n"
+}
+set_k(){
+ printf "${YELLOW}Configuring kvantum...${RC}\n"
+ wget -P "$HOME/.config/Kvantum/catppuccin-$1-$2/"  https://raw.githubusercontent.com/catppuccin/Kvantum/main/themes/catppuccin-"$1"-"$2"/catppuccin-"$1"-"$2".svg
+ wget -P "$HOME/.config/Kvantum/catppuccin-$1-$2/"  https://raw.githubusercontent.com/catppuccin/Kvantum/main/themes/catppuccin-"$1"-"$2"/catppuccin-"$1"-"$2".kvconfig
+cat <<EOF > "$HOME/.config/Kvantum/kvantum.kvconfig"
+[General]
+theme=catppuccin-$1-$2
+EOF
+printf "${YELLOW}Configured kvantum...${RC}\n"
+echo "Theme set to catppuccin-$1-$2."
+}
+set_accent(){
+     cat <<EOF
+Choose an accent -
+    1. Rosewater
+    2. Flamingo
+    3. Pink
+    4. Mauve
+    5. Red
+    6. Maroon
+    7. Peach
+    8. Yellow
+    9. Green
+    10. Teal
+    11. Sky
+    12. Sapphire
+    13. Blue
+    14. Lavender
+EOF
+    while true; do
+    read -rp "Enter your choice (the number): " accent
+   case "$accent" in
+    1)
+        ACCENTNAME="rosewater"
+        ;;
+    2)
+        ACCENTNAME="flamingo"
+        ;;
+    3)
+        ACCENTNAME="pink"
+        ;;
+    4)
+        ACCENTNAME="mauve"
+        ;;
+    5)
+        ACCENTNAME="red"
+        ;;
+    6)
+        ACCENTNAME="maroon"
+        ;;
+    7)
+        ACCENTNAME="peach"
+        ;;
+    8)
+        ACCENTNAME="yellow"
+        ;;
+    9)
+        ACCENTNAME="green"
+        ;;
+    10)
+        ACCENTNAME="teal"
+        ;;
+    11)
+        ACCENTNAME="sky"
+        ;;
+    12)
+        ACCENTNAME="sapphire"
+        ;;
+    13)
+        ACCENTNAME="blue"
+        ;;
+    14)
+        ACCENTNAME="lavender"
+        ;;
+    *)
+    echo "write a valid accent bro :(" ;;
+esac
+
+    set_k ${1,,} $ACCENTNAME
+    break
+    done
+}
+set_theme() {
+  set_qt $1
+  set_accent $1
+  echo "Catppuccin theme is set:)"
+  exit 0
+}
+configure_flavour() {
+    while true; do
+     cat <<EOF
+  Choose flavor out of -
+      1. Mocha
+      2. Macchiato
+      3. Frappé
+      4. Latte
+      (Type the number corresponding to said flavour)
+EOF
+      read -rp flavour
+        case $flavour in
+          1 ) set_theme "Mocha"   ;;
+          2 ) set_theme "Latte"   ;;
+          3 ) set_theme  "Macchiato"  ;;
+          4 ) set_theme "Frappe" ;;
+            * ) printf "Write a valid flavour"  ;;
+        esac
+    done
+  }
+. ./system-setup/3-global-theme.sh
+configure_flavour

--- a/src/list.rs
+++ b/src/list.rs
@@ -98,14 +98,20 @@ impl CustomList {
                     command: Command::LocalFile("system-setup/2-gaming-setup.sh"),
                 },
                 ListNode {
-                    name: "Global Theme",
-                    command: Command::LocalFile("system-setup/3-global-theme.sh"),
+                name: "Global Theme(Avoid Using With Desktop Environments)",
+                command: Command::None,
+                } => {
+                ListNode {
+                    name: "Catppuccin",
+                    command: Command::LocalFile("system-setup/global-themes/catppuccin.sh"),
                 },
+            },            
                 ListNode {
                     name: "Remove Snaps",
                     command: Command::LocalFile("system-setup/4-remove-snaps.sh"),
                 },
             },
+
             ListNode {
                 name: "Utilities",
                 command: Command::None


### PR DESCRIPTION
# Pull Request

## Title
Introduce Automatic Global Theming and some fixes 

## Type of Change
- [x] New feature
- [x] Bug fix
- [ ] Documentation Update
- [x] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
Made a global themes directory in which theme files can be stored the 3-global-theme.sh is now only used for stuff which will be common with all themes, the files change qt6ct and Kvantum themes. Also removed the creation of linuxtoolbox dir because it was causing issues 

## Testing
Tested in a latest up-to-date arch vm, running kde 

## Impact
Does what is supposed to do but may break Kde theming,we may want to check for qt6-kde and kde appropriate theming for this, this will work for most applications using qt but not gtk we may want to also look for projects  to make way here for gtk-theming

## Issue related to PR
[What issue/discussion is related to this PR (if any)]
- Resolves #122 

## Additional Information
This (referring to catppuccin theme) also sets a standard way to how themes in the future must be added

## Checklist
- [ ] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
