### PR TITLE
Refactoring: Allow themes to scale with ease

### DIFF
--- a/src/list.rs
+++ b/src/list.rs
@@ -195,8 +195,8 @@ impl CustomList {
             // icons:   
             if !self.at_root() {
                 items.push(
-                    Line::from(format!("{}  ..", state.theme.dir_icon))
-                        .style(state.theme.dir_color),
+                    Line::from(format!("{}  ..", state.theme.dir_icon()))
+                        .style(state.theme.dir_color()),
                 );
             }
 
@@ -212,13 +212,13 @@ impl CustomList {
                 // it's a directory and will be handled as such
                 if node.has_children() {
                     items.push(
-                        Line::from(format!("{}  {}", state.theme.dir_icon, node.value().name))
-                            .style(state.theme.dir_color),
+                        Line::from(format!("{}  {}", state.theme.dir_icon(), node.value().name))
+                            .style(state.theme.dir_color()),
                     );
                 } else {
                     items.push(
-                        Line::from(format!("{}  {}", state.theme.cmd_icon, node.value().name))
-                            .style(state.theme.cmd_color),
+                        Line::from(format!("{}  {}", state.theme.cmd_icon(), node.value().name))
+                            .style(state.theme.cmd_color()),
                     );
                 }
             }
@@ -227,8 +227,8 @@ impl CustomList {
             self.filtered_items
                 .iter()
                 .map(|node| {
-                    Line::from(format!("{}  {}", state.theme.cmd_icon, node.name))
-                        .style(state.theme.cmd_color)
+                    Line::from(format!("{}  {}", state.theme.cmd_icon(), node.name))
+                        .style(state.theme.cmd_color())
                 })
                 .collect()
         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,7 +39,7 @@ use theme::ThemeType;
 struct Args {
     #[arg(short, long, value_enum)]
     #[arg(default_value_t = ThemeType::Default)]
-    #[arg(help = "Set the theme to use in the applicaiton")]
+    #[arg(help = "Set the theme to use in the application")]
     theme: ThemeType,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,24 +32,21 @@ use ratatui::{
 use running_command::RunningCommand;
 use state::AppState;
 use tempdir::TempDir;
-use theme::THEMES;
+use theme::ThemeType;
 
-/// This is a binary :), Chris, change this to update the documentation on -h
+// Linux utility toolbox
 #[derive(Debug, Parser)]
 struct Args {
-    /// Enable compatibility mode (disable icons and RGB colors)
-    #[arg(short, long, default_value_t = false)]
-    compat: bool,
+    #[arg(short, long, value_enum)]
+    #[arg(default_value_t = ThemeType::Default)]
+    #[arg(help = "Set the theme to use in the applicaiton")]
+    theme: ThemeType,
 }
 
 fn main() -> std::io::Result<()> {
     let args = Args::parse();
 
-    let theme = if args.compat {
-        THEMES[0].clone()
-    } else {
-        THEMES[1].clone()
-    };
+    let theme = args.theme.into();
     let commands_dir = include_dir!("src/commands");
     let temp_dir: TempDir = TempDir::new("linutil_scripts").unwrap();
     commands_dir

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,21 +32,21 @@ use ratatui::{
 use running_command::RunningCommand;
 use state::AppState;
 use tempdir::TempDir;
-use theme::ThemeType;
+use theme::Theme;
 
 // Linux utility toolbox
 #[derive(Debug, Parser)]
 struct Args {
     #[arg(short, long, value_enum)]
-    #[arg(default_value_t = ThemeType::Default)]
+    #[arg(default_value_t = Theme::Default)]
     #[arg(help = "Set the theme to use in the application")]
-    theme: ThemeType,
+    theme: Theme,
 }
 
 fn main() -> std::io::Result<()> {
     let args = Args::parse();
 
-    let theme = args.theme.into();
+    let theme = args.theme;
     let commands_dir = include_dir!("src/commands");
     let temp_dir: TempDir = TempDir::new("linutil_scripts").unwrap();
     commands_dir

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -5,6 +5,7 @@ use ratatui::style::Color;
 // This is more secure than the previous list
 // We cannot index out of bounds, and we are giving
 // names to our various themes, making it very clear
+// This will make it easy to add new themes
 #[derive(Clone, Debug, PartialEq, Default, ValueEnum, Copy)]
 pub enum Theme {
     #[default]
@@ -27,6 +28,13 @@ impl Theme {
         }
     }
 
+    pub fn tab_color(&self) -> Color{
+        match self {
+            Theme::Default => Color::Rgb(255, 255, 85),
+            Theme::Compatible => Color::Yellow,
+        }
+    }
+
     pub fn dir_icon(&self) -> &'static str {
         match self {
             Theme::Default => "  ",
@@ -41,6 +49,13 @@ impl Theme {
         }
     }
 
+    pub fn tab_icon(&self) -> &'static str {
+        match self {
+            Theme::Default => "  ",
+            Theme::Compatible => ">> ",
+        }
+    }
+
     pub fn success_color(&self) -> Color {
         match self {
             Theme::Default => Color::Rgb(199, 55, 44),
@@ -52,6 +67,20 @@ impl Theme {
         match self {
             Theme::Default => Color::Rgb(5, 255, 55),
             Theme::Compatible => Color::Red,
+        }
+    }
+
+    pub fn focused_color(&self) -> Color {
+        match self {
+            Theme::Default => Color::LightBlue,
+            Theme::Compatible => Color::LightBlue,
+        }
+    }
+
+    pub fn unfocused_color(&self) -> Color {
+        match self {
+            Theme::Default => Color::Gray,
+            Theme::Compatible => Color::Gray,
         }
     }
 }

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -1,4 +1,3 @@
-use clap::builder::PossibleValue;
 use clap::ValueEnum;
 use ratatui::style::Color;
 
@@ -6,133 +5,69 @@ use ratatui::style::Color;
 // This is more secure than the previous list
 // We cannot index out of bounds, and we are giving
 // names to our various themes, making it very clear
-#[derive(Clone, Debug, PartialEq, Default)]
-pub enum ThemeType {
+#[derive(Clone, Debug, PartialEq, Default, ValueEnum, Copy)]
+pub enum Theme {
     #[default]
     Default,
     Compatible,
 }
 
-// Clap uses the `ValueEnum` trait to convert the user input directly into a
-// `ThemeType` from the command line.
-const THEME_TYPES: &[ThemeType] = &[ThemeType::Default, ThemeType::Compatible];
-impl ValueEnum for ThemeType {
-    fn value_variants<'a>() -> &'a [Self] {
-        THEME_TYPES
-    }
-
-    fn from_str(input: &str, ignore_case: bool) -> Result<Self, String> {
-        let input = if ignore_case {
-            input.to_lowercase()
-        } else {
-            input.to_owned()
-        };
-
-        match input.as_str() {
-            "default" => Ok(Self::Default),
-            "compatible" => Ok(Self::Compatible),
-            _ => Err(format!("Invalid theme: {}", input)),
+impl Theme {
+    pub fn dir_color(&self) -> Color {
+        match self {
+            Theme::Default => Color::Blue,
+            Theme::Compatible => Color::Blue,
         }
     }
 
-    fn to_possible_value(&self) -> Option<PossibleValue> {
-        Some(match self {
-            Self::Default => PossibleValue::new("default"),
-            Self::Compatible => PossibleValue::new("compatible"),
-        })
+    pub fn cmd_color(&self) -> Color {
+        match self {
+            Theme::Default => Color::Rgb(204, 224, 208),
+            Theme::Compatible => Color::LightGreen,
+        }
+    }
+
+    pub fn dir_icon(&self) -> &'static str {
+        match self {
+            Theme::Default => "  ",
+            Theme::Compatible => "[DIR]",
+        }
+    }
+
+    pub fn cmd_icon(&self) -> &'static str {
+        match self {
+            Theme::Default => "  ",
+            Theme::Compatible => "[CMD]",
+        }
+    }
+
+    pub fn success_color(&self) -> Color {
+        match self {
+            Theme::Default => Color::Rgb(199, 55, 44),
+            Theme::Compatible => Color::Green,
+        }
+    }
+
+    pub fn fail_color(&self) -> Color {
+        match self {
+            Theme::Default => Color::Rgb(5, 255, 55),
+            Theme::Compatible => Color::Red,
+        }
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
-pub struct Theme {
-    pub dir_color: Color,
-    pub cmd_color: Color,
-    pub dir_icon: &'static str,
-    pub cmd_icon: &'static str,
-    pub success_color: Color,
-    pub fail_color: Color,
-}
-
-// Provides the ability to cycle through the available themes at runtime
-// while building on the ValueEnum implementation
 impl Theme {
-    // I left them unused, so you can accept the PR even if you don't
-    // want this feature.
     #[allow(unused)]
     pub fn next(self) -> Self {
-        let theme_type: ThemeType = self.into();
-        let position = theme_type as usize;
-        let types = ThemeType::value_variants();
-
-        types[(position + 1) % types.len()].clone().into()
+        let position = self as usize;
+        let types = Theme::value_variants();
+        types[(position + 1) % types.len()].into()
     }
 
     #[allow(unused)]
     pub fn prev(self) -> Self {
-        let theme_type: ThemeType = self.into();
-        let position = theme_type as usize;
-        let types = ThemeType::value_variants();
-
-        types[(position + types.len() - 1) % types.len()]
-            .clone()
-            .into()
-    }
-}
-
-impl Into<ThemeType> for Theme {
-    // We could branch here rather than converting until we find,
-    // but this does not require to be maintained in the future
-    fn into(self) -> ThemeType {
-        let types = ThemeType::value_variants();
-
-        types
-            .iter()
-            .find(|t| {
-                let theme: Theme = t.into();
-                theme == self
-            })
-            .unwrap_or(&ThemeType::Default)
-            .clone()
-    }
-}
-impl From<ThemeType> for Theme {
-    fn from(theme: ThemeType) -> Self {
-        Theme::from(&theme)
-    }
-}
-
-impl From<&ThemeType> for Theme {
-    fn from(theme: &ThemeType) -> Self {
-        Theme::from(&theme)
-    }
-}
-impl From<&&ThemeType> for Theme {
-    // Add Theme properties here for a new theme
-    fn from(theme: &&ThemeType) -> Self {
-        match theme {
-            ThemeType::Default => Theme::default(),
-            ThemeType::Compatible => Theme {
-                dir_color: Color::Blue,
-                cmd_color: Color::LightGreen,
-                dir_icon: "[DIR]",
-                cmd_icon: "[CMD]",
-                success_color: Color::Green,
-                fail_color: Color::Red,
-            },
-        }
-    }
-}
-
-// Makes it very clear what is the default theme
-impl Default for Theme {
-    fn default() -> Self {
-        Theme {
-            dir_color: Color::Blue,
-            cmd_color: Color::Rgb(204, 224, 208),
-            dir_icon: "  ",
-            cmd_icon: "  ",
-            fail_color: Color::Rgb(199, 55, 44),
-            success_color: Color::Rgb(5, 255, 55),
-        }
+        let position = self as usize;
+        let types = Theme::value_variants();
+        types[(position + types.len() - 1) % types.len()].into()
     }
 }

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -1,6 +1,49 @@
+use clap::builder::PossibleValue;
+use clap::ValueEnum;
 use ratatui::style::Color;
 
-#[derive(Clone)]
+// Add the Theme name here for a new theme
+// This is more secure than the previous list
+// We cannot index out of bounds, and we are giving
+// names to our various themes, making it very clear
+#[derive(Clone, Debug, PartialEq, Default)]
+pub enum ThemeType {
+    #[default]
+    Default,
+    Compatible,
+}
+
+// Clap uses the `ValueEnum` trait to convert the user input directly into a
+// `ThemeType` from the command line.
+const THEME_TYPES: &[ThemeType] = &[ThemeType::Default, ThemeType::Compatible];
+impl ValueEnum for ThemeType {
+    fn value_variants<'a>() -> &'a [Self] {
+        THEME_TYPES
+    }
+
+    fn from_str(input: &str, ignore_case: bool) -> Result<Self, String> {
+        let input = if ignore_case {
+            input.to_lowercase()
+        } else {
+            input.to_owned()
+        };
+
+        match input.as_str() {
+            "default" => Ok(Self::Default),
+            "compatible" => Ok(Self::Compatible),
+            _ => Err(format!("Invalid theme: {}", input)),
+        }
+    }
+
+    fn to_possible_value(&self) -> Option<PossibleValue> {
+        Some(match self {
+            Self::Default => PossibleValue::new("default"),
+            Self::Compatible => PossibleValue::new("compatible"),
+        })
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
 pub struct Theme {
     pub dir_color: Color,
     pub cmd_color: Color,
@@ -10,21 +53,86 @@ pub struct Theme {
     pub fail_color: Color,
 }
 
-pub const THEMES: [Theme; 2] = [
-    Theme {
-        dir_color: Color::Blue,
-        cmd_color: Color::LightGreen,
-        dir_icon: "[DIR]",
-        cmd_icon: "[CMD]",
-        success_color: Color::Green,
-        fail_color: Color::Red,
-    },
-    Theme {
-        dir_color: Color::Blue,
-        cmd_color: Color::Rgb(204, 224, 208),
-        dir_icon: "  ",
-        cmd_icon: "  ",
-        fail_color: Color::Rgb(199, 55, 44),
-        success_color: Color::Rgb(5, 255, 55),
-    },
-];
+// Provides the ability to cycle through the available themes at runtime
+// while building on the ValueEnum implementation
+impl Theme {
+    // I left them unused, so you can accept the PR even if you don't
+    // want this feature.
+    #[allow(unused)]
+    pub fn next(self) -> Self {
+        let theme_type: ThemeType = self.into();
+        let position = theme_type as usize;
+        let types = ThemeType::value_variants();
+
+        types[(position + 1) % types.len()].clone().into()
+    }
+
+    #[allow(unused)]
+    pub fn prev(self) -> Self {
+        let theme_type: ThemeType = self.into();
+        let position = theme_type as usize;
+        let types = ThemeType::value_variants();
+
+        types[(position + types.len() - 1) % types.len()]
+            .clone()
+            .into()
+    }
+}
+
+impl Into<ThemeType> for Theme {
+    // We could branch here rather than converting until we find,
+    // but this does not require to be maintained in the future
+    fn into(self) -> ThemeType {
+        let types = ThemeType::value_variants();
+
+        types
+            .iter()
+            .find(|t| {
+                let theme: Theme = t.into();
+                theme == self
+            })
+            .unwrap_or(&ThemeType::Default)
+            .clone()
+    }
+}
+impl From<ThemeType> for Theme {
+    fn from(theme: ThemeType) -> Self {
+        Theme::from(&theme)
+    }
+}
+
+impl From<&ThemeType> for Theme {
+    fn from(theme: &ThemeType) -> Self {
+        Theme::from(&theme)
+    }
+}
+impl From<&&ThemeType> for Theme {
+    // Add Theme properties here for a new theme
+    fn from(theme: &&ThemeType) -> Self {
+        match theme {
+            ThemeType::Default => Theme::default(),
+            ThemeType::Compatible => Theme {
+                dir_color: Color::Blue,
+                cmd_color: Color::LightGreen,
+                dir_icon: "[DIR]",
+                cmd_icon: "[CMD]",
+                success_color: Color::Green,
+                fail_color: Color::Red,
+            },
+        }
+    }
+}
+
+// Makes it very clear what is the default theme
+impl Default for Theme {
+    fn default() -> Self {
+        Theme {
+            dir_color: Color::Blue,
+            cmd_color: Color::Rgb(204, 224, 208),
+            dir_icon: "  ",
+            cmd_icon: "  ",
+            fail_color: Color::Rgb(199, 55, 44),
+            success_color: Color::Rgb(5, 255, 55),
+        }
+    }
+}


### PR DESCRIPTION
# Pull Request

## Title
Allow theme scaling without risk of indexing out of bounds

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation Update
- [x] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [x] UI/UX improvement

## Description
This is following a suggestion that was made last week.

Converting the list to an enum to identify the themes, using the ValueEnum trait to allow clap to show the list in the terminal. This avoid any risk of indexing out of bounds while adding / removing themes making it extendable without risk of crashing the app. Also, the code in main will not need to be updated when adding / removing themes.

I added a next/prev function as unused to make sure this could be merged without risk of conflicting with any of the major refactoring I see coming up in the main or if its not desired, they can easily be deleted.

@ChrisTitusTech, if you wish to attempt to implement it yourself, go ahead. It requires to listen to a new key and call next or previous. In what context you are might matter depending on the key that you listen to. 

For example, if you take `t`, you cannot listen to it in search mode as its a searchable character, but if you take `F2` you could.
Meaning, that if you want to be able to change theme in any mode, it needs to be a non searchable character else, it needs to be handled only when out of search mode or preview mode.

## Testing
Manual testing

## Impact
Nothing really, this is self contained and should not affect other features.


## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
