### PR TITLE
fix: redirection should work on sh

### DIFF
--- a/src/commands/utils/bluetooth-control.sh
+++ b/src/commands/utils/bluetooth-control.sh
@@ -104,7 +104,7 @@ prompt_for_mac() {
         fi
 
         # Display devices with numbers
-        IFS=$'\n' read -r -a device_list <<<"$devices"
+        echo "$devices" | IFS=$'\n' read -r -a device_list
         for i in "${!device_list[@]}"; do
             echo "$((i+1)). ${device_list[$i]}"
         done


### PR DESCRIPTION
`<<<` is not supported on sh shell

# Pull Request

## Title
This fixes the bluetooth manager

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
`<<<` redirection only works on bash. SInce the shell type of the script is now `sh` the current redirection fails. This fix should work on both `bash` and `sh`

## Testing
I ran the script locally to test it works. Further testing might be required. 

## Impact
The approach with here-string(```) is a better approach and better performance wise because`|` involves a subprocess

## Issue related to PR
<!--[What issue/discussion is related to this PR (if any)]-->
- Resolves #246

## Additional Information
<!--[Any additional information that reviewers should be aware of.]-->

## Checklist
- [ ] My code adheres to the coding and style guidelines of the project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
