### PR TITLE
Update user guide with new Linutil image and keybind information

### DIFF
--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -6,4 +6,6 @@ Run the following command in a terminal on your Linux System:
 curl -fsSL https://christitus.com/linux | sh
 ```
 Once you have run that command you will see the following GUI show on your screen:
-![Main Page](assets/mainpage.png)
+![Main Page](assets/preview.png)
+
+**`Q` is the current keybind to exit Linutil.**


### PR DESCRIPTION
## Type of Change
- [ ] New feature
- [ ] Bug fix
- [x] Documentation Update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
This pull request updates the `userguide.md` in the `docs` folder for the Linutil project. The changes include:
- Replacing the image in the user guide to reflect the latest version of Linutil.
- Adding information on the current keybinding used to exit Linutil, ensuring users are aware of the updated shortcut for exiting.

## Testing
The changes were manually reviewed by checking the `userguide.md` file to ensure:
- The image is updated correctly and displays as expected.
- The keybind information is clearly mentioned and formatted properly.

## Impact
These updates improve the clarity of the documentation and ensure it reflects the current state of Linutil, providing better guidance to users.

## Issue related to PR
- Resolves general problem of not knowing this exit key-binding as it is not explicitely mentioned anywhere.

## Additional Information
No additional information.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.