### PR TITLE
fix: Correctly Detect Pictures Directory and Clone Path for Background

### DIFF
--- a/tabs/applications-setup/dwmtitus-setup.sh
+++ b/tabs/applications-setup/dwmtitus-setup.sh
@@ -142,29 +142,32 @@ clone_config_folders() {
 }
 
 configure_backgrounds() {
+    # Set the variable PIC_DIR which stores the path for images
+    PIC_DIR="$HOME/Pictures"
+
     # Set the variable BG_DIR to the path where backgrounds will be stored
-    BG_DIR="$HOME/Pictures/backgrounds"
+    BG_DIR="$PIC_DIR/backgrounds"
 
     # Check if the ~/Pictures directory exists
-    if [ ! -d "~/Pictures" ]; then
+    if [ ! -d "$PIC_DIR" ]; then
         # If it doesn't exist, print an error message and return with a status of 1 (indicating failure)
         echo "Pictures directory does not exist"
-        mkdir ~/Pictures
+        mkdir "$PIC_DIR"
         echo "Directory was created in Home folder"
     fi
-    
+
     # Check if the backgrounds directory (BG_DIR) exists
     if [ ! -d "$BG_DIR" ]; then
         # If the backgrounds directory doesn't exist, attempt to clone a repository containing backgrounds
-        if ! git clone https://github.com/ChrisTitusTech/nord-background.git ~/Pictures; then
+        if ! git clone https://github.com/ChrisTitusTech/nord-background.git "$PIC_DIR/nord-background"; then
             # If the git clone command fails, print an error message and return with a status of 1
             echo "Failed to clone the repository"
             return 1
         fi
         # Rename the cloned directory to 'backgrounds'
-        mv ~/Pictures/nord-background ~/Pictures/backgrounds
+        mv "$PIC_DIR/nord-background" "$PIC_DIR/backgrounds"
         # Print a success message indicating that the backgrounds have been downloaded
-        echo "Downloaded desktop backgrounds to $BG_DIR"    
+        echo "Downloaded desktop backgrounds to $BG_DIR"
     else
         # If the backgrounds directory already exists, print a message indicating that the download is being skipped
         echo "Path $BG_DIR exists for desktop backgrounds, skipping download of backgrounds"
@@ -290,9 +293,6 @@ setupDisplayManager() {
             echo "Auto-login configuration skipped"
         fi
     fi
-    
-
-    
 }
 
 checkEnv


### PR DESCRIPTION
# Pull Request

## Title
Correctly Detect Pictures Directory and Clone Path for Background

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation Update
- [x] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
<!--[Provide a detailed explanation of the changes you have made. Include the reasons behind these changes and any relevant context. Link any related issues.]-->
The `configure_background` function couldn't correctly detect existing `Pictures` directory and installed the `nord-background` repo to the top level of the `Pictures` directory

https://github.com/ChrisTitusTech/linutil/issues/303

## Testing
Tested both having no `Pictures` directory and an existing `Pictures` directory, then ran the `DWM-Titus` script from the TUI. Both times the images from the `nord-background` repository wound up in `~/Pictures/background`

## Impact
N/A

## Issue related to PR
<!--[What issue/discussion is related to this PR (if any)]-->
- Resolves #303 

## Additional Information
<!--[Any additional information that reviewers should be aware of.]-->
This will still fail if you already have a `~/Pictures/nord-background` folder that's not empty but that seemed a bit extra to go clobbering that if it existed.

## Checklist
- [ ] My code adheres to the coding and style guidelines of the project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no errors/warnings/merge conflicts.
