### PR TITLE
Fixed some Rust code structure and modified the workflow to fail if clippy returns warnings

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -38,7 +38,7 @@ jobs:
           restore-keys: ${{ runner.os }}-cargo-index-
 
       - name: Run cargo clippy
-        run: cargo clippy
+        run: cargo clippy -- -Dwarnings
 
       - name: Run cargo fmt
         run: cargo fmt --all --check

--- a/tui/src/state.rs
+++ b/tui/src/state.rs
@@ -21,6 +21,7 @@ use ratatui::{
 
 const MIN_WIDTH: u16 = 77;
 const MIN_HEIGHT: u16 = 19;
+const TITLE: &str = concat!("Linux Toolbox - ", env!("BUILD_DATE"));
 
 pub struct AppState {
     /// Selected theme
@@ -243,15 +244,11 @@ impl AppState {
             Style::new()
         };
 
-        let title = format!(
-            "Linux Toolbox - {} {}",
-            env!("BUILD_DATE"),
-            if self.multi_select {
-                "[Multi-Select]"
-            } else {
-                ""
-            }
-        );
+        let title = if self.multi_select {
+            &format!("{} [Multi-Select]", TITLE)
+        } else {
+            TITLE
+        };
 
         #[cfg(feature = "tips")]
         let bottom_title = Line::from(self.tip.bold().blue()).right_aligned();

--- a/tui/src/state.rs
+++ b/tui/src/state.rs
@@ -246,7 +246,11 @@ impl AppState {
         let title = format!(
             "Linux Toolbox - {} {}",
             env!("BUILD_DATE"),
-            self.multi_select.then(|| "[Multi-Select]").unwrap_or("")
+            if self.multi_select {
+                "[Multi-Select]"
+            } else {
+                ""
+            }
         );
 
         #[cfg(feature = "tips")]


### PR DESCRIPTION
## Type of Change
- [x] Refactoring

## Description
Changed the unnecessary `then` & `unwrap_or` to an if statement.
Modified the Rust workflow to fail if clippy returns warnings

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no errors/warnings/merge conflicts.
