### PR TITLE
Cleaned the main.rs file a bit.

### DIFF
--- a/src/float.rs
+++ b/src/float.rs
@@ -7,6 +7,10 @@ use ratatui::{
 pub trait FloatContent {
     fn draw(&mut self, frame: &mut Frame, area: Rect);
     fn handle_key_event(&mut self, key: &KeyEvent) -> bool;
+    // Lets the float know if it's content has finished.
+    // This is used to know if we can close the float.
+    // The running_command only returns true after the command has finished.
+    // The preview command always returns true.
     fn is_finished(&self) -> bool;
 }
 


### PR DESCRIPTION
My previous PR #137 changed the logic for the command output float a bit.

In this PR, I am moving it out of main and into list.rs.

The logic behind this is that the only things that should belong in the main.rs file are the root widgets of the app, which for now are the search bar and the commands list.

This PR makes list.rs spawn the float of the command output, to let main be cleaner. This change also makes it so that the key press flow is cleaner.

Key presses are received by main, which then either: send it to the search bar; send it to the commands list; or process them.

The flow then continues down the widgets.
Every parent either handles the key press or passes it down to its children.