### PR TITLE
opt-level: optimize for binary size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ path = "src/main.rs"
 
 
 [profile.release]
-opt-level = 3
+opt-level = "z"
 debug = false
 lto = true
 codegen-units = 1


### PR DESCRIPTION
# Pull Request

## Title
opt-level: optimize binary for size

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [x] UI/UX improvement

## Description
optimize binary for size, but also turn off loop vectorization: <https://doc.rust-lang.org/cargo/reference/profiles.html#opt-level>

## Testing
<!--[Detail the testing you have performed to ensure that these changes function as intended. Include information about any added tests.]-->

## Impact
### Before PR
```shell
-rwx------ 2 zdiff zdiff 1597472 Sep  5 18:13 target/release/linutil
```

### opt-level = "s"
```shell
-rwx------ 2 zdiff zdiff 1357544 Sep  5 18:18 target/release/linutil
```

### opt-level = "z"
```shell
-rwx------ 2 zdiff zdiff 1341624 Sep  5 18:19 target/release/linutil
```


## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
