### PR TITLE
Removed `aarch64` from start.sh scripts

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -19,7 +19,6 @@ check() {
 findArch() {
     case "$(uname -m)" in
         x86_64|amd64) arch="x86_64" ;;
-        aarch64|arm64) arch="aarch64" ;;
         *) check 1 "Unsupported architecture"
     esac
 }

--- a/startdev.sh
+++ b/startdev.sh
@@ -50,7 +50,6 @@ addArch() {
 findArch() {
     case "$(uname -m)" in
         x86_64|amd64) arch="x86_64" ;;
-        aarch64|arm64) arch="aarch64" ;;
         *) check 1 "Unsupported architecture"
     esac
 }


### PR DESCRIPTION
# BEFORE MERGING THIS RECONSIDER ADDING ARM64 SUPPORT BACK https://github.com/ChrisTitusTech/linutil/pull/445#issuecomment-2355800238

## Type of Change
- [x] Bug fix

## Description
Linutil no longer supports ARM64. It's misleading to have start.sh try to download it and just not work.
Not clearly showing "Unsupported architecture" leads to confusion, confusion leads to research, possibly opening more duplicate issues, and overall waste of time.

## Issue related to PR
- Resolves #444 
- Resolves #450

## Checklist
- [x] I have performed a self-review of my own code.
- [x] My changes generate no errors/warnings/merge conflicts.
