### PR TITLE
use dash instead of bash for inlined application-setup commands

### DIFF
--- a/src/commands/applications-setup/tab_data.toml
+++ b/src/commands/applications-setup/tab_data.toml
@@ -6,7 +6,7 @@ script = "alacritty-setup.sh"
 
 [[data]]
 name = "Bash Prompt"
-command = "bash -c \"$(curl -s https://raw.githubusercontent.com/ChrisTitusTech/mybash/main/setup.sh)\""
+command = "curl -sSL https://raw.githubusercontent.com/ChrisTitusTech/mybash/main/setup.sh | sh"
 
 [[data]]
 name = "DWM-Titus"
@@ -18,7 +18,7 @@ script = "kitty-setup.sh"
 
 [[data]]
 name = "Neovim"
-command = "bash -c \"$(curl -s https://raw.githubusercontent.com/ChrisTitusTech/neovim/main/setup.sh)\""
+command = "curl -sSL https://raw.githubusercontent.com/ChrisTitusTech/neovim/main/setup.sh | sh"
 
 [[data]]
 name = "Rofi"


### PR DESCRIPTION
# Use dash instead of bash for inlined application-setup commands

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation Update
- [x] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [x] UI/UX improvement

## Description
The setup scripts for both [mybash](https://github.com/ChrisTitusTech/mybash) & [Chris's custom neovim setup](https://github.com/ChrisTitusTech/neovim) use ANSI escapes to color text, but bash isn't posix compliant in the way that the echo command handles escapes. This change allows for proper presentation of the commands as they emit notifications without distracting escape sequences being emitted without being interpreted.

## Testing
Very simple change, just verified that the commands run with the escape sequences being interpreted properly

## Impact
Removes a lot of superfluous escape sequences and makes the command output more readable.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
