### PR TITLE
feat: titus starship prompt setup script

### DIFF
--- a/core/tabs/applications-setup/tab_data.toml
+++ b/core/tabs/applications-setup/tab_data.toml
@@ -47,7 +47,7 @@ script = "linutil-installer.sh"
 [[data.preconditions]]
 matches = false
 data = "command_exists"
-values = [ "linutil" ]
+values = ["linutil"]
 
 [[data]]
 name = "Linutil Updater"
@@ -57,7 +57,7 @@ script = "linutil-updater.sh"
 [[data.preconditions]]
 matches = true
 data = "command_exists"
-values = [ "linutil" ]
+values = ["linutil"]
 
 [[data]]
 name = "Neovim"
@@ -73,6 +73,11 @@ script = "office-suite-setup.sh"
 name = "Rofi"
 description = "Rofi is a window switcher, run dialog, ssh-launcher and dmenu replacement that started as a clone of simpleswitcher, written by Sean Pringle and later expanded by Dave Davenport.\nThis command installs and configures rofi with configuration from CTT's DWM repo.\nhttps://github.com/ChrisTitusTech/dwm-titus"
 script = "rofi-setup.sh"
+
+[[data]]
+name = "Titus Starship Prompt Setup"
+description = "Starship is a multi-terminal prompt based on rust.\nThis command installs and configures starship with configuration from CTT's mybash repo.\nhttps://github.com/ChrisTitusTech/mybash"
+script = "titus-starship-prompt-setup.sh"
 
 [[data]]
 name = "ZSH Prompt"

--- a/core/tabs/applications-setup/tab_data.toml
+++ b/core/tabs/applications-setup/tab_data.toml
@@ -47,7 +47,7 @@ script = "linutil-installer.sh"
 [[data.preconditions]]
 matches = false
 data = "command_exists"
-values = ["linutil"]
+values = [ "linutil" ]
 
 [[data]]
 name = "Linutil Updater"
@@ -57,7 +57,7 @@ script = "linutil-updater.sh"
 [[data.preconditions]]
 matches = true
 data = "command_exists"
-values = ["linutil"]
+values = [ "linutil" ]
 
 [[data]]
 name = "Neovim"

--- a/core/tabs/applications-setup/tab_data.toml
+++ b/core/tabs/applications-setup/tab_data.toml
@@ -75,7 +75,7 @@ description = "Rofi is a window switcher, run dialog, ssh-launcher and dmenu rep
 script = "rofi-setup.sh"
 
 [[data]]
-name = "Titus Starship Prompt Setup"
+name = "Titus Starship Prompt"
 description = "Starship is a multi-terminal prompt based on rust.\nThis command installs and configures starship with configuration from CTT's mybash repo.\nhttps://github.com/ChrisTitusTech/mybash"
 script = "titus-starship-prompt-setup.sh"
 

