### PR TITLE
Fix: Selected-cmd bug

### DIFF
--- a/tui/src/state.rs
+++ b/tui/src/state.rs
@@ -516,7 +516,8 @@ impl AppState {
 
     pub fn selected_item_is_cmd(&self) -> bool {
         // Any item that is not a directory or up directory (..) must be a command
-        !(self.selected_item_is_up_dir() || self.selected_item_is_dir())
+        self.selection.selected().is_some()
+            && !(self.selected_item_is_up_dir() || self.selected_item_is_dir())
     }
     pub fn selected_item_is_up_dir(&self) -> bool {
         let selected_index = self.selection.selected().unwrap_or(0);


### PR DESCRIPTION
## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
- Fixed a bug where floating window appears even though no command is selected.

![command](https://github.com/user-attachments/assets/adee98be-25b2-40cc-bb5d-86217707122b)

## Testing
- Working as expected.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
