### PR TITLE
[Dwm-Titus-Setup] add slstatus installation option

### DIFF
--- a/tabs/applications-setup/dwmtitus-setup.sh
+++ b/tabs/applications-setup/dwmtitus-setup.sh
@@ -296,27 +296,30 @@ setupDisplayManager() {
 }
 
 install_slstatus() {
-    printf "Do you want to install slstatus? (y/n): " # using printf instead of 'echo' to avoid newline, -n flag for 'echo' is not supported in POSIX
-    read -r response # -r flag to prevent backslashes from being interpreted
-    case "$response" in
-        [Yy] | [Yy][Ee][Ss]) # Matches: Y, y, Yes, yes, YES, yEs, yeS, etc.
-            echo "Installing slstatus"
-            cd slstatus/ || { echo "Failed to change directory to slstatus"; return 1; }
-            if $ESCALATION_TOOL make clean install; then
-                echo "slstatus installed successfully"
-            else
-                echo "Failed to install slstatus"
-                return 1
-            fi
-            ;;
-        [Nn] | [Nn][Oo]) # same logic as above, but for No
-            echo "Skipping slstatus installation"
-            ;;
-        *)
-            echo "Invalid input. Please enter y/yes or n/no."
-            install_slstatus
-            ;;
-    esac
+    while true; do
+        printf "Do you want to install slstatus? (y/n): " # using printf instead of 'echo' to avoid newline, -n flag for 'echo' is not supported in POSIX
+        read -r response # -r flag to prevent backslashes from being interpreted
+        case "$response" in
+            [Yy] | [Yy][Ee][Ss]) # Matches: Y, y, Yes, yes, YES, yEs, yeS, etc.
+                echo "Installing slstatus"
+                cd slstatus/ || { echo "Failed to change directory to slstatus"; return 1; }
+                if $ESCALATION_TOOL make clean install; then
+                    echo "slstatus installed successfully"
+                else
+                    echo "Failed to install slstatus"
+                    return 1
+                fi
+                break
+                ;;
+            [Nn] | [Nn][Oo]) # same logic as above, but for No
+                echo "Skipping slstatus installation"
+                break
+                ;;
+            *)
+                echo "Invalid input. Please enter y/yes or n/no."
+                ;;
+        esac
+    done
     cd ..
 }
 

--- a/tabs/applications-setup/dwmtitus-setup.sh
+++ b/tabs/applications-setup/dwmtitus-setup.sh
@@ -296,30 +296,20 @@ setupDisplayManager() {
 }
 
 install_slstatus() {
-    while true; do
-        printf "Do you want to install slstatus? (y/n): " # using printf instead of 'echo' to avoid newline, -n flag for 'echo' is not supported in POSIX
-        read -r response # -r flag to prevent backslashes from being interpreted
-        case "$response" in
-            [Yy] | [Yy][Ee][Ss]) # Matches: Y, y, Yes, yes, YES, yEs, yeS, etc.
-                echo "Installing slstatus"
-                cd slstatus/ || { echo "Failed to change directory to slstatus"; return 1; }
-                if $ESCALATION_TOOL make clean install; then
-                    echo "slstatus installed successfully"
-                else
-                    echo "Failed to install slstatus"
-                    return 1
-                fi
-                break
-                ;;
-            [Nn] | [Nn][Oo]) # same logic as above, but for No
-                echo "Skipping slstatus installation"
-                break
-                ;;
-            *)
-                echo "Invalid input. Please enter y/yes or n/no."
-                ;;
-        esac
-    done
+    printf "Do you want to install slstatus? (y/N): " # using printf instead of 'echo' to avoid newline, -n flag for 'echo' is not supported in POSIX
+    read -r response # -r flag to prevent backslashes from being interpreted
+    if [ "$response" = "y" ] || [ "$response" = "Y" ]; then
+        echo "Installing slstatus"
+        cd slstatus/ || { echo "Failed to change directory to slstatus"; return 1; }
+        if $ESCALATION_TOOL make clean install; then
+            echo "slstatus installed successfully"
+        else
+            echo "Failed to install slstatus"
+            return 1
+        fi
+    else
+        echo "Skipping slstatus installation"
+    fi
     cd ..
 }
 

--- a/tabs/applications-setup/dwmtitus-setup.sh
+++ b/tabs/applications-setup/dwmtitus-setup.sh
@@ -300,7 +300,7 @@ install_slstatus() {
     read -r response # -r flag to prevent backslashes from being interpreted
     if [ "$response" = "y" ] || [ "$response" = "Y" ]; then
         echo "Installing slstatus"
-        cd slstatus/ || { echo "Failed to change directory to slstatus"; return 1; }
+        cd "$HOME/dwm-titus/slstatus" || { echo "Failed to change directory to slstatus"; return 1; }
         if $ESCALATION_TOOL make clean install; then
             echo "slstatus installed successfully"
         else

--- a/tabs/applications-setup/dwmtitus-setup.sh
+++ b/tabs/applications-setup/dwmtitus-setup.sh
@@ -295,11 +295,37 @@ setupDisplayManager() {
     
 }
 
+install_slstatus() {
+    printf "Do you want to install slstatus? (y/n): " # using printf instead of 'echo' to avoid newline, -n flag for 'echo' is not supported in POSIX
+    read -r response # -r flag to prevent backslashes from being interpreted
+    case "$response" in
+        [Yy] | [Yy][Ee][Ss]) # Matches: Y, y, Yes, yes, YES, yEs, yeS, etc.
+            echo "Installing slstatus"
+            cd slstatus/ || { echo "Failed to change directory to slstatus"; return 1; }
+            if $ESCALATION_TOOL make clean install; then
+                echo "slstatus installed successfully"
+            else
+                echo "Failed to install slstatus"
+                return 1
+            fi
+            ;;
+        [Nn] | [Nn][Oo]) # same logic as above, but for No
+            echo "Skipping slstatus installation"
+            ;;
+        *)
+            echo "Invalid input. Please enter y/yes or n/no."
+            install_slstatus
+            ;;
+    esac
+    cd ..
+}
+
 checkEnv
 checkEscalationTool
 setupDisplayManager
 setupDWM
 makeDWM
+install_slstatus
 install_nerd_font
 clone_config_folders
 configure_backgrounds

--- a/tabs/applications-setup/dwmtitus-setup.sh
+++ b/tabs/applications-setup/dwmtitus-setup.sh
@@ -310,7 +310,7 @@ install_slstatus() {
     else
         echo "Skipping slstatus installation"
     fi
-    cd ..
+    cd "$HOME"
 }
 
 checkEnv


### PR DESCRIPTION
# Pull Request

## Title
[Dwm-Titus-Setup] add slstatus installation option

## Type of Change
- [x] New feature
- [x] Bug fix
- [x] Hotfix

## Description
This PR introduces a new function to optionally install `slstatus` during the DWM setup process. It prompts the user for confirmation and handles different responses (yes/no). Additionally, it ensures proper directory navigation and error handling during the installation process using the system's escalation tool. This change enhances the flexibility of the DWM setup script by allowing users to choose whether or not to install `slstatus`.

## Issue related to PR
- Resolves #351 

## Additional Information
Provide any suggestion if required changes.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no errors/warnings/merge conflicts.
