### PR TITLE
Filter out special keys (arrows, page up/down, home, insert, function, end, and delete) from terminal input

### DIFF
--- a/src/running_command.rs
+++ b/src/running_command.rs
@@ -108,7 +108,7 @@ impl FloatContent for RunningCommand {
             KeyCode::Enter if self.is_finished() => {
                 return true;
             }
-            // do not pass arrow keys, page up/down, home, insert, any function key, or end to the terminal
+            // do not pass arrow keys, page up/down, home, insert, delete, any function key, or end to the terminal
             KeyCode::Down => {}
             KeyCode::Up => {}
             KeyCode::Left => {}
@@ -118,6 +118,7 @@ impl FloatContent for RunningCommand {
             KeyCode::Home => {}
             KeyCode::End => {}
             KeyCode::Insert => {}
+            KeyCode::Delete => {}
             KeyCode::F(_) => {}
             // Pass all other keys to the terminal
             _ => self.handle_passthrough_key_event(key),

--- a/src/running_command.rs
+++ b/src/running_command.rs
@@ -108,7 +108,18 @@ impl FloatContent for RunningCommand {
             KeyCode::Enter if self.is_finished() => {
                 return true;
             }
-            // Pass other key events to the terminal
+            // do not pass arrow keys, page up/down, home, insert, any function key, or end to the terminal
+            KeyCode::Down => {}
+            KeyCode::Up => {}
+            KeyCode::Left => {}
+            KeyCode::Right => {}
+            KeyCode::PageUp => {}
+            KeyCode::PageDown => {}
+            KeyCode::Home => {}
+            KeyCode::End => {}
+            KeyCode::Insert => {}
+            KeyCode::F(_) => {}
+            // Pass all other keys to the terminal
             _ => self.handle_passthrough_key_event(key),
         }
         false


### PR DESCRIPTION
# Pull Request

## Title
Filter out special keys (arrows, page up/down, home, insert, function, end, and delete) from terminal input.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [x] UI/UX improvement

## Description
This PR filters out special keyboard keys (arrow keys, page up/down, home, end, insert, and function keys) that generate escape codes. These escape codes can interfere with terminal-based input, such as sudo passwords and confirmations, leading to unexpected behavior. By preventing these keys from being passed to the terminal, we enhance the user experience.

## Testing
I have tested each option in the linutil menu and verified that they are all working as intended.

## Impact
It may have an impact on input prompts that require these because it filters out keys and doesn't send the input for them.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
