### PR TITLE
allow scrolling past last entry / first entry

### DIFF
--- a/tui/src/state.rs
+++ b/tui/src/state.rs
@@ -761,9 +761,6 @@ impl AppState {
 
     fn scroll_tab_down(&mut self) {
         let len = self.tabs.len();
-        if len == 0 {
-            return;
-        }
         let current = self.current_tab.selected().unwrap_or(0);
         let next = if current + 1 >= len { 0 } else { current + 1 };
         self.current_tab.select(Some(next));

--- a/tui/src/state.rs
+++ b/tui/src/state.rs
@@ -512,6 +512,9 @@ impl AppState {
 
     fn scroll_down(&mut self) {
         let len = self.filter.item_list().len();
+        if len == 0 {
+            return;
+        }
         let current = self.selection.selected().unwrap_or(0);
         let max_index = if self.at_root() { len - 1 } else { len };
         let next = if current + 1 > max_index {
@@ -525,6 +528,9 @@ impl AppState {
 
     fn scroll_up(&mut self) {
         let len = self.filter.item_list().len();
+        if len == 0 {
+            return;
+        }
         let current = self.selection.selected().unwrap_or(0);
         let max_index = if self.at_root() { len - 1 } else { len };
         let next = if current == 0 { max_index } else { current - 1 };

--- a/tui/src/state.rs
+++ b/tui/src/state.rs
@@ -478,17 +478,9 @@ impl AppState {
             Focus::TabList => match key.code {
                 KeyCode::Enter | KeyCode::Char('l') | KeyCode::Right => self.focus = Focus::List,
 
-                KeyCode::Char('j') | KeyCode::Down
-                    if self.current_tab.selected().unwrap() + 1 < self.tabs.len() =>
-                {
-                    self.current_tab.select_next();
-                    self.refresh_tab();
-                }
+                KeyCode::Char('j') | KeyCode::Down => self.scroll_tab_down(),
 
-                KeyCode::Char('k') | KeyCode::Up => {
-                    self.current_tab.select_previous();
-                    self.refresh_tab();
-                }
+                KeyCode::Char('k') | KeyCode::Up => self.scroll_tab_up(),
 
                 KeyCode::Char('/') => self.enter_search(),
                 KeyCode::Char('t') => self.theme.next(),
@@ -498,8 +490,8 @@ impl AppState {
             },
 
             Focus::List if key.kind != KeyEventKind::Release => match key.code {
-                KeyCode::Char('j') | KeyCode::Down => self.selection.select_next(),
-                KeyCode::Char('k') | KeyCode::Up => self.selection.select_previous(),
+                KeyCode::Char('j') | KeyCode::Down => self.scroll_down(),
+                KeyCode::Char('k') | KeyCode::Up => self.scroll_up(),
                 KeyCode::Char('p') | KeyCode::Char('P') => self.enable_preview(),
                 KeyCode::Char('d') | KeyCode::Char('D') => self.enable_description(),
                 KeyCode::Enter | KeyCode::Char('l') | KeyCode::Right => self.handle_enter(),
@@ -516,6 +508,32 @@ impl AppState {
             _ => (),
         };
         true
+    }
+
+    fn scroll_down(&mut self) {
+        let len = self.filter.item_list().len();
+        if len == 0 {
+            return;
+        }
+        let current = self.selection.selected().unwrap_or(0);
+        let max_index = if self.at_root() { len - 1 } else { len };
+        let next = if current + 1 > max_index {
+            0
+        } else {
+            current + 1
+        };
+        self.selection.select(Some(next));
+    }
+
+    fn scroll_up(&mut self) {
+        let len = self.filter.item_list().len();
+        if len == 0 {
+            return;
+        }
+        let current = self.selection.selected().unwrap_or(0);
+        let max_index = if self.at_root() { len - 1 } else { len };
+        let next = if current == 0 { max_index } else { current - 1 };
+        self.selection.select(Some(next));
     }
 
     fn toggle_multi_select(&mut self) {
@@ -553,6 +571,13 @@ impl AppState {
         if !self.is_current_tab_multi_selectable() {
             self.multi_select = false;
             self.selected_commands.clear();
+        }
+        let len = self.filter.item_list().len();
+        if len > 0 {
+            let current = self.selection.selected().unwrap_or(0);
+            self.selection.select(Some(current.min(len - 1)));
+        } else {
+            self.selection.select(None);
         }
     }
 
@@ -732,6 +757,28 @@ impl AppState {
             80,
             80,
         );
+    }
+
+    fn scroll_tab_down(&mut self) {
+        let len = self.tabs.len();
+        if len == 0 {
+            return;
+        }
+        let current = self.current_tab.selected().unwrap_or(0);
+        let next = if current + 1 >= len { 0 } else { current + 1 };
+        self.current_tab.select(Some(next));
+        self.refresh_tab();
+    }
+
+    fn scroll_tab_up(&mut self) {
+        let len = self.tabs.len();
+        if len == 0 {
+            return;
+        }
+        let current = self.current_tab.selected().unwrap_or(0);
+        let next = if current == 0 { len - 1 } else { current - 1 };
+        self.current_tab.select(Some(next));
+        self.refresh_tab();
     }
 }
 

--- a/tui/src/state.rs
+++ b/tui/src/state.rs
@@ -772,9 +772,6 @@ impl AppState {
 
     fn scroll_tab_up(&mut self) {
         let len = self.tabs.len();
-        if len == 0 {
-            return;
-        }
         let current = self.current_tab.selected().unwrap_or(0);
         let next = if current == 0 { len - 1 } else { current - 1 };
         self.current_tab.select(Some(next));

--- a/tui/src/state.rs
+++ b/tui/src/state.rs
@@ -519,6 +519,7 @@ impl AppState {
         } else {
             current + 1
         };
+
         self.selection.select(Some(next));
     }
 
@@ -527,6 +528,7 @@ impl AppState {
         let current = self.selection.selected().unwrap_or(0);
         let max_index = if self.at_root() { len - 1 } else { len };
         let next = if current == 0 { max_index } else { current - 1 };
+
         self.selection.select(Some(next));
     }
 
@@ -757,6 +759,7 @@ impl AppState {
         let len = self.tabs.len();
         let current = self.current_tab.selected().unwrap_or(0);
         let next = if current + 1 >= len { 0 } else { current + 1 };
+
         self.current_tab.select(Some(next));
         self.refresh_tab();
     }
@@ -765,6 +768,7 @@ impl AppState {
         let len = self.tabs.len();
         let current = self.current_tab.selected().unwrap_or(0);
         let next = if current == 0 { len - 1 } else { current - 1 };
+
         self.current_tab.select(Some(next));
         self.refresh_tab();
     }

--- a/tui/src/state.rs
+++ b/tui/src/state.rs
@@ -512,9 +512,6 @@ impl AppState {
 
     fn scroll_down(&mut self) {
         let len = self.filter.item_list().len();
-        if len == 0 {
-            return;
-        }
         let current = self.selection.selected().unwrap_or(0);
         let max_index = if self.at_root() { len - 1 } else { len };
         let next = if current + 1 > max_index {
@@ -527,9 +524,6 @@ impl AppState {
 
     fn scroll_up(&mut self) {
         let len = self.filter.item_list().len();
-        if len == 0 {
-            return;
-        }
         let current = self.selection.selected().unwrap_or(0);
         let max_index = if self.at_root() { len - 1 } else { len };
         let next = if current == 0 { max_index } else { current - 1 };


### PR DESCRIPTION
# watch the video

<!--
Read Contributing Guidelines before opening a PR.
https://github.com/ChrisTitusTech/linutil/blob/main/.github/CONTRIBUTING.md
-->

regular scrolling and tab scrolling **NEEDS** to be separated, without separation, we wont be able to properly handle subdir cases

## Type of Change
- [x] New feature

## Description
wraps the user to the top of the list or to the bottom of the list depending on where they are at
example:

https://github.com/user-attachments/assets/567753aa-7725-4cce-b83c-966a868ea207


