### PR TITLE
Close linutil on Control-C, don't reset cursor position on exit

### DIFF
--- a/tui/src/float.rs
+++ b/tui/src/float.rs
@@ -64,9 +64,7 @@ impl Float {
     // Returns true if the floating window is finished.
     pub fn handle_key_event(&mut self, key: &KeyEvent) -> bool {
         match key.code {
-            KeyCode::Enter | KeyCode::Char('p') | KeyCode::Esc | KeyCode::Char('q')
-                if self.content.is_finished() =>
-            {
+            KeyCode::Enter | KeyCode::Char('p') | KeyCode::Esc if self.content.is_finished() => {
                 true
             }
             _ => self.content.handle_key_event(key),

--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -14,7 +14,6 @@ use std::{
 use crate::theme::Theme;
 use clap::Parser;
 use crossterm::{
-    cursor::RestorePosition,
     event::{self, DisableMouseCapture, Event, KeyEventKind},
     style::ResetColor,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
@@ -38,7 +37,7 @@ struct Args {
     override_validation: bool,
 }
 
-fn main() -> std::io::Result<()> {
+fn main() -> io::Result<()> {
     let args = Args::parse();
 
     let mut state = AppState::new(args.theme, args.override_validation);
@@ -55,8 +54,8 @@ fn main() -> std::io::Result<()> {
     terminal.backend_mut().execute(LeaveAlternateScreen)?;
     terminal.backend_mut().execute(DisableMouseCapture)?;
     terminal.backend_mut().execute(ResetColor)?;
-    terminal.backend_mut().execute(RestorePosition)?;
     terminal.show_cursor()?;
+
     Ok(())
 }
 

--- a/tui/src/state.rs
+++ b/tui/src/state.rs
@@ -6,7 +6,7 @@ use crate::{
     running_command::RunningCommand,
     theme::Theme,
 };
-use crossterm::event::{KeyCode, KeyEvent, KeyEventKind};
+use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 use ego_tree::NodeId;
 use linutil_core::{Command, ListNode, Tab};
 use ratatui::{
@@ -185,6 +185,7 @@ impl AppState {
 
         draw_shortcuts(self, frame, vertical[1]);
     }
+
     pub fn handle_key(&mut self, key: &KeyEvent) -> bool {
         match &mut self.focus {
             Focus::FloatingWindow(command) => {
@@ -192,31 +193,43 @@ impl AppState {
                     self.focus = Focus::List;
                 }
             }
+
             Focus::Search => match self.filter.handle_key(key) {
                 SearchAction::Exit => self.exit_search(),
                 SearchAction::Update => self.update_items(),
                 _ => {}
             },
-            _ if key.code == KeyCode::Char('q') => return false,
+
+            _ if key.code == KeyCode::Char('q')
+                || key.code == KeyCode::Char('c')
+                    && key.modifiers.contains(KeyModifiers::CONTROL) =>
+            {
+                return false;
+            }
+
             Focus::TabList => match key.code {
                 KeyCode::Enter | KeyCode::Char('l') | KeyCode::Right | KeyCode::Tab => {
                     self.focus = Focus::List
                 }
+
                 KeyCode::Char('j') | KeyCode::Down
                     if self.current_tab.selected().unwrap() + 1 < self.tabs.len() =>
                 {
                     self.current_tab.select_next();
                     self.refresh_tab();
                 }
+
                 KeyCode::Char('k') | KeyCode::Up => {
                     self.current_tab.select_previous();
                     self.refresh_tab();
                 }
+
                 KeyCode::Char('/') => self.enter_search(),
                 KeyCode::Char('t') => self.theme.next(),
                 KeyCode::Char('T') => self.theme.prev(),
                 _ => {}
             },
+
             Focus::List if key.kind != KeyEventKind::Release => match key.code {
                 KeyCode::Char('j') | KeyCode::Down => self.selection.select_next(),
                 KeyCode::Char('k') | KeyCode::Up => self.selection.select_previous(),
@@ -235,10 +248,12 @@ impl AppState {
                 KeyCode::Char('T') => self.theme.prev(),
                 _ => {}
             },
-            _ => {}
+
+            _ => (),
         };
         true
     }
+
     fn update_items(&mut self) {
         self.filter.update_items(
             &self.tabs,
@@ -246,12 +261,14 @@ impl AppState {
             *self.visit_stack.last().unwrap(),
         );
     }
+
     /// Checks ehther the current tree node is the root node (can we go up the tree or no)
     /// Returns `true` if we can't go up the tree (we are at the tree root)
     /// else returns `false`
     pub fn at_root(&self) -> bool {
         self.visit_stack.len() == 1
     }
+
     fn enter_parent_directory(&mut self) {
         self.visit_stack.pop();
         self.selection.select(Some(0));


### PR DESCRIPTION
# Pull Request

## Title
Added the ability to exit the application with Control-C to match the expected behavior of some users
Added a screen blank on exit to prevent text present on screen from persisting from before starting the application.

## Type of Change
- [x] New feature
- [x] Bug fix
- [ ] Documentation Update
- [x] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
Control-C is the universal "I want to get out of here" chord. Having the binding only exist on the 'q' key makes it unintuitive to exit the app while running. It was only a few lines that needed to be added to accomplish this.

Also, I noticed that stale text would be persisted from before starting the application, so I removed the cursor position reset and it seems to be fixed.

## Testing
I verified that both 'q' and Control-c behave as expected, and I ran a test neovim install to verify that package management functionality wasn't broken.

## Impact
I believe that this makes the application behave as a naive user would expect.

## Issue related to PR
- Resolves #236 

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
