### PR TITLE
refactor: Seperate style and title variables

### DIFF
--- a/tui/src/state.rs
+++ b/tui/src/state.rs
@@ -237,22 +237,16 @@ impl AppState {
             Style::new()
         };
 
+        let title = format!(
+            "Linux Toolbox - {} {}",
+            env!("BUILD_DATE"),
+            self.multi_select.then(|| "[Multi-Select]").unwrap_or("")
+        );
+
         // Create the list widget with items
         let list = List::new(items)
-            .highlight_style(if let Focus::List = self.focus {
-                Style::default().reversed()
-            } else {
-                Style::new()
-            })
-            .block(Block::default().borders(Borders::ALL).title(format!(
-                "Linux Toolbox - {} {}",
-                env!("BUILD_DATE"),
-                if self.multi_select {
-                    "[Multi-Select]"
-                } else {
-                    ""
-                }
-            )))
+            .highlight_style(style)
+            .block(Block::default().borders(Borders::ALL).title(title))
             .scroll_padding(1);
         frame.render_stateful_widget(list, chunks[1], &mut self.selection);
 


### PR DESCRIPTION
Added lj's thought process from https://github.com/ChrisTitusTech/linutil/pull/490

## Type of Change
- [x] Refactoring

## Description
- Separate the styles and title variables.
- Fixes the warning that pops up in terminal.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no errors/warnings/merge conflicts.
