### PR TITLE
Emit all shellcheck errors using github action toolkit annotations and check for tab indentation

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -39,7 +39,7 @@ jobs:
                   # fast fail on the action runner would fail immediately if there weren't any tabs found
                   # this check makes sure that we don't continue if there's something really weird going on
                   if [ "$?" = "2" ]; then
-                      echo "::error file=$file::There was a critical while grepping $file, aborting"
+                      echo "::error file=$file::There was a critical error while grepping $file, aborting"
                       exit 1
                   fi
 

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -14,17 +14,42 @@ jobs:
       - uses: actions/checkout@v4
       - run: git fetch origin ${{ github.base_ref }}
 
-      - name: Download and set up shellcheck
+      - name: Download, setup, and run ShellCheck
+        shell: bash {0}
         run : |
-          wget https://github.com/koalaman/shellcheck/releases/download/v0.10.0/shellcheck-v0.10.0.linux.x86_64.tar.xz
-          tar -xf shellcheck-v0.10.0.linux.x86_64.tar.xz
-          cd shellcheck-v0.10.0
-          chmod +x shellcheck
+          SC_URL="https://github.com/koalaman/shellcheck/releases/download/v0.10.0/shellcheck-v0.10.0.linux.x86_64.tar.xz"
+          curl -fsSL "$SC_URL" | tar -Jx
+          chmod +x "./shellcheck-v0.10.0/shellcheck"
 
-      - name: Run shellcheck
-        run: |
-          for file in $(git diff --name-only origin/${{ github.base_ref }} HEAD core/tabs); do
+          error=0
+          files_to_check=$(git diff --name-only origin/${{ github.base_ref }} HEAD core/tabs)
+
+          for file in $files_to_check; do
               if [[ "$file" == *.sh ]] && [[ -f "$file" ]]; then
-                  ./shellcheck-v0.10.0/shellcheck -S error "$file"
+                  sc_output=$(./shellcheck-v0.10.0/shellcheck -fgcc -Serror "$file")
+                  iter_safe_parsed_errors=$(echo -e "$sc_output" | sed -n 's/\(.\+\)\:\([0-9]\+\)\:\([0-9]\+\)\: \(.*\)/::error file=\1,line=\2,col=\3::\4/p' | sed 's/ /:space:/g')
+
+                  for error in $iter_safe_parsed_errors; do
+                      echo "$error" | sed 's/:space:/ /g'
+                      error=1
+                  done
+
+                  tabs_detected=$(grep -nP '^\t+\S+' "$file")
+
+                  # fast fail on the action runner would fail immediately if there weren't any tabs found
+                  # this check makes sure that we don't continue if there's something really weird going on
+                  if [ "$?" = "2" ]; then
+                      echo "::error file=$file::There was a critical while grepping $file, aborting"
+                      exit 1
+                  fi
+
+                  iter_safe_parsed_tabs_detected=$(echo "$tabs_detected" | sed -n 's,\([0-9]\+\).*,::error file='"$file"'\,line=\1::Found tab indentations,p' | sed 's/ /:space:/g')
+
+                  for error in $iter_safe_parsed_tabs_detected; do
+                      echo "$error" | sed 's/:space:/ /g'
+                      error=1
+                  done
               fi
           done
+
+          exit $error

