### PR TITLE
fix: Use proper backspace character in PTY

### DIFF
--- a/src/running_command.rs
+++ b/src/running_command.rs
@@ -270,7 +270,7 @@ impl RunningCommand {
                 send
             }
             KeyCode::Enter => vec![b'\n'],
-            KeyCode::Backspace => vec![8],
+            KeyCode::Backspace => vec![0x7f],
             KeyCode::Left => vec![27, 91, 68],
             KeyCode::Right => vec![27, 91, 67],
             KeyCode::Up => vec![27, 91, 65],


### PR DESCRIPTION
# Pull Request

## Title
Send ASCII DEL character to PTY on backspace, rather than ASCII BS

## Type of Change
- [x] Bug fix

## Description
ASCII BS (0x08) is not the character sent by terminal emulators for the backspace key. Rather, ASCII DEL (0x7f) is. This change fixes unexpected behaviour from certain programs which perform different actions for these 2 inputs, such as `sudo`.  

## Testing
`sudo` behaves correctly on backspace, keycode sent to pty matches that sent to host terminal.

## Issue related to PR
<!--[What issue/discussion is related to this PR (if any)]-->
- Resolves #231 
- Resolves #230 

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no errors/warnings/merge conflicts.
