### PR TITLE
chore: Add spacing before and after for tui titles

### DIFF
--- a/tui/src/filter.rs
+++ b/tui/src/filter.rs
@@ -95,7 +95,7 @@ impl Filter {
 
         //Create the search bar widget
         let search_bar = Paragraph::new(display_text)
-            .block(Block::default().borders(Borders::ALL).title("Search"))
+            .block(Block::default().borders(Borders::ALL).title(" Search "))
             .style(Style::default().fg(search_color));
 
         //Render the search bar (First chunk of the screen)

--- a/tui/src/running_command.rs
+++ b/tui/src/running_command.rs
@@ -73,7 +73,7 @@ impl FloatContent for RunningCommand {
 
             title_line.push_span(
                 Span::default()
-                    .content(" press <ENTER> to close this window ")
+                    .content(" Press <ENTER> to close this window ")
                     .style(Style::default()),
             );
 

--- a/tui/src/state.rs
+++ b/tui/src/state.rs
@@ -21,7 +21,7 @@ use ratatui::{
 
 const MIN_WIDTH: u16 = 77;
 const MIN_HEIGHT: u16 = 19;
-const TITLE: &str = concat!("Linux Toolbox - ", env!("BUILD_DATE"));
+const TITLE: &str = concat!(" Linux Toolbox - ", env!("BUILD_DATE"), " ");
 const ACTIONS_GUIDE: &str = "List of important tasks performed by commands' names:
 
 D  - disk modifications (ex. partitioning) (privileged)
@@ -357,7 +357,7 @@ impl AppState {
         };
 
         let title = if self.multi_select {
-            &format!("{} [Multi-Select]", TITLE)
+            &format!("{}[Multi-Select] ", TITLE)
         } else {
             TITLE
         };
@@ -367,7 +367,7 @@ impl AppState {
         #[cfg(not(feature = "tips"))]
         let bottom_title = "";
 
-        let task_list_title = Line::from("Important Actions ").right_aligned();
+        let task_list_title = Line::from(" Important Actions ").right_aligned();
 
         // Create the list widget with items
         let list = List::new(items)
@@ -694,5 +694,5 @@ fn get_random_tip() -> &'static str {
 
     let mut rng = rand::thread_rng();
     let random_index = rng.gen_range(0..tips.len());
-    tips[random_index]
+    Box::leak(format!(" {} ", tips[random_index]).into_boxed_str())
 }


### PR DESCRIPTION
## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [x] UI/UX improvement

## Description
- Add spacing before and after titles and tips in TUI.

Before

![before](https://github.com/user-attachments/assets/3618f35d-f0a9-4ac9-b284-9725abb11c01)

After

![after](https://github.com/user-attachments/assets/8b33693b-6f70-4b40-aba1-81433aeb4894)

## Testing
- Tested no issues.

## Additional Information
- `Box::leak` was used for cool tips as it is static and will be displayed through out the whole program.
- `Box::leak` must be used with caution as it can lead to memory leaks. But here the cool tips is not borrowed or used in mutable state so there should be no issues.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
