### PR TITLE
fix(ci): `bashisms.yml`. again. will work all the time this time i swear.

### DIFF
--- a/.github/workflows/bashisms.yml
+++ b/.github/workflows/bashisms.yml
@@ -33,6 +33,7 @@ jobs:
       - name: Check for bashisms
         if: steps.get_sh_files.outputs.changed == 1
         run: |
+          echo "Running for:\n$(cat changed_files)\n"
           for file in $(cat changed_files); do
             if [[ -f "$file" ]]; then
               checkbashisms "$file"

--- a/.github/workflows/bashisms.yml
+++ b/.github/workflows/bashisms.yml
@@ -19,17 +19,26 @@ jobs:
         id: get_sh_files
         run: |
           sh_files=$(git diff --name-only origin/${{ github.base_ref }} HEAD core/tabs | grep '\.sh$' || true)
-          echo "::set-output name=sh_files::$sh_files"
+          if [ -n "$sh_files" ]; then
+            echo "$sh_files" > changed_files
+            echo "changed=1" >> $GITHUB_OUTPUT
+          else
+            echo "changed=0" >> $GITHUB_OUTPUT
+          fi
       
       - name: Install devscripts
-        if: steps.get_sh_files.outputs.sh_files != ''
+        if: steps.get_sh_files.outputs.changed == 1
         run: sudo apt-get update && sudo apt-get install devscripts
 
       - name: Check for bashisms
-        if: steps.get_sh_files.outputs.sh_files != ''
+        if: steps.get_sh_files.outputs.changed == 1
         run: |
-          for file in ${{ steps.get_sh_files.outputs.sh_files }}; do
-              if [[ -f "$file" ]]; then
-                  checkbashisms "$file"
-              fi
+          for file in $(cat changed_files); do
+            if [[ -f "$file" ]]; then
+              checkbashisms "$file"
+            fi
           done
+
+      - name: Remove the created file
+        if: steps.get_sh_files.outputs.changed == 1
+        run: rm changed_files


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [x] Hotfix

## Description
Yeah so changed a bit here.
1. Does not use GitHub Output to store the list now (this was the *main* issue here), instead creates a file
2. Still uses GitHub Output for storing a bool
3. It's now easier to debug beacause the list is being echoed
4. The file is being removed at the end

And yeah that's about it. Will work now.
Still, it'd be much better to just grap the `checkbashisms` binary but [Debian doesn't seem to care](https://salsa.debian.org/debian/devscripts).

## Testing
I waste too much time testing workflows. GitHub should make that easier somehow. (yes, it's tested)

## Additional Information
Any additional information that reviewers should be aware of? Nope, not here.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no errors/warnings/merge conflicts.

Oopsie forgot about resolves #711 