### PR TITLE
fix: Floating window color and text rendering

### DIFF
--- a/tui/src/floating_text.rs
+++ b/tui/src/floating_text.rs
@@ -6,7 +6,7 @@ use crossterm::event::{KeyCode, KeyEvent};
 use linutil_core::Command;
 use ratatui::{
     layout::Rect,
-    style::{Style, Stylize},
+    style::{Color, Style, Stylize},
     text::Line,
     widgets::{Block, Borders, List},
     Frame,
@@ -59,7 +59,7 @@ impl FloatContent for FloatingText {
         // Define the Block with a border and background color
         let block = Block::default()
             .borders(Borders::ALL)
-            .style(Style::default());
+            .style(Style::default().fg(Color::Reset));
 
         // Draw the Block first
         frame.render_widget(block.clone(), area);
@@ -74,7 +74,7 @@ impl FloatContent for FloatingText {
             .skip(self.scroll)
             .flat_map(|line| {
                 if line.is_empty() {
-                    return vec![String::new()];
+                    return vec![" ".repeat(inner_area.width as usize)]; // Prevent background text from appearing in the floating window
                 }
                 line.chars()
                     .collect::<Vec<char>>()
@@ -89,7 +89,8 @@ impl FloatContent for FloatingText {
         // Create list widget
         let list = List::new(lines)
             .block(Block::default())
-            .highlight_style(Style::default().reversed());
+            .highlight_style(Style::default().reversed())
+            .style(Style::default().fg(Color::Reset));
 
         // Render the list inside the bordered area
         frame.render_widget(list, inner_area);


### PR DESCRIPTION
# Pull Request

## Title
Fix floating window color and text rendering

## Type of Change
- [x] Bug fix
- [x] UI/UX improvement

## Description
- Fixed the issue where background text and colors are displayed in the floating window
- This is fixed by rendering spaces if there is an empty line and resetting the foreground color

### Before
![color](https://github.com/user-attachments/assets/204bb71a-ca98-4e94-81be-9a1e61793cda)

### After
![no-color](https://github.com/user-attachments/assets/f9e7beb0-445e-4842-828e-81d43996845d)

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no errors/warnings/merge conflicts.
