### PR TITLE
feat: implement syntax highlighting for preview text

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -33,6 +42,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "ansi-to-tui"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00c4af0bef1b514c9b6a32a773caf604c1390fa7913f4eaa23bfe76f251d6a42"
+dependencies = [
+ "nom",
+ "ratatui",
+ "simdutf8",
+ "smallvec",
+ "thiserror",
 ]
 
 [[package]]
@@ -483,6 +505,8 @@ dependencies = [
 name = "linutil_tui"
 version = "24.9.19"
 dependencies = [
+ "ansi-to-tui",
+ "anstyle",
  "chrono",
  "clap",
  "crossterm",
@@ -492,8 +516,11 @@ dependencies = [
  "portable-pty",
  "rand 0.8.5",
  "ratatui",
+ "tree-sitter-bash",
+ "tree-sitter-highlight",
  "tui-term",
  "unicode-width",
+ "zips",
 ]
 
 [[package]]
@@ -543,6 +570,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "mio"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -567,6 +600,16 @@ dependencies = [
  "libc",
  "memoffset",
  "pin-utils",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -771,6 +814,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+
+[[package]]
 name = "remove_dir_all"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -934,6 +1006,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simdutf8"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
+
+[[package]]
 name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1056,6 +1134,46 @@ dependencies = [
  "toml_datetime",
  "winnow",
 ]
+
+[[package]]
+name = "tree-sitter"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20f4cd3642c47a85052a887d86704f4eac272969f61b686bdd3f772122aabaff"
+dependencies = [
+ "cc",
+ "regex",
+ "regex-syntax",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-bash"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3aa5e1c6bd02c0053f3f68edcf5d8866b38a8640584279e30fca88149ce14dda"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-highlight"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "395d7a477a4504fd7d5e4d003e0dd41bd5b9c4985d53592a943a8354ec452dae"
+dependencies = [
+ "lazy_static",
+ "regex",
+ "thiserror",
+ "tree-sitter",
+]
+
+[[package]]
+name = "tree-sitter-language"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2545046bd1473dac6c626659cc2567c6c0ff302fc8b84a56c4243378276f7f57"
 
 [[package]]
 name = "tui-term"
@@ -1357,6 +1475,17 @@ name = "zerocopy-derive"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zips"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba09194204fda6b1e206faf9096a3c0658ddf7606560f6edce112da3fcc9b111"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -30,6 +30,11 @@ tui-term = "0.1.12"
 unicode-width = "0.1.13"
 rand =  "0.8.5"
 linutil_core = { path = "../core", version = "24.9.19" }
+tree-sitter-highlight = "0.23.0"
+tree-sitter-bash = "0.23.1"
+anstyle = "1.0.8"
+ansi-to-tui = "6.0.0"
+zips = "0.1.7"
 
 [build-dependencies]
 chrono = "0.4.33"

--- a/tui/src/floating_text.rs
+++ b/tui/src/floating_text.rs
@@ -1,5 +1,3 @@
-#![allow(soft_unstable)]
-
 use std::{
     borrow::Cow,
     collections::VecDeque,

--- a/tui/src/floating_text.rs
+++ b/tui/src/floating_text.rs
@@ -52,7 +52,7 @@ const SYNTAX_HIGHLIGHT_STYLES: [(&'static str, anstyle::Style); 8] = [
     ("number", style!(181, 206, 168)),   // light green
 ];
 
-fn get_highlighted_string<'a>(s: &'a str) -> Option<String> {
+fn get_highlighted_string(s: &str) -> Option<String> {
     let mut hl_conf = hl::HighlightConfiguration::new(
         hl_bash::LANGUAGE.into(),
         "bash",

--- a/tui/src/floating_text.rs
+++ b/tui/src/floating_text.rs
@@ -41,7 +41,7 @@ macro_rules! style {
     }};
 }
 
-const SYNTAX_HIGHLIGHT_STYLES: [(&'static str, anstyle::Style); 8] = [
+const SYNTAX_HIGHLIGHT_STYLES: [(&str, anstyle::Style); 8] = [
     ("function", style!(220, 220, 170)), // yellow
     ("string", style!(206, 145, 120)),   // brown
     ("property", style!(156, 220, 254)), // light blue

--- a/tui/src/floating_text.rs
+++ b/tui/src/floating_text.rs
@@ -179,10 +179,12 @@ impl FloatContent for FloatingText {
 
         // Calculate the inner area to ensure text is not drawn over the border
         let inner_area = block.inner(area);
+        let Rect { height, .. } = inner_area;
         let lines = self
             .src
             .lines()
             .skip(self.scroll)
+            .take(height as usize)
             .map(|l| l.into_text().unwrap())
             .collect::<Vec<_>>();
 

--- a/tui/src/floating_text.rs
+++ b/tui/src/floating_text.rs
@@ -1,3 +1,5 @@
+#![allow(soft_unstable)]
+
 use std::io::{Cursor, Read as _, Seek, SeekFrom, Write as _};
 
 use crate::{
@@ -28,9 +30,8 @@ pub enum FloatingTextMode {
 }
 
 pub struct FloatingText {
-    src: String,
+    pub src: Vec<String>,
     scroll: usize,
-    n_lines: usize,
     mode: FloatingTextMode,
 }
 
@@ -111,14 +112,9 @@ fn get_highlighted_string(s: &str) -> Option<String> {
 
 impl FloatingText {
     pub fn new(text: String, mode: FloatingTextMode) -> Self {
-        let mut n_lines = 0;
-
-        text.split("\n").for_each(|_| n_lines += 1);
-
         Self {
-            src: text,
+            src: text.split("\n").map(|s| s.to_string()).collect(),
             scroll: 0,
-            n_lines,
             mode,
         }
     }
@@ -147,7 +143,7 @@ impl FloatingText {
     }
 
     fn scroll_down(&mut self) {
-        if self.scroll + 1 < self.n_lines {
+        if self.scroll + 1 < self.src.len() {
             self.scroll += 1;
         }
     }
@@ -179,12 +175,11 @@ impl FloatContent for FloatingText {
 
         // Calculate the inner area to ensure text is not drawn over the border
         let inner_area = block.inner(area);
-        let Rect { height, .. } = inner_area;
         let lines = self
             .src
-            .lines()
+            .iter()
             .skip(self.scroll)
-            .take(height as usize)
+            .take(inner_area.height as usize)
             .map(|l| l.into_text().unwrap())
             .collect::<Vec<_>>();
 

--- a/tui/src/state.rs
+++ b/tui/src/state.rs
@@ -494,12 +494,7 @@ impl AppState {
     }
     fn enable_description(&mut self) {
         if let Some(command_description) = self.get_selected_description() {
-            let description_content: Vec<String> = vec![]
-                .into_iter()
-                .chain(command_description.lines().map(|line| line.to_string())) // New line when \n is given in toml
-                .collect();
-
-            let description = FloatingText::new(description_content, FloatingTextMode::Description);
+            let description = FloatingText::new(command_description, FloatingTextMode::Description);
             self.spawn_float(description, 80, 80);
         }
     }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/81e359f8-3786-4c79-9864-2af94ae16beb)

Tree-sitter is a permissively-licensed, open-source parser framework, well known for its integrations in many popular editors (i use nvim, btw). Luckily, they provide Rust bindings that are reasonably straightforward to use. This PR implements syntax highlighting for the source preview, making it much easier to read for people wanting to understand the code behind commands that they are running.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [x] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [x] UI/UX improvement

## Description
- Implement tree-sitter-based syntax highlighting

## Testing
Manual testing by perusing the previews of various commands

## Impact
This should make it much easier to understand the source while being presented in the preview

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
