### PR TITLE
Fix Spelling in `hint.rs` and Add Linutil Logo via `state.rs`.

### DIFF
--- a/tui/src/hint.rs
+++ b/tui/src/hint.rs
@@ -124,10 +124,10 @@ pub fn draw_shortcuts(state: &AppState, frame: &mut Frame, area: Rect) {
                 if state.selected_item_is_up_dir() {
                     hints.push(Shortcut::new(
                         vec!["l", "Right", "Enter", "h", "Left"],
-                        "Go to parrent directory",
+                        "Go to parent directory",
                     ));
                 } else {
-                    hints.push(Shortcut::new(vec!["h", "Left"], "Go to parrent directory"));
+                    hints.push(Shortcut::new(vec!["h", "Left"], "Go to parent directory"));
                     hints.push(get_list_item_shortcut(state));
                     if state.selected_item_is_cmd() {
                         hints.push(Shortcut::new(vec!["p"], "Enable preview"));

--- a/tui/src/state.rs
+++ b/tui/src/state.rs
@@ -11,7 +11,7 @@ use ego_tree::NodeId;
 use linutil_core::{Command, ListNode, Tab};
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout},
-    style::{Style, Stylize},
+    style::{Color, Modifier, Style, Stylize},
     text::{Line, Span},
     widgets::{Block, Borders, List, ListState, Paragraph},
     Frame,
@@ -65,25 +65,44 @@ impl AppState {
         state
     }
     pub fn draw(&mut self, frame: &mut Frame) {
-        let label_block =
-            Block::default()
-                .borders(Borders::all())
-                .border_set(ratatui::symbols::border::Set {
-                    top_left: " ",
-                    top_right: " ",
-                    bottom_left: " ",
-                    bottom_right: " ",
-                    vertical_left: " ",
-                    vertical_right: " ",
-                    horizontal_top: "*",
-                    horizontal_bottom: "*",
-                });
-        let str1 = "Linutil ";
-        let str2 = "by Chris Titus";
-        let label = Paragraph::new(Line::from(vec![
-            Span::styled(str1, Style::default().bold()),
-            Span::styled(str2, Style::default().italic()),
-        ]))
+        let label_block = Block::default()
+            .borders(Borders::all())
+            .border_set(ratatui::symbols::border::Set {
+                top_left: " ",
+                top_right: " ",
+                bottom_left: " ",
+                bottom_right: " ",
+                vertical_left: " ",
+                vertical_right: " ",
+                horizontal_top: "*",
+                horizontal_bottom: "*",
+            });
+        
+        let ctt_style = Style::default()
+            .fg(Color::Rgb(0, 0, 100))
+            .add_modifier(Modifier::BOLD | Modifier::ITALIC);
+        
+        let string1 = Line::from(vec![
+            Span::raw(""),
+            Span::styled("CTT", ctt_style),
+        ]);
+        let blue_colors = [
+            Color::Rgb(0, 0, 100),  // Darkest blue
+            Color::Rgb(0, 0, 150),
+            Color::Rgb(0, 0, 200),
+            Color::LightBlue,       // Lightest blue
+        ];
+        let string2 = Line::from(Span::styled(" __    _         _   _ _ ", Style::default().fg(blue_colors[0])));
+        let string3 = Line::from(Span::styled("|  |  |_|___ _ _| |_|_| |", Style::default().fg(blue_colors[1])));
+        let string4 = Line::from(Span::styled("|  |__| |   | | |  _| | |", Style::default().fg(blue_colors[2])));
+        let string5 = Line::from(Span::styled("|_____|_|_|_|___|_| |_|_|", Style::default().fg(blue_colors[3])));
+        let label = Paragraph::new(vec![
+            string1,
+            string2,
+            string3,
+            string4,
+            string5,
+        ])
         .block(label_block)
         .alignment(Alignment::Center);
 
@@ -93,7 +112,7 @@ impl AppState {
             .map(|tab| tab.name.len() + self.theme.tab_icon().len())
             .max()
             .unwrap_or(0)
-            .max(str1.len() + str2.len());
+            .max(25);
 
         let vertical = Layout::default()
             .direction(Direction::Vertical)
@@ -114,7 +133,7 @@ impl AppState {
 
         let left_chunks = Layout::default()
             .direction(Direction::Vertical)
-            .constraints([Constraint::Length(3), Constraint::Min(1)])
+            .constraints([Constraint::Length(7), Constraint::Min(1)])
             .split(horizontal[0]);
         frame.render_widget(label, left_chunks[0]);
 


### PR DESCRIPTION
## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
This PR includes the following changes:
1. **Corrections in `hint.rs`**: Fixes minor spelling mistakes in the text shown to users.
2. **Add Linutil Logo**: Adds a new ASCII logo for Linutil by editing `state.rs` and using ANSI color codes in the `ratatui` library to render a colorful (blue) logo.

The changes are primarily aesthetic and focused on improving the user experience through clear messaging and branding.

## Testing
- Verified that the spelling corrections display correctly when running the tool.
- Tested the rendering of the ASCII logo to ensure it displays properly and the colors are applied correctly.

## Impact
- No new dependencies introduced.
- The changes are visual and should not impact performance or core functionality.

## Issue related to PR
- Resolves no specific issue but addresses minor UI/UX improvements.

## Additional Information
- The logo is designed in blue using ANSI colors, adding a unique branding element to Linutil.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.