### PR TITLE
refactor: Modify theme in place

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -196,8 +196,8 @@ impl AppState {
                     self.refresh_tab();
                 }
                 KeyCode::Char('/') => self.enter_search(),
-                KeyCode::Char('t') => self.theme = self.theme.next(),
-                KeyCode::Char('T') => self.theme = self.theme.prev(),
+                KeyCode::Char('t') => self.theme.next(),
+                KeyCode::Char('T') => self.theme.prev(),
                 _ => {}
             },
             Focus::List if key.kind != KeyEventKind::Release => match key.code {
@@ -214,8 +214,8 @@ impl AppState {
                 }
                 KeyCode::Char('/') => self.enter_search(),
                 KeyCode::Tab => self.focus = Focus::TabList,
-                KeyCode::Char('t') => self.theme = self.theme.next(),
-                KeyCode::Char('T') => self.theme = self.theme.prev(),
+                KeyCode::Char('t') => self.theme.next(),
+                KeyCode::Char('T') => self.theme.prev(),
                 _ => {}
             },
             _ => {}

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -87,16 +87,16 @@ impl Theme {
 
 impl Theme {
     #[allow(unused)]
-    pub fn next(self) -> Self {
-        let position = self as usize;
+    pub fn next(&mut self) {
+        let position = *self as usize;
         let types = Theme::value_variants();
-        types[(position + 1) % types.len()].into()
+        *self = types[(position + 1) % types.len()];
     }
 
     #[allow(unused)]
-    pub fn prev(self) -> Self {
-        let position = self as usize;
+    pub fn prev(&mut self) {
+        let position = *self as usize;
         let types = Theme::value_variants();
-        types[(position + types.len() - 1) % types.len()].into()
+        *self = types[(position + types.len() - 1) % types.len()];
     }
 }

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -86,14 +86,12 @@ impl Theme {
 }
 
 impl Theme {
-    #[allow(unused)]
     pub fn next(&mut self) {
         let position = *self as usize;
         let types = Theme::value_variants();
         *self = types[(position + 1) % types.len()];
     }
 
-    #[allow(unused)]
     pub fn prev(&mut self) {
         let position = *self as usize;
         let types = Theme::value_variants();


### PR DESCRIPTION
# Pull Request

## Title
Refactor next & previous theme to modify the value in place

## Type of Change
- [x] Refactoring

## Description
Currently, theme next() and prev() methods return a new value. There's no purpose for this, since we're only using the next and prev methods for modifying the value of the theme variable itself. Instead, I've changed the functions to modify the receiver in place, which improves the readability of the code.

## Testing
Next and previous theme function correctly.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no errors/warnings/merge conflicts.
