### PR TITLE
Auto power profiling in arch needs to run an extra command.

### DIFF
--- a/core/tabs/utils/power-profile.sh
+++ b/core/tabs/utils/power-profile.sh
@@ -34,6 +34,7 @@ installAutoCpufreq() {
         cd auto-cpufreq
         printf "%b\n" "${YELLOW}Running auto-cpufreq installer...${RC}"
         "$ESCALATION_TOOL" ./auto-cpufreq-installer
+        "$ESCALATION_TOOL"  auto-cpufreq --install
 
         cd ..
     fi


### PR DESCRIPTION
## Type of Change
- [x] Bug fix

## Description
Auto power profiling in arch needs to run an extra command. added it to ensure all systems run it before setting power profile.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