--- a/core/tabs/applications-setup/titus-starship-prompt-setup.sh
+++ b/core/tabs/applications-setup/titus-starship-prompt-setup.sh
@@ -30,7 +30,7 @@ setupStarshipTomlFile() {
     cmdCheck
     printf "%b\n" "${CYAN} Download Titus starship prompt file ${RC}"
     mkdir -p "$HOME/.config/starship/"
-    curl -sSLo "${HOME}/.config/starship/starship.toml" "https://github.com/ChrisTitusTech/mybash/raw/main/starship.toml"
+    curl -sSLo "$HOME/.config/starship/starship.toml" "https://github.com/ChrisTitusTech/mybash/raw/main/starship.toml"
     cmdCheck
   else
     printf "%b\n" "${CYAN} Download Titus starship prompt file ${RC}"

--- a/core/tabs/applications-setup/titus-starship-prompt-setup.sh
+++ b/core/tabs/applications-setup/titus-starship-prompt-setup.sh
@@ -45,8 +45,8 @@ configureShell() {
   printf "%b\n" "${CYAN} Setting up your shell. ${RC}"
   if [ -e "$HOME/.bashrc" ]; then
     printf "%b\n" "${CYAN} Setting up bash to use starship as default prompt ${RC}"
-    printf "%s\n" 'eval "$(starship init bash)"' >>"$HOME/.bashrc"
-    printf "%s\n" "export STARSHIP_CONFIG=~/.config/starship/starship.toml" >>"$HOME/.bashrc"
+    printf "%s\n" 'eval "$(starship init bash)"' >> "$HOME/.bashrc"
+    printf "%s\n" "export STARSHIP_CONFIG=~/.config/starship/starship.toml" >> "$HOME/.bashrc"
     cmdCheck
   fi
 

--- a/core/tabs/applications-setup/titus-starship-prompt-setup.sh
+++ b/core/tabs/applications-setup/titus-starship-prompt-setup.sh
@@ -33,7 +33,7 @@ setupStarshipTomlFile() {
     curl -sSLo "$HOME/.config/starship/starship.toml" "https://github.com/ChrisTitusTech/mybash/raw/main/starship.toml"
     cmdCheck
   else
-    printf "%b\n" "${CYAN} Download Titus starship prompt file ${RC}"
+    printf "%b\n" "${CYAN} Downloading Titus' starship prompt file ${RC}"
     mkdir -p "$HOME/.config/starship/"
     curl -sSLo "$HOME/.config/starship/starship.toml" "https://github.com/ChrisTitusTech/mybash/raw/main/starship.toml"
     cmdCheck

--- a/core/tabs/applications-setup/titus-starship-prompt-setup.sh
+++ b/core/tabs/applications-setup/titus-starship-prompt-setup.sh
@@ -35,7 +35,7 @@ setupStarshipTomlFile() {
   else
     printf "%b\n" "${CYAN} Download Titus starship prompt file ${RC}"
     mkdir -p "$HOME/.config/starship/"
-    curl -sSLo "${HOME}/.config/starship/starship.toml" "https://github.com/ChrisTitusTech/mybash/raw/main/starship.toml"
+    curl -sSLo "$HOME/.config/starship/starship.toml" "https://github.com/ChrisTitusTech/mybash/raw/main/starship.toml"
     cmdCheck
   fi
 }

--- a/core/tabs/applications-setup/titus-starship-prompt-setup.sh
+++ b/core/tabs/applications-setup/titus-starship-prompt-setup.sh
@@ -52,8 +52,8 @@ configureShell() {
 
   if [ -e "$HOME/.zshrc" ]; then
     printf "%b\n" "${CYAN} Setting up zsh to use starship as default prompt ${RC}"
-    printf "%s\n" 'eval "$(starship init zsh)"' >>"$HOME/.zshrc"
-    printf "%s\n" "export STARSHIP_CONFIG=~/.config/starship/starship.toml" >>"$HOME/.zshrc"
+    printf "%s\n" 'eval "$(starship init zsh)"' >> "$HOME/.zshrc"
+    printf "%s\n" "export STARSHIP_CONFIG=~/.config/starship/starship.toml" >> "$HOME/.zshrc"
     cmdCheck
   fi
 

--- a/core/tabs/applications-setup/titus-starship-prompt-setup.sh
+++ b/core/tabs/applications-setup/titus-starship-prompt-setup.sh
@@ -1,0 +1,74 @@
+#!/bin/sh -e
+
+. ../common-script.sh
+
+# HACK: Only Setup Titus Starship prompt without compromising with your bash or zsh config
+
+cmdCheck() {
+  if [ $? -eq 0 ]; then
+    printf "%b\n" "${GREEN}**SUCCESS**${RC}"
+  else
+    printf "%b\n" "${RED}**FAIL**${RC}"
+  fi
+}
+
+installStarship() {
+  if ! command_exists starship; then
+    printf "%b\n" "${CYAN} Installing starship ${RC}"
+    curl -sS https://starship.rs/install.sh | sh
+    cmdCheck
+  else
+    printf "%b\n" "${CYAN} Starship is already installed ${RC}"
+  fi
+}
+
+setupStarshipTomlFile() {
+  printf "%b\n" "${YELLOW} Copying starship prompt config ${RC}"
+  if [ -d "$HOME/.config/starship" ]; then
+    printf "%b\n" "${CYAN} Backing up existing starship prompt ${RC}"
+    mv "$HOME/.config/starship/" "$HOME/.config/starship.bk/"
+    cmdCheck
+    printf "%b\n" "${CYAN} Download Titus starship prompt file ${RC}"
+    mkdir -p "$HOME/.config/starship/"
+    curl -sSLo "${HOME}/.config/starship/starship.toml" "https://github.com/ChrisTitusTech/mybash/raw/main/starship.toml"
+    cmdCheck
+  else
+    printf "%b\n" "${CYAN} Download Titus starship prompt file ${RC}"
+    mkdir -p "$HOME/.config/starship/"
+    curl -sSLo "${HOME}/.config/starship/starship.toml" "https://github.com/ChrisTitusTech/mybash/raw/main/starship.toml"
+    cmdCheck
+  fi
+}
+
+# NOTE: Checking if starship config line exist in particular shell
+configureShell() {
+  printf "%b\n" "${CYAN} Setting up your shell.\n${YELLOW}NOTE: currently this script only support bash and zsh. ${RC}"
+  if [ -e "$HOME/.bashrc" ]; then
+    printf "%b\n" "${CYAN} Setting up bash to use starship as default prompt ${RC}"
+    printf "%s\n" 'eval "$(starship init bash)"' >>"$HOME/.bashrc"
+    printf "%s\n" "export STARSHIP_CONFIG=~/.config/starship/starship.toml" >>"$HOME/.bashrc"
+    cmdCheck
+  fi
+
+  if [ -e "$HOME/.zshrc" ]; then
+    printf "%b\n" "${CYAN} Setting up zsh to use starship as default prompt ${RC}"
+    printf "%s\n" 'eval "$(starship init zsh)"' >>"$HOME/.zshrc"
+    printf "%s\n" "export STARSHIP_CONFIG=~/.config/starship/starship.toml" >>"$HOME/.zshrc"
+    cmdCheck
+  fi
+
+  # NOTE: There is a script in linutil application section which sets up zsh in .config directory.
+  # I need to add this config just for that script, if someone has configured their z shell using linutil
+  if [ -e "$HOME/.config/.zshrc" ]; then
+    printf "%b\n" "${CYAN} Setting up zsh to use starship as default prompt ${RC}"
+    printf "%s\n" 'eval "$(starship init fish)"' >>"$HOME/.config/.zshrc"
+    printf "%s\n" "export STARSHIP_CONFIG=~/.config/starship/starship.toml" >>"$HOME/.config/.zshrc"
+    cmdCheck
+  fi
+}
+
+checkEnv
+installStarship
+setupStarshipTomlFile
+configureShell
+printf "%b\n" "${GREEN} Starship Setup is now complete ${RC}"

--- a/core/tabs/applications-setup/titus-starship-prompt-setup.sh
+++ b/core/tabs/applications-setup/titus-starship-prompt-setup.sh
@@ -42,7 +42,7 @@ setupStarshipTomlFile() {
 
 # NOTE: Checking if starship config line exist in particular shell
 configureShell() {
-  printf "%b\n" "${CYAN} Setting up your shell.\n${YELLOW}NOTE: currently this script only support bash and zsh. ${RC}"
+  printf "%b\n" "${CYAN} Setting up your shell. ${RC}"
   if [ -e "$HOME/.bashrc" ]; then
     printf "%b\n" "${CYAN} Setting up bash to use starship as default prompt ${RC}"
     printf "%s\n" 'eval "$(starship init bash)"' >>"$HOME/.bashrc"
@@ -68,6 +68,7 @@ configureShell() {
 }
 
 checkEnv
+printf "%b\n" "${YELLOW}NOTE: currently this script only support bash and zsh."
 installStarship
 setupStarshipTomlFile
 configureShell

--- a/core/tabs/applications-setup/titus-starship-prompt-setup.sh
+++ b/core/tabs/applications-setup/titus-starship-prompt-setup.sh
@@ -61,8 +61,8 @@ configureShell() {
   # I need to add this config just for that script, if someone has configured their z shell using linutil
   if [ -e "$HOME/.config/.zshrc" ]; then
     printf "%b\n" "${CYAN} Setting up zsh to use starship as default prompt ${RC}"
-    printf "%s\n" 'eval "$(starship init fish)"' >>"$HOME/.config/.zshrc"
-    printf "%s\n" "export STARSHIP_CONFIG=~/.config/starship/starship.toml" >>"$HOME/.config/.zshrc"
+    printf "%s\n" 'eval "$(starship init fish)"' >> "$HOME/.config/.zshrc"
+    printf "%s\n" "export STARSHIP_CONFIG=~/.config/starship/starship.toml" >> "$HOME/.config/.zshrc"
     cmdCheck
   fi
 }


### PR DESCRIPTION
<!--
Read Contributing Guidelines before opening a PR.
https://github.com/ChrisTitusTech/linutil/blob/main/.github/CONTRIBUTING.md
-->

## Type of Change
- [x] New feature

## Description
If anyone just want to add titus prompt style on their config. This script sets up the prompt without installing whole titus bash prompt.

## Testing
- Test are performed on my own system in bash and z shell.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
