### PR TITLE
fix: multilib check in gaming setup

### DIFF
--- a/core/tabs/system-setup/gaming-setup.sh
+++ b/core/tabs/system-setup/gaming-setup.sh
@@ -9,7 +9,7 @@ installDepend() {
     case "$PACKAGER" in
         pacman)
             #Check for multilib
-            if ! grep -q "^\s*$$multilib$$" /etc/pacman.conf; then
+            if ! grep -q "^\s*\[multilib\]" /etc/pacman.conf; then
                 echo "[multilib]" | "$ESCALATION_TOOL" tee -a /etc/pacman.conf
                 echo "Include = /etc/pacman.d/mirrorlist" | "$ESCALATION_TOOL" tee -a /etc/pacman.conf
                 "$ESCALATION_TOOL" "$PACKAGER" -Syu


### PR DESCRIPTION
<!--
Read Contributing Guidelines before opening a PR.
https://github.com/ChrisTitusTech/linutil/blob/main/.github/CONTRIBUTING.md
-->

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description

I've edited the regex for checking presence of multilib package mirrors in `/etc/pacman.conf`.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
