### PR TITLE
fix: Recheck date whenever code is modified

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,9 @@
 fn main() {
     // Rebuild program if any file in commands directory changes.
     println!("cargo:rerun-if-changed=src/commands");
+    // Rerun build script if any code is modified
+    println!("cargo:rerun-if-changed=src");
+
     // Add current date as a variable to be displayed in the 'Linux Toolbox' text.
     println!(
         "cargo:rustc-env=BUILD_DATE={}",


### PR DESCRIPTION
# Pull Request

## Title
Re-populate build_date variable whenever any code is modified

## Type of Change
- [x] Bug fix

## Description
#221 added a date variable to be filled by the build script, but the build script only specifies that it's re-run whenever a file in the src/commands directory (a script) is modified. If changes occur to the code but not to a script, build.rs will not repopulate the date field and the previous date will remain.

The compile_time crate appears to have the same issue, from my testing. Therefore, I propose instead modifying the build script to re-run whenever any code (in the src/ directory) is modified. As long as no major additions are made to build.rs, this will have no sizable impact on compile time since the build script only includes a few print statements and a check for the date.

## Testing
Modifying the system clock and then editing any code causes linutil to recompile including the new set date. 

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no errors/warnings/merge conflicts.
