### PR TITLE
Added option to remove snaps

### DIFF
--- a/src/commands/system-setup/4-remove-snaps.sh
+++ b/src/commands/system-setup/4-remove-snaps.sh
@@ -1,0 +1,28 @@
+#!/bin/sh -e
+
+. ./common-script.sh
+
+removeSnaps() {
+    case $PACKAGER in
+        pacman)
+            sudo ${PACKAGER} -Rns snapd
+            ;;
+        apt-get|nala)
+            sudo ${PACKAGER} autoremove --purge snapd
+            if [ "$ID" = ubuntu ]; then
+                sudo apt-mark hold snapd
+            fi
+            ;;
+        dnf)
+            sudo ${PACKAGER} remove snapd
+            ;;
+        zypper)
+            sudo ${PACKAGER} remove snapd
+            ;;
+        *)
+            echo "removing snapd not implemented for this package manager"
+    esac
+}
+
+checkEnv
+removeSnaps

--- a/src/list.rs
+++ b/src/list.rs
@@ -74,6 +74,10 @@ impl CustomList {
                     name: "Global Theme",
                     command: Command::LocalFile("system-setup/3-global-theme.sh"),
                 },
+                ListNode {
+                    name: "Remove Snaps",
+                    command: Command::LocalFile("system-setup/4-remove-snaps.sh"),
+                },
             },
             ListNode {
                 name: "Security",


### PR DESCRIPTION
# Pull Request

## Title
Added an option to remove snaps and snapd from the system. 
On Ubuntu, this script will also put a hold on snapd to prevent it from being reinstalled.

## Type of Change
- New feature

## Description
added script `src/commands/system-setup/4-remove-snaps.sh`
added node in `src/list.rs` so that the new script can be run.

## Testing
I installed various distributions via distrobox, installed snapd, then removed snapd with this new script, and checked that /var/lib/snapd/ was no longer present to indicate that snapd was removed successfully. On ubuntu, I also checked that `sudo apt install firefox` would not install snapd.

## Impact
New option under system-setup

## Issue related to PR
This PR is a step towards resolving issue #35

## Additional Information
Option to install apt or flatpak version of Firefox and other packages on Ubuntu should likely be added in the future, because this script will remove the snap version of programs such as Firefox.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
