### PR TITLE
fix: Correctly enter up directories

### DIFF
--- a/tui/src/state.rs
+++ b/tui/src/state.rs
@@ -479,7 +479,8 @@ impl AppState {
     }
 
     pub fn selected_item_is_cmd(&self) -> bool {
-        !self.selected_item_is_dir()
+        // Any item that is not a directory or up directory (..) must be a command
+        !(self.selected_item_is_up_dir() || self.selected_item_is_dir())
     }
     pub fn selected_item_is_up_dir(&self) -> bool {
         let selected_index = self.selection.selected().unwrap_or(0);


### PR DESCRIPTION
<!--
Read Contributing Guidelines before opening a PR.
https://github.com/ChrisTitusTech/linutil/blob/main/.github/CONTRIBUTING.md
-->

## Type of Change
- [x] Bug fix
- [x] Hotfix

## Description
#490 introduced a regression where entering an up directory (..) results in an empty command executing, instead of entering the parent directory. This resolves the issue by including a check for whether the current selection is an up directory in addition to whether it's a standard directory.

## Issues / other PRs related
<!--[What issue/discussion is related to this PR (if any)]-->
- Resolves #579 

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no errors/warnings/merge conflicts.
