### PR TITLE
fix: uuid retrieve bug

### DIFF
--- a/core/tabs/utils/auto-mount.sh
+++ b/core/tabs/utils/auto-mount.sh
@@ -21,7 +21,7 @@ select_drive() {
 
 # Function to get UUID and FSTYPE of the selected drive
 get_uuid_fstype() {
-    UUID=$(blkid -s UUID -o value "${partition}")
+    UUID=$("$ESCALATION_TOOL" blkid -s UUID -o value "${partition}")
     FSTYPE=$(lsblk -no FSTYPE "${partition}")
     NAME=$(lsblk -no NAME "${partition}")
 


### PR DESCRIPTION
## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
- `blkid` requires escalation to retrieve information.

## Testing
- Tested on arch linux, working fine.

## Issues / other PRs related
- Resolves #684 

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
