### PR TITLE
enhancement: Rate mirrors heads up message

### DIFF
--- a/tabs/system-setup/system-update.sh
+++ b/tabs/system-setup/system-update.sh
@@ -6,7 +6,9 @@ fastUpdate() {
     case ${PACKAGER} in
         pacman)
 
-          $AUR_HELPER -S --needed --noconfirm rate-mirrors-bin
+            $AUR_HELPER -S --needed --noconfirm rate-mirrors-bin
+
+            printf "%b\n" "${YELLOW}Generating a new list of mirrors using rate-mirrors. This process may take a few seconds...${RC}"
 
             if [ -s /etc/pacman.d/mirrorlist ]; then
                 $ESCALATION_TOOL cp /etc/pacman.d/mirrorlist /etc/pacman.d/mirrorlist.bak


### PR DESCRIPTION
# Pull Request

## Title
Rate mirrors heads up message

## Type of Change
- [x] UI/UX improvement

## Description
I've noticed that users often cancel the script while rate-mirrors is running, due to the lack of a visible message indicating that the process is ongoing. This results in an empty mirrorlist making it a hell for linux newbies. Adding a  heads-up message informing the user that the process may take a couple of seconds to complete can save the day for a linux rookie.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no errors/warnings/merge conflicts.
