### PR TITLE
Install paru faster

### DIFF
--- a/src/commands/system-setup/arch/paru-setup.sh
+++ b/src/commands/system-setup/arch/paru-setup.sh
@@ -8,8 +8,8 @@ installDepend() {
             if ! command_exists paru; then
                 echo "Installing paru as AUR helper..."
                 $ESCALATION_TOOL "$PACKAGER" -S --needed --noconfirm base-devel
-                cd /opt && $ESCALATION_TOOL git clone https://aur.archlinux.org/paru.git && $ESCALATION_TOOL chown -R "$USER": ./paru
-                cd paru && makepkg --noconfirm -si
+                cd /opt && $ESCALATION_TOOL git clone https://aur.archlinux.org/paru-bin.git && $ESCALATION_TOOL chown -R "$USER": ./paru-bin
+                cd paru-bin && makepkg --noconfirm -si
                 echo "Paru installed"
             else
                 echo "Paru already installed"


### PR DESCRIPTION
Paru.git takes time to compile, while paru-bin is precompiled for faster installation.