### PR TITLE
Fixed the bashisms CI to only check files that exist

### DIFF
--- a/.github/workflows/bashisms.yml
+++ b/.github/workflows/bashisms.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Check for bashisms in changed files
         run: |
           for file in $(git diff --name-only origin/${{ github.base_ref }} HEAD core/tabs); do
-              if [[ "$file" == *.sh ]]; then
+              if [[ "$file" == *.sh ]] && [[ -f "$file" ]];; then
                   checkbashisms "$file"
               fi
           done


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [x] Hotfix

## Description
When a shell file is deleted or moved, this CI fails. This fixes it.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no errors/warnings/merge conflicts.
