### PR TITLE
Enable RPMFusion repos as well on rpmfusion script

### DIFF
--- a/core/tabs/system-setup/fedora/rpm-fusion-setup.sh
+++ b/core/tabs/system-setup/fedora/rpm-fusion-setup.sh
@@ -11,7 +11,9 @@ installRPMFusion() {
                 printf "%b\n" "${YELLOW}Installing RPM Fusion...${RC}"
                 "$ESCALATION_TOOL" "$PACKAGER" install https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-$(rpm -E %fedora).noarch.rpm
                 "$ESCALATION_TOOL" "$PACKAGER" config-manager --enable fedora-cisco-openh264
-                printf "%b\n" "${GREEN}RPM Fusion installed${RC}"
+                "$ESCALATION_TOOL" dnf config-manager --set-enabled rpmfusion-nonfree-updates
+                "$ESCALATION_TOOL" dnf config-manager --set-enabled rpmfusion-free-updates
+                printf "%b\n" "${GREEN}RPM Fusion installed and enabled${RC}"
             else
                 printf "%b\n" "${GREEN}RPM Fusion already installed${RC}"
             fi

--- a/core/tabs/system-setup/fedora/rpm-fusion-setup.sh
+++ b/core/tabs/system-setup/fedora/rpm-fusion-setup.sh
@@ -11,8 +11,8 @@ installRPMFusion() {
                 printf "%b\n" "${YELLOW}Installing RPM Fusion...${RC}"
                 "$ESCALATION_TOOL" "$PACKAGER" install https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-$(rpm -E %fedora).noarch.rpm
                 "$ESCALATION_TOOL" "$PACKAGER" config-manager --enable fedora-cisco-openh264
-                "$ESCALATION_TOOL" dnf config-manager --set-enabled rpmfusion-nonfree-updates
-                "$ESCALATION_TOOL" dnf config-manager --set-enabled rpmfusion-free-updates
+                "$ESCALATION_TOOL" "$PACKAGER" config-manager --set-enabled rpmfusion-nonfree-updates
+                "$ESCALATION_TOOL" "$PACKAGER" config-manager --set-enabled rpmfusion-free-updates
                 printf "%b\n" "${GREEN}RPM Fusion installed and enabled${RC}"
             else
                 printf "%b\n" "${GREEN}RPM Fusion already installed${RC}"


### PR DESCRIPTION
<!--
Read Contributing Guidelines before opening a PR.
https://github.com/ChrisTitusTech/linutil/blob/main/.github/CONTRIBUTING.md
-->

## Type of Change
- [x] Bug fix 

## Description
Is there any reason for the rpm fusion setup not enabling the repos?
<!--[Provide a detailed explanation of the changes you have made. Include the reasons behind these changes and any relevant context. Link any related issues.]-->

## Testing
I was working on the Nvidia-driver script (on a non-standard fedora install)  and noticed that it was failing cuz rpm-fussion never got enabled globally and the rpm-fusion-nvidia repo only exists on fedora DE spins
<!--[Detail the testing you have performed to ensure that these changes function as intended. Include information about any added tests.]-->

## Checklist
- [ ] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no errors/warnings/merge conflicts.
