### PR TITLE
fix: do not hard depend on sudo being installed

### DIFF
--- a/core/tabs/common-script.sh
+++ b/core/tabs/common-script.sh
@@ -125,11 +125,11 @@ checkDistro() {
 }
 
 checkEnv() {
-    checkCommandRequirements 'curl groups sudo'
+    checkEscalationTool
+    checkCommandRequirements "curl groups $ESCALATION_TOOL"
     checkPackageManager 'nala apt-get dnf pacman zypper'
     checkCurrentDirectoryWritable
     checkSuperUser
     checkDistro
-    checkEscalationTool
     checkAURHelper
 }


### PR DESCRIPTION
<!--
Read Contributing Guidelines before opening a PR.
https://github.com/ChrisTitusTech/linutil/blob/main/.github/CONTRIBUTING.md
-->

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
<!--[Provide a detailed explanation of the changes you have made. Include the reasons behind these changes and any relevant context. Link any related issues.]-->
the checkCommandRequirements function under checkEnv function in common-script.sh hard-depended on sudo, although doas could be picked as an $ESCALATION_TOOL.

## Testing
<!--[Detail the testing you have performed to ensure that these changes function as intended. Include information about any added tests.]-->
I activated acouple of the scripts from with the UI, there was no error for not having sudo on my sudo-less system anymore.

## Impact
<!--[Discuss the impact of your changes on the project. This might include effects on performance, new dependencies, or changes in behaviour.]-->
Allows doas to properly be used as an escalation tool now.

## Issues / other PRs related
<!--[What issue/discussion is related to this PR (if any)]-->
- Similar to #193 which introduced doas support.

## Additional Information
<!--[Any additional information that reviewers should be aware of.]-->

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
