### PR TITLE
feat: Add word wrap to preview window

### DIFF
--- a/src/floating_text.rs
+++ b/src/floating_text.rs
@@ -69,6 +69,9 @@ impl FloatContent for FloatingText {
             .iter()
             .skip(self.scroll)
             .flat_map(|line| {
+                if line.is_empty() {
+                    return vec![String::new()];
+                }
                 line.chars()
                     .collect::<Vec<char>>()
                     .chunks(inner_area.width as usize)

--- a/src/floating_text.rs
+++ b/src/floating_text.rs
@@ -68,8 +68,15 @@ impl FloatContent for FloatingText {
             .text
             .iter()
             .skip(self.scroll)
+            .flat_map(|line| {
+                line.chars()
+                    .collect::<Vec<char>>()
+                    .chunks(inner_area.width as usize)
+                    .map(|chunk| chunk.iter().collect())
+                    .collect::<Vec<String>>()
+            })
             .take(inner_area.height as usize)
-            .map(|line| Line::from(line.as_str()))
+            .map(Line::from)
             .collect();
 
         // Create list widget


### PR DESCRIPTION
# Pull Request

## Title
Add word wrap to preview window

## Type of Change
- [x] New feature
- [x] UI/UX improvement

## Description
Currently, if a line in the preview window exceeds its width, it is not possible to view the rest of the line. The preview window cannot be scrolled horizontally, and text outside of the window will not be rendered. This PR proposes implementing word wrap for the preview window, by splitting each line into chunks of the floating window's width. 

## Testing
Preview window scrolling functions correctly, and all lines are rendered properly.

## Impact
Improve user understanding of scripts, solve potential security concerns from unreadable code.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no errors/warnings/merge conflicts.
