### PR TITLE
Use Dtype instead of Packager

### DIFF
--- a/tabs/system-setup/arch/paru-setup.sh
+++ b/tabs/system-setup/arch/paru-setup.sh
@@ -3,8 +3,8 @@
 . "$(dirname "$0")/../../common-script.sh"
 
 installDepend() {
-    case $PACKAGER in
-        pacman)
+    case $DTYPE in
+        arch)
             if ! command_exists paru; then
                 echo "Installing paru as AUR helper..."
                 $ESCALATION_TOOL "$PACKAGER" -S --needed --noconfirm base-devel
@@ -16,7 +16,7 @@ installDepend() {
             fi
             ;;
         *)
-            echo "Unsupported package manager: $PACKAGER"
+            echo "Unsupported distribution: $DTYPE"
             ;;
     esac
 }

--- a/tabs/system-setup/arch/yay-setup.sh
+++ b/tabs/system-setup/arch/yay-setup.sh
@@ -3,8 +3,8 @@
 . "$(dirname "$0")/../../common-script.sh"
 
 installDepend() {
-    case $PACKAGER in
-        pacman)
+    case $DTYPE in
+        arch)
             if ! command_exists yay; then
                 echo "Installing yay as AUR helper..."
                 $ESCALATION_TOOL "$PACKAGER" -S --needed --noconfirm base-devel
@@ -16,7 +16,7 @@ installDepend() {
             fi
             ;;
         *)
-            echo "Unsupported package manager: $PACKAGER"
+            echo "Unsupported distribution: $DTYPE"
             ;;
     esac
 }

--- a/tabs/system-setup/fedora/rpm-fusion-setup.sh
+++ b/tabs/system-setup/fedora/rpm-fusion-setup.sh
@@ -5,8 +5,8 @@
 # https://rpmfusion.org/Configuration
 
 installRPMFusion() {
-    case $PACKAGER in
-        dnf)
+    case $DTYPE in
+        fedora)
             if [[ ! -e /etc/yum.repos.d/rpmfusion-free.repo || ! -e /etc/yum.repos.d/rpmfusion-nonfree.repo ]]; then
                 echo "Installing RPM Fusion..."
                 $ESCALATION_TOOL "$PACKAGER" install https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-$(rpm -E %fedora).noarch.rpm


### PR DESCRIPTION
## Type of Change
- [x] Refactoring

## Description
Uses Dtype instead of packager to keep the consistency with the Fedora section.

Changed Packager at the top of the RPM Fusion script to Dtype.

Might want to look into #258 before deciding on what to do with this PR, as that one uses Packager at the top of the added scripts.

look into #287 before deciding on what to do with both of these PRs

- Conflicts with #287
- Might conflict with #282 
- Closes #287

## Testing
Works perfectly

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no errors/warnings/merge conflicts.
