### PR TITLE
Reduce the size of the linutil binary by removing unused features from `core/Cargo.toml`

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 [dependencies]
 include_dir = "0.7.4"
 tempdir = "0.3.7"
-serde = { version = "1.0.205", features = ["derive"] }
-toml = "0.8.19"
+serde = { version = "1.0.205", features = ["derive"], default-features = false }
+toml = { version = "0.8.19", features = ["parse"], default-features = false }
 which = "6.0.3"
 ego-tree = { workspace = true }


### PR DESCRIPTION
# Pull Request

## Title
Reduce the size of the `linutil` binary by removing unused features from `core/Cargo.toml`

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [x] UI/UX improvement

## Description

### Before PR
```shell
ls -l target/release/linutil
-rwx------ 2 zdiff zdiff 1366216 Sep 12 18:48 target/release/linutil
```
### After PR
```shell
ls -l target/release/linutil
-rwx------ 2 zdiff zdiff 1365368 Sep 12 18:50 target/release/linutil
```

## Testing
Build and ran `linutil` using `cargo build --release && ./target/release/linutil`

## Impact
Reduction in binary size

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
