### PR TITLE
fix: Replace tilde with $HOME

### DIFF
--- a/tabs/applications-setup/dwmtitus-setup.sh
+++ b/tabs/applications-setup/dwmtitus-setup.sh
@@ -146,7 +146,7 @@ configure_backgrounds() {
     BG_DIR="$HOME/Pictures/backgrounds"
 
     # Check if the ~/Pictures directory exists
-    if [ ! -d "~/Pictures" ]; then
+    if [ ! -d "$HOME/Pictures" ]; then
         # If it doesn't exist, print an error message and return with a status of 1 (indicating failure)
         echo "Pictures directory does not exist"
         mkdir ~/Pictures


### PR DESCRIPTION
# Pull Request

## Title
Replace tilde with $HOME since `~` does not expand inside quotes

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
Tilde (~) doesn't expand inside quotes hence it will affect the test statement. This is only a minor issue and most probably will not affect most people since `~/Pictures` will be present unless deleted by user. But I thought about fixing it since it kinda bothered me while watching your streams to see the warning in Cursor.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