--- a/core/tabs/applications-setup/Developer-tools/sublime-setup.sh
+++ b/core/tabs/applications-setup/Developer-tools/sublime-setup.sh
@@ -3,37 +3,37 @@
 . ../../common-script.sh
 
 installSublime() {
-	if ! command_exists sublime; then
-            printf "%b\n" "${YELLOW}Installing Sublime...${RC}"
-            case "$PACKAGER" in
-                apt-get|nala)
-                    curl -fsSL https://download.sublimetext.com/sublimehq-pub.gpg | "$ESCALATION_TOOL" apt-key add -
-                    echo "deb https://download.sublimetext.com/ apt/stable/" | "$ESCALATION_TOOL" tee /etc/apt/sources.list.d/sublime-text.list
-                    "$ESCALATION_TOOL" "$PACKAGER" update
-                    "$ESCALATION_TOOL" "$PACKAGER" install -y sublime-text
-                    ;;
-                zypper)
-                    "$ESCALATION_TOOL" rpm -v --import https://download.sublimetext.com/sublimehq-rpm-pub.gpg
-                    "$ESCALATION_TOOL" "$PACKAGER" addrepo -g -f https://download.sublimetext.com/rpm/dev/x86_64/sublime-text.repo
-                    "$ESCALATION_TOOL" "$PACKAGER" refresh
-                    "$ESCALATION_TOOL" "$PACKAGER" --non-interactive install sublime-text
-                    ;;
-                pacman)
-                    "$AUR_HELPER" -S --needed --noconfirm sublime-text-4
-                    ;;
-                dnf)
-                    "$ESCALATION_TOOL" rpm -v --import https://download.sublimetext.com/sublimehq-rpm-pub.gpg
-                    "$ESCALATION_TOOL" "$PACKAGER" config-manager --add-repo https://download.sublimetext.com/rpm/stable/x86_64/sublime-text.repo
-                    "$ESCALATION_TOOL" "$PACKAGER" install -y sublime-text
-                    ;;
-                *)
-                    printf "%b\n" "${RED}Unsupported package manager: ""$PACKAGER""${RC}"
-                    exit 1
-                    ;;
-            esac
-        else
-            printf "%b\n" "${GREEN}Sublime is already installed.${RC}"
-        fi
+    if ! command_exists sublime; then
+        printf "%b\n" "${YELLOW}Installing Sublime...${RC}"
+        case "$PACKAGER" in
+            apt-get|nala)
+                curl -fsSL https://download.sublimetext.com/sublimehq-pub.gpg | "$ESCALATION_TOOL" apt-key add -
+                echo "deb https://download.sublimetext.com/ apt/stable/" | "$ESCALATION_TOOL" tee /etc/apt/sources.list.d/sublime-text.list
+                "$ESCALATION_TOOL" "$PACKAGER" update
+                "$ESCALATION_TOOL" "$PACKAGER" install -y sublime-text
+                ;;
+            zypper)
+                "$ESCALATION_TOOL" rpm -v --import https://download.sublimetext.com/sublimehq-rpm-pub.gpg
+                "$ESCALATION_TOOL" "$PACKAGER" addrepo -g -f https://download.sublimetext.com/rpm/dev/x86_64/sublime-text.repo
+                "$ESCALATION_TOOL" "$PACKAGER" refresh
+                "$ESCALATION_TOOL" "$PACKAGER" --non-interactive install sublime-text
+                ;;
+            pacman)
+                "$AUR_HELPER" -S --needed --noconfirm sublime-text-4
+                ;;
+            dnf)
+                "$ESCALATION_TOOL" rpm -v --import https://download.sublimetext.com/sublimehq-rpm-pub.gpg
+                "$ESCALATION_TOOL" "$PACKAGER" config-manager --add-repo https://download.sublimetext.com/rpm/stable/x86_64/sublime-text.repo
+                "$ESCALATION_TOOL" "$PACKAGER" install -y sublime-text
+                ;;
+            *)
+                printf "%b\n" "${RED}Unsupported package manager: ""$PACKAGER""${RC}"
+                exit 1
+                ;;
+        esac
+    else
+        printf "%b\n" "${GREEN}Sublime is already installed.${RC}"
+    fi
 
 }
 

--- a/core/tabs/system-setup/arch/server-setup.sh
+++ b/core/tabs/system-setup/arch/server-setup.sh
@@ -466,7 +466,7 @@ if [[  $TOTAL_MEM -lt 8000000 ]]; then
     mkswap /mnt/opt/swap/swapfile
     swapon /mnt/opt/swap/swapfile
     # The line below is written to /mnt/ but doesn't contain /mnt/, since it's just / for the system itself.
-    echo "/opt/swap/swapfile	none	swap	sw	0	0" >> /mnt/etc/fstab # Add swap to fstab, so it KEEPS working after installation.
+    echo "/opt/swap/swapfile    none    swap    sw    0    0" >> /mnt/etc/fstab # Add swap to fstab, so it KEEPS working after installation.
 fi
 
 gpu_type=$(lspci | grep -E "VGA|3D|Display")
@@ -493,8 +493,8 @@ nc=$(grep -c ^processor /proc/cpuinfo)
 echo -ne "
 -------------------------------------------------------------------------
                     You have " $nc" cores. And
-			changing the makeflags for " $nc" cores. Aswell as
-				changing the compression settings.
+            changing the makeflags for " $nc" cores. Aswell as
+                changing the compression settings.
 -------------------------------------------------------------------------
 "
 TOTAL_MEM=$(cat /proc/meminfo | grep -i 'memtotal' | grep -o '[[:digit:]]*')

--- a/start.sh
+++ b/start.sh
@@ -14,8 +14,8 @@ check() {
         exit 1
     fi
 
-	unset exit_code
-	unset message
+    unset exit_code
+    unset message
 }
 
 findArch() {


### PR DESCRIPTION
Tabs are problematic when rendering previews of shell scripts, as it results in a disparity between the position of expected rendered characters and where they may actually be rendered on the screen, and having mixed space/tab indentation in the same file is generally problematic as well.

## Type of Change
- [x] Bug fix
- [x] Refactoring

## Description
- Emit all errors found within the changed files using gh actions toolkit annotations, before, the workflow would fail on the first shellcheck invocation that had an error emission
- Add a tab indentation check to enforce consistency in code style
- removed all current tab indentations that I've found in shell scripts

## Testing
Verified using workflow runs within my own repository

## Impact
Helps provide complete error information from both shellcheck and tab indentation detection

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
