### PR TITLE
Add wget dependency to application setups

### DIFF
--- a/src/commands/applications-setup/alacritty-setup.sh
+++ b/src/commands/applications-setup/alacritty-setup.sh
@@ -27,6 +27,8 @@ setupAlacritty() {
                 $ESCALATION_TOOL ${PACKAGER} install -y wget
                 ;;
         esac
+    else
+        echo "wget is already installed."
     fi
     
     echo "Copy alacritty config files"

--- a/src/commands/applications-setup/alacritty-setup.sh
+++ b/src/commands/applications-setup/alacritty-setup.sh
@@ -16,6 +16,19 @@ setupAlacritty() {
     else
         echo "alacritty is already installed."
     fi
+
+    echo "Install wget if not already installed..."
+    if ! command_exists wget; then
+        case ${PACKAGER} in
+            pacman)
+                $ESCALATION_TOOL ${PACKAGER} -S --needed --noconfirm wget
+                ;;
+            *)
+                $ESCALATION_TOOL ${PACKAGER} install -y wget
+                ;;
+        esac
+    fi
+    
     echo "Copy alacritty config files"
     if [ -d "${HOME}/.config/alacritty" ]; then
         cp -r "${HOME}/.config/alacritty" "${HOME}/.config/alacritty-bak"

--- a/src/commands/applications-setup/kitty-setup.sh
+++ b/src/commands/applications-setup/kitty-setup.sh
@@ -16,6 +16,19 @@ setupKitty() {
     else
         echo "Kitty is already installed."
     fi
+
+    echo "Install wget if not already installed..."
+    if ! command_exists wget; then
+        case ${PACKAGER} in
+            pacman)
+                $ESCALATION_TOOL ${PACKAGER} -S --needed --noconfirm wget
+                ;;
+            *)
+                $ESCALATION_TOOL ${PACKAGER} install -y wget
+                ;;
+        esac
+    fi
+    
     echo "Copy Kitty config files"
     if [ -d "${HOME}/.config/kitty" ]; then
         cp -r "${HOME}/.config/kitty" "${HOME}/.config/kitty-bak"

--- a/src/commands/applications-setup/kitty-setup.sh
+++ b/src/commands/applications-setup/kitty-setup.sh
@@ -27,8 +27,10 @@ setupKitty() {
                 $ESCALATION_TOOL ${PACKAGER} install -y wget
                 ;;
         esac
+    else
+        echo "wget is already installed."
     fi
-    
+        
     echo "Copy Kitty config files"
     if [ -d "${HOME}/.config/kitty" ]; then
         cp -r "${HOME}/.config/kitty" "${HOME}/.config/kitty-bak"

--- a/src/commands/applications-setup/rofi-setup.sh
+++ b/src/commands/applications-setup/rofi-setup.sh
@@ -27,6 +27,8 @@ setupRofi() {
                 $ESCALATION_TOOL ${PACKAGER} install -y wget
                 ;;
         esac
+    else
+        echo "wget is already installed."
     fi
 
     echo "Copy Rofi config files"

--- a/src/commands/applications-setup/rofi-setup.sh
+++ b/src/commands/applications-setup/rofi-setup.sh
@@ -16,6 +16,19 @@ setupRofi() {
     else
         echo "Rofi is already installed."
     fi
+
+    echo "Install wget if not already installed..."
+    if ! command_exists wget; then
+        case ${PACKAGER} in
+            pacman)
+                $ESCALATION_TOOL ${PACKAGER} -S --needed --noconfirm wget
+                ;;
+            *)
+                $ESCALATION_TOOL ${PACKAGER} install -y wget
+                ;;
+        esac
+    fi
+
     echo "Copy Rofi config files"
     if [ -d "$HOME/.config/rofi" ]; then
         cp -r "$HOME/.config/rofi" "$HOME/.config/rofi.bak"


### PR DESCRIPTION
# Pull Request

## Title
Add wget dependency to alacritty,kitty and rofi setups

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation Update
- [ ] Refactoring
- [x] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
The issue was alacritty,kitty and rofi setups failed due to wget not installed in some systems. This PR adds check for wget and installs them if not found.

## Testing
Works as expected

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
