### PR TITLE
feat: Display build date to user, rather than current date

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-chrono = "0.4.33"
 clap = { version = "4.5.16", features = ["derive"] }
 crossterm = "0.27.0"
 ego-tree = "0.6.2"
@@ -17,6 +16,9 @@ tempdir = "0.3.7"
 serde = { version = "1.0.205", features = ["derive"] }
 toml = "0.8.19"
 which = "6.0.3"
+
+[build-dependencies]
+chrono = "0.4.33"
 
 [[bin]]
 name = "linutil"

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,9 @@
 fn main() {
     // Rebuild program if any file in commands directory changes.
     println!("cargo:rerun-if-changed=src/commands");
+    // Add current date as a variable to be displayed in the 'Linux Toolbox' text.
+    println!(
+        "cargo:rustc-env=BUILD_DATE={}",
+        chrono::Local::now().format("%Y-%m-%d")
+    );
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -153,10 +153,11 @@ impl AppState {
             } else {
                 Style::new()
             })
-            .block(Block::default().borders(Borders::ALL).title(format!(
-                "Linux Toolbox - {}",
-                chrono::Local::now().format("%Y-%m-%d")
-            )))
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .title(format!("Linux Toolbox - {}", env!("BUILD_DATE"))),
+            )
             .scroll_padding(1);
         frame.render_stateful_widget(list, chunks[1], &mut self.selection);
 


### PR DESCRIPTION
# Pull Request

## Title
Provide the date of the linutil build to the user

## Type of Change
- [x] New feature
- [x] UI/UX improvement

## Description
This provides the same feature #210 claims to be trying to implement. However, this actually works, rather than being completely broken LLM-generated code that doesn't work whatsoever and would block the drawing thread every single time even if it did build.

## Testing
The build date is correctly displayed.

## Issue related to PR
<!--[What issue/discussion is related to this PR (if any)]-->
- Closes #210 

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no errors/warnings/merge conflicts.
