### PR TITLE
Reduce the weight of the produced binary for faster start time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,14 @@ tempdir = "0.3.7"
 [[bin]]
 name = "linutil"
 path = "src/main.rs"
+
+
+
+[profile.release]
+opt-level = "z"
+debug = false
+lto = true
+codegen-units = 1
+panic = "abort"
+strip = true
+incremental = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ path = "src/main.rs"
 
 
 [profile.release]
-opt-level = "z"
+opt-level = 3
 debug = false
 lto = true
 codegen-units = 1


### PR DESCRIPTION
Optimise for weight at the expense of compile time, speed and we strip debuging elements

# Pull Request

## Title
Reduce binary weight to reduce waiting time for slower connection.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [x] UI/UX improvement

## Description
Indicate to the compiler to : 
- Optimise for weight rather than speed
- Take more time to improve linking at compile time
- Remove debug info (is already the default on release)
- Compile using only 1 code gen unit (longer compile time in exchange for better optimisation)
- To abort when under panic (reduce code generation, and so far the unwinding with Ratatui is horrible)
- Strip any symbols from the binary. (An other option is strip = "debuginfo" if we don't want to go that far)
- Incremental build turned to off (in our case this should not have any effect, but there is cases where loses of  performance where noted)

## Testing
Yes

## Impact
Reduce the binary size from 2.2 MB to 1.1 MB, so around 50% reduced weight with no human noticeable impact to performance.

## Issue related to PR
- Resolves #170 

## Additional Information
Those improvement are stable. There is also unstable improvements that can be added.
Lets also note that we could also create a slim release rather than making this the default. Unsure if there would be any real benefits to be found.

For more information: 
https://doc.rust-lang.org/rustc/codegen-options/index.html

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
