### PR TITLE
refactor: command_exists 

### DIFF
--- a/tabs/common-script.sh
+++ b/tabs/common-script.sh
@@ -8,7 +8,7 @@ YELLOW='\033[33m'
 GREEN='\033[32m'
 
 command_exists() {
-    which "$1" >/dev/null 2>&1
+    command -v "$1" >/dev/null 2>&1
 }
 
 checkAURHelper() {


### PR DESCRIPTION
# Pull Request

## Title
Refactor command_exists function to use command -v instead of which

## Type of Change
- [x] Refactoring

## Description
`command_exists` function uses `which`, that is not POSIX-compliant that may result in error in some systems. A simple refactor to `command -v` solves the issue. `command -v` is also a POSIX-compliant built-in command.

## Issue related to PR
- Resolves #https://github.com/ChrisTitusTech/linutil/issues/211

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no errors/warnings/merge conflicts.
