### PR TITLE
Modify the bashisms workflow to only check modified files

### DIFF
--- a/.github/workflows/bashisms.yml
+++ b/.github/workflows/bashisms.yml
@@ -1,10 +1,10 @@
 name: Check for bashisms
 
 on:
-  push:
-    paths:
-      - tabs/**
-    branches: [ "main" ]
+  # push:
+  #   paths:
+  #     - tabs/**
+  #   branches: [ "main" ]
   pull_request:
     paths:
       - tabs/**
@@ -16,11 +16,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+      - run: git fetch origin ${{ github.base_ref }}
       
       - name: Install devscripts
         run: sudo apt-get update && sudo apt-get install devscripts
 
-      - name: Check for bashisms
-        working-directory: tabs
-        run: find . -name '*.sh' | xargs -P 4 -n 1 checkbashisms
+      - name: Check for bashisms in changed files
+        run: |
+          for file in $(git diff --name-only origin/${{ github.base_ref }} HEAD tabs); do
+              if [[ "$file" == *.sh ]]; then
+                  checkbashisms "$file"
+              fi
+          done


### PR DESCRIPTION
## Type of Change
- [x] Hotfix

## Description
Modified `bashisms.yml` to only check modified `.sh` files using `git diff --name-only <base branch> HEAD tabs`.

## Testing
Works like a charm :))

## Impact
Less not deserverd CI failures i guess.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no errors/warnings/merge conflicts.
