### PR TITLE
fix: Crates.io package installation on Debian & Fedora

### DIFF
--- a/core/tabs/applications-setup/linutil-installer.sh
+++ b/core/tabs/applications-setup/linutil-installer.sh
@@ -37,13 +37,17 @@ installLinutil() {
                             pacman)
                                 "$ESCALATION_TOOL" "$PACKAGER" -S --needed --noconfirm rustup
                                 ;;
+                            dnf)
+                                "$ESCALATION_TOOL" "$PACKAGER" install -y rustup
+                                ;;
                             zypper)
                                 "$ESCALATION_TOOL" "$PACKAGER" install -n curl gcc make
-                                curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+                                curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
                                 . $HOME/.cargo/env
                                 ;;
                             *)
-                                "$ESCALATION_TOOL" "$PACKAGER" install -y rustup
+                                curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+                                . $HOME/.cargo/env
                                 ;;
                         esac
                     fi


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [x] Hotfix

## Description
The script tries to install `rustup`, but Debian doesn't provide it in stable repos. That's why the installation failed on Chris' latest stream.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no errors/warnings/merge conflicts.
