### PR TITLE
Fix search commands

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -167,7 +167,6 @@ fn run<B: Backend>(terminal: &mut Terminal<B>, state: &AppState) -> io::Result<(
                 } else if let Some(cmd) = custom_list.handle_key(key, state) {
                     command_opt = Some(RunningCommand::new(cmd, state));
                 } else {
-
                     // Handle keys while not in search mode
                     match key.code {
                         // Exit the program
@@ -176,7 +175,7 @@ fn run<B: Backend>(terminal: &mut Terminal<B>, state: &AppState) -> io::Result<(
                         KeyCode::Char('/') => {
                             in_search_mode = true;
                             continue;
-                        },
+                        }
                         _ => {}
                     }
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -142,15 +142,6 @@ fn run<B: Backend>(terminal: &mut Terminal<B>, state: &AppState) -> io::Result<(
                     command_opt = None;
                 }
             } else {
-                if key.code == KeyCode::Char('q') {
-                    return Ok(());
-                }
-                //Activate search mode if the forward slash key gets pressed
-                if key.code == KeyCode::Char('/') {
-                    // Enter search mode
-                    in_search_mode = true;
-                    continue;
-                }
                 //Insert user input into the search bar
                 if in_search_mode {
                     match key.code {
@@ -175,6 +166,19 @@ fn run<B: Backend>(terminal: &mut Terminal<B>, state: &AppState) -> io::Result<(
                     }
                 } else if let Some(cmd) = custom_list.handle_key(key, state) {
                     command_opt = Some(RunningCommand::new(cmd, state));
+                } else {
+
+                    // Handle keys while not in search mode
+                    match key.code {
+                        // Exit the program
+                        KeyCode::Char('q') => return Ok(()),
+                        //Activate search mode if the forward slash key gets pressed
+                        KeyCode::Char('/') => {
+                            in_search_mode = true;
+                            continue;
+                        },
+                        _ => {}
+                    }
                 }
             }
         }


### PR DESCRIPTION
# Pull Request

## Title
Fix search, / and q acting as char

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation Update
- [x] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
Before, when searching, pressing the letter q would quit the programme.
Same goes for / using its action rather than acting a letter.

Following this, both act as letters. To exit the program, the user must get out of the search before with <ENTER> or <ESC>.

Also did a bit of refactoring to reduce the amount of if. This would go out  of hands when adding new commands ( I am about to... :D ).

## Testing
Manual testing

## Impact
Can now write words containing q and / :) 

## Additional Information
Don't look at the long list of commits, this is me walking on the bug while adding a new feature. Had to branch out and go back to fix it independently.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
