### PR TITLE
Adding Swedish keymap to Arch server install script

### DIFF
--- a/src/commands/system-setup/arch/server-setup.sh
+++ b/src/commands/system-setup/arch/server-setup.sh
@@ -182,7 +182,7 @@ keymap () {
     echo -ne "
     Please select key board layout from this list"
     # These are default key maps as presented in official arch repo archinstall
-    options=(us by ca cf cz de dk es et fa fi fr gr hu il it lt lv mk nl no pl ro ru sg ua uk)
+    options=(us by ca cf cz de dk es et fa fi fr gr hu il it lt lv mk nl no pl ro ru se sg ua uk)
 
     select_option "${options[@]}"
     keymap=${options[$?]}


### PR DESCRIPTION
Adding SE keymap.

# Pull Request

## Title
Adding Swedish (se) keymap to Arch server install script

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
Added Swedish language to the keymap list, lot of languages are in the list but missing Swedish.

## Testing
Tested the script independendly, works fine on my end.

## Impact
No difference, it's giving more options to the user.

## Issue related to PR
-

## Additional Information
-

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no errors/warnings/merge conflicts.
