### PR TITLE
Add tips box to display useful information

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ mod running_command;
 pub mod state;
 mod tabs;
 mod theme;
+mod tips;
 
 use std::{
     io::{self, stdout},

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,5 +1,6 @@
 use crate::{
     filter::{Filter, SearchAction},
+    tips::Tips,
     float::{Float, FloatContent},
     floating_text::FloatingText,
     running_command::{Command, RunningCommand},
@@ -33,6 +34,7 @@ pub struct AppState {
     /// widget
     selection: ListState,
     filter: Filter,
+    tips: Tips
 }
 
 pub enum Focus {
@@ -60,6 +62,7 @@ impl AppState {
             visit_stack: vec![root_id],
             selection: ListState::default().with_selected(Some(0)),
             filter: Filter::new(),
+            tips: Tips::new()
         };
         state.update_items();
         state
@@ -107,6 +110,7 @@ impl AppState {
             .constraints([Constraint::Length(3), Constraint::Min(1)].as_ref())
             .split(horizontal[1]);
 
+        self.tips.draw_tips(frame, left_chunks[0], &self.theme);
         self.filter.draw_searchbar(frame, chunks[0], &self.theme);
 
         let mut items: Vec<Line> = Vec::new();

--- a/src/tips.rs
+++ b/src/tips.rs
@@ -1,0 +1,29 @@
+use crate::theme::Theme;
+
+use ratatui::{
+    layout::Rect,
+    style::Style,
+    widgets::{Block, Borders, Paragraph},
+    Frame,
+};
+
+
+pub struct Tips {
+    text_to_display: String
+}
+
+impl Tips {
+    pub fn new() -> Self {
+        Self {
+            text_to_display: "Press Q to Exit".to_string()
+        }
+    }
+
+    pub fn draw_tips(&self, frame: &mut Frame, area: Rect, theme: &Theme){
+
+        let search_bar = Paragraph::new(self.text_to_display.to_string())
+            .block(Block::default().borders(Borders::ALL).title("Linux Toolbox".to_string()))
+            .style(Style::default().fg(theme.unfocused_color()));
+        frame.render_widget(search_bar, area);
+    }
+}


### PR DESCRIPTION
# Pull Request

## Title
Add tips box to display useful information

## Type of Change
- [x] New feature

## Description
Adding a box on the top left corner to display useful information, at first, it displays the command to exit, but can be used to display state of installs, errors etc.

## Testing
- Tested navigation on all sub menus;
- Tested state while installing packages;
- Tested visual integrity before and after adding the display box;

## Impact
- Should have no impact in performance, as it's just a new visual text display;

## Issue related to PR
- resolves https://github.com/ChrisTitusTech/linutil/issues/235
- resolves https://github.com/ChrisTitusTech/linutil/issues/236


## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no errors/warnings/merge conflicts.
