### PR TITLE
Change deprecated `frame.size()` to `frame.area()` after ec76dcd

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -103,7 +103,7 @@ impl AppState {
                 Constraint::Min(2 + SHORTCUT_LINES as u16),
             ])
             .margin(0)
-            .split(frame.size());
+            .split(frame.area());
 
         let horizontal = Layout::default()
             .direction(Direction::Horizontal)


### PR DESCRIPTION
Continuing #271 after ec76dcd.
Meant to do this in #271 but it got merged.