### PR TITLE
fix(meta): bump crates versions to `24.9.28`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace.package]
 license = "MIT"
-version = "24.9.23"
+version = "24.9.28"
 
 [workspace.dependencies]
 ego-tree = "0.6.2"

--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -24,7 +24,7 @@ ratatui = "0.28.1"
 tui-term = "0.1.12"
 unicode-width = "0.1.13"
 rand = { version = "0.8.5", optional = true }
-linutil_core = { path = "../core", version = "24.9.23" }
+linutil_core = { path = "../core", version = "24.9.28" }
 tree-sitter-highlight = "0.23.0"
 tree-sitter-bash = "0.23.1"
 anstyle = "1.0.8"


### PR DESCRIPTION
## Type of Change
- [x] Hotfix

## Description
The updated version is already up on `crates.io`.
Ref https://github.com/ChrisTitusTech/linutil/issues/691#issuecomment-2381011204

## Testing
No dep conflicts, everything updated, should work.

## Issues / other PRs related
- Resolves #691
