### PR TITLE
Add aarch64 again

### DIFF
--- a/.github/workflows/linutil.yml
+++ b/.github/workflows/linutil.yml
@@ -44,9 +44,13 @@ jobs:
       - name: Build x86_64 binary
         run: cargo build --target-dir=build --release --verbose --target=x86_64-unknown-linux-musl
 
+      - name: Build aarch64 binary
+        run: cross build --target-dir=build --release --verbose --target=aarch64-unknown-linux-musl
+
       - name: Move binaries to build directory
         run: |
           mv build/x86_64-unknown-linux-musl/release/linutil build/linutil
+          mv build/aarch64-unknown-linux-musl/release/linutil build/linutil-aarch64
 
       - name: Pull latest changes
         run: |
@@ -57,7 +61,7 @@ jobs:
       - uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: Commit Linutil
-          file_pattern: "build/linutil"
+          file_pattern: "build/linutil build/linutil-aarch64"
           add_options: '--force'
         if: success()
 
@@ -87,9 +91,12 @@ jobs:
             ${{ steps.generate_notes.outputs.body }}
             
             ![GitHub Downloads (specific asset, specific tag)](https://img.shields.io/github/downloads/ChrisTitusTech/linutil/${{ env.version }}/linutil)
+            ![GitHub Downloads (specific asset, specific tag)](https://img.shields.io/github/downloads/ChrisTitusTech/linutil/${{ env.version }}/linutil-aarch64)
+
           append_body: false
           files: |
             ./build/linutil
+            ./build/linutil-aarch64
             ./start.sh
             ./startdev.sh
           prerelease: true


### PR DESCRIPTION
## Type of Change
- I don't really know what type of change is this. I just added the aarch64 in CI and it works.

## Description
- Added aarch64 in workflow

## Testing
- Tested on linutil fork and runs without errors.

## Issues / other PRs related
- Resolves #450 
- Resolves #252 
- Resolves #259

## Additional Information
- I took a look at the old errors of aarch64 build. I encounter similar errors when switching from my arch system to ubuntu20 testing system sometimes. Doing a cargo clean and re-building would resolve the errors. I am not sure whether these two issues are related. **For now aarch64 has no errors**. In case we encounter such errors in future we can fix them.
- The error happens when half of the cargo.lock gets build on newer glibc and the other half gets build on older glibc.
- `cargo clean` would clear all the old built crate binaries and will build again from the start so there would no conflicts.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no errors/warnings/merge conflicts.
