### PR TITLE
Feat: confirmation prompts

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,5 +1,7 @@
 mod inner;
 
+use std::rc::Rc;
+
 use ego_tree::Tree;
 use std::path::PathBuf;
 
@@ -20,7 +22,7 @@ pub enum Command {
 #[derive(Clone, Hash, Eq, PartialEq)]
 pub struct Tab {
     pub name: String,
-    pub tree: Tree<ListNode>,
+    pub tree: Tree<Rc<ListNode>>,
     pub multi_selectable: bool,
 }
 

--- a/tui/src/confirmation.rs
+++ b/tui/src/confirmation.rs
@@ -36,7 +36,7 @@ impl ConfirmPrompt {
     }
 
     pub fn scroll_down(&mut self) {
-        if self.scroll < self.names.len() {
+        if self.scroll < self.names.len() - 1 {
             self.scroll += 1;
         }
     }
@@ -67,7 +67,8 @@ impl FloatContent for ConfirmPrompt {
             .iter()
             .skip(self.scroll)
             .map(|p| {
-                Line::from(Span::from(Cow::<'_, str>::Borrowed(p))).style(Style::default().bold())
+                let span = Span::from(Cow::<'_, str>::Borrowed(p));
+                Line::from(span).style(Style::default().bold())
             })
             .collect::<Text>();
 
@@ -80,6 +81,8 @@ impl FloatContent for ConfirmPrompt {
         self.status = match key.code {
             Char('y') | Char('Y') => ConfirmStatus::Confirm,
             Char('n') | Char('N') | Esc => ConfirmStatus::Abort,
+            Char('j') => { self.scroll_down(); ConfirmStatus::None },
+            Char('k') => { self.scroll_up(); ConfirmStatus::None },
             _ => ConfirmStatus::None,
         };
 
@@ -100,6 +103,9 @@ impl FloatContent for ConfirmPrompt {
             Box::new([
                 Shortcut::new("Continue", ["Y", "y"]),
                 Shortcut::new("Abort", ["N", "n"]),
+                Shortcut::new("Scroll up", ["j"]),
+                Shortcut::new("Scroll down", ["k"]),
+                Shortcut::new("Close linutil", ["CTRL-c", "q"])
             ]),
         )
     }

--- a/tui/src/confirmation.rs
+++ b/tui/src/confirmation.rs
@@ -4,6 +4,7 @@ use crate::{float::FloatContent, hint::Shortcut};
 
 use crossterm::event::{KeyCode, KeyEvent};
 use ratatui::{
+    layout::Alignment,
     prelude::*,
     widgets::{Block, Borders, Clear, List},
 };
@@ -52,12 +53,11 @@ impl FloatContent for ConfirmPrompt {
     fn draw(&mut self, frame: &mut Frame, area: Rect) {
         let block = Block::default()
             .borders(Borders::ALL)
-            .title("Confirm selections")
-            .title_alignment(ratatui::layout::Alignment::Center)
-            .title_style(Style::default().reversed())
+            .title(" Confirm selections ")
+            .title_alignment(Alignment::Center)
+            .title_style(Style::default().bold())
             .style(Style::default());
 
-        // Draw the Block first
         frame.render_widget(block.clone(), area);
 
         let inner_area = block.inner(area);
@@ -68,7 +68,7 @@ impl FloatContent for ConfirmPrompt {
             .skip(self.scroll)
             .map(|p| {
                 let span = Span::from(Cow::<'_, str>::Borrowed(p));
-                Line::from(span).style(Style::default().bold())
+                Line::from(span).style(Style::default())
             })
             .collect::<Text>();
 
@@ -81,8 +81,14 @@ impl FloatContent for ConfirmPrompt {
         self.status = match key.code {
             Char('y') | Char('Y') => ConfirmStatus::Confirm,
             Char('n') | Char('N') | Esc => ConfirmStatus::Abort,
-            Char('j') => { self.scroll_down(); ConfirmStatus::None },
-            Char('k') => { self.scroll_up(); ConfirmStatus::None },
+            Char('j') => {
+                self.scroll_down();
+                ConfirmStatus::None
+            }
+            Char('k') => {
+                self.scroll_up();
+                ConfirmStatus::None
+            }
             _ => ConfirmStatus::None,
         };
 
@@ -105,7 +111,7 @@ impl FloatContent for ConfirmPrompt {
                 Shortcut::new("Abort", ["N", "n"]),
                 Shortcut::new("Scroll up", ["j"]),
                 Shortcut::new("Scroll down", ["k"]),
-                Shortcut::new("Close linutil", ["CTRL-c", "q"])
+                Shortcut::new("Close linutil", ["CTRL-c", "q"]),
             ]),
         )
     }

--- a/tui/src/confirmation.rs
+++ b/tui/src/confirmation.rs
@@ -1,0 +1,106 @@
+use std::borrow::Cow;
+
+use crate::{float::FloatContent, hint::Shortcut};
+
+use crossterm::event::{KeyCode, KeyEvent};
+use ratatui::{
+    prelude::*,
+    widgets::{Block, Borders, Clear, List},
+};
+
+pub enum ConfirmStatus {
+    Confirm,
+    Abort,
+    None,
+}
+
+pub struct ConfirmPrompt {
+    pub names: Box<[String]>,
+    pub status: ConfirmStatus,
+    scroll: usize,
+}
+
+impl ConfirmPrompt {
+    pub fn new(names: &[&str]) -> Self {
+        let names = names
+            .iter()
+            .zip(1..)
+            .map(|(name, n)| format!("{n}. {name}"))
+            .collect();
+
+        Self {
+            names,
+            status: ConfirmStatus::None,
+            scroll: 0,
+        }
+    }
+
+    pub fn scroll_down(&mut self) {
+        if self.scroll < self.names.len() {
+            self.scroll += 1;
+        }
+    }
+
+    pub fn scroll_up(&mut self) {
+        if self.scroll > 0 {
+            self.scroll -= 1;
+        }
+    }
+}
+
+impl FloatContent for ConfirmPrompt {
+    fn draw(&mut self, frame: &mut Frame, area: Rect) {
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .title("Confirm selections")
+            .title_alignment(ratatui::layout::Alignment::Center)
+            .title_style(Style::default().reversed())
+            .style(Style::default());
+
+        // Draw the Block first
+        frame.render_widget(block.clone(), area);
+
+        let inner_area = block.inner(area);
+
+        let paths_text = self
+            .names
+            .iter()
+            .skip(self.scroll)
+            .map(|p| {
+                Line::from(Span::from(Cow::<'_, str>::Borrowed(p))).style(Style::default().bold())
+            })
+            .collect::<Text>();
+
+        frame.render_widget(Clear, inner_area);
+        frame.render_widget(List::new(paths_text), inner_area);
+    }
+
+    fn handle_key_event(&mut self, key: &KeyEvent) -> bool {
+        use KeyCode::*;
+        self.status = match key.code {
+            Char('y') | Char('Y') => ConfirmStatus::Confirm,
+            Char('n') | Char('N') | Esc => ConfirmStatus::Abort,
+            _ => ConfirmStatus::None,
+        };
+
+        false
+    }
+
+    fn is_finished(&self) -> bool {
+        use ConfirmStatus::*;
+        match self.status {
+            Confirm | Abort => true,
+            None => false,
+        }
+    }
+
+    fn get_shortcut_list(&self) -> (&str, Box<[Shortcut]>) {
+        (
+            "Confirmation prompt",
+            Box::new([
+                Shortcut::new("Continue", ["Y", "y"]),
+                Shortcut::new("Abort", ["N", "n"]),
+            ]),
+        )
+    }
+}

--- a/tui/src/confirmation.rs
+++ b/tui/src/confirmation.rs
@@ -54,6 +54,7 @@ impl FloatContent for ConfirmPrompt {
         let block = Block::default()
             .borders(Borders::ALL)
             .title(" Confirm selections ")
+            .title_bottom(" [y] to continue, [n] to abort ")
             .title_alignment(Alignment::Center)
             .title_style(Style::default().bold())
             .style(Style::default());

--- a/tui/src/confirmation.rs
+++ b/tui/src/confirmation.rs
@@ -23,10 +23,17 @@ pub struct ConfirmPrompt {
 
 impl ConfirmPrompt {
     pub fn new(names: &[&str]) -> Self {
+        let max_count_str = format!("{}", names.len());
         let names = names
             .iter()
             .zip(1..)
-            .map(|(name, n)| format!("{n}. {name}"))
+            .map(|(name, n)| {
+                let count_str = format!("{n}");
+                let space_str = (0..(max_count_str.len() - count_str.len()))
+                    .map(|_| ' ')
+                    .collect::<String>();
+                format!("{space_str}{n}. {name}")
+            })
             .collect();
 
         Self {

--- a/tui/src/float.rs
+++ b/tui/src/float.rs
@@ -13,14 +13,14 @@ pub trait FloatContent {
     fn get_shortcut_list(&self) -> (&str, Box<[Shortcut]>);
 }
 
-pub struct Float {
-    content: Box<dyn FloatContent>,
+pub struct Float<Content: FloatContent + ?Sized> {
+    pub content: Box<Content>,
     width_percent: u16,
     height_percent: u16,
 }
 
-impl Float {
-    pub fn new(content: Box<dyn FloatContent>, width_percent: u16, height_percent: u16) -> Self {
+impl<Content: FloatContent + ?Sized> Float<Content> {
+    pub fn new(content: Box<Content>, width_percent: u16, height_percent: u16) -> Self {
         Self {
             content,
             width_percent,

--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -1,3 +1,4 @@
+mod confirmation;
 mod filter;
 mod float;
 mod floating_text;

--- a/tui/src/state.rs
+++ b/tui/src/state.rs
@@ -43,7 +43,7 @@ pub struct AppState {
     /// Selected theme
     theme: Theme,
     /// Currently focused area
-    pub focus: Focus<dyn FloatContent>,
+    pub focus: Focus,
     /// List of tabs
     tabs: Vec<Tab>,
     /// Current tab
@@ -62,11 +62,11 @@ pub struct AppState {
     tip: &'static str,
 }
 
-pub enum Focus<Content: FloatContent + ?Sized> {
+pub enum Focus {
     Search,
     TabList,
     List,
-    FloatingWindow(Float<Content>),
+    FloatingWindow(Float<dyn FloatContent>),
     ConfirmationPrompt(Float<ConfirmPrompt>),
 }
 


### PR DESCRIPTION
# Add confirmation prompt to prevent accidental command execution

## Type of Change
- [x] New feature
- [x] UI/UX improvement

## Description
Having an accidental keypress result in a significant environment change sucks. Adding a prompt to confirm the execution of a command makes it less likely that a user will have a destructive command accidentally execute and have to decipher the command source to revert the changes (if they even are revertible).

## Testing
locally, tested aborting and confirming command selections

## Impact
should prevent accidental neovim config deletions, at least :)

## Issues / other PRs related
- Resolves #686 


## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
