### PR TITLE
📃 fix(system-cleanup): pacman orphan package removal

### DIFF
--- a/core/tabs/system-setup/system-cleanup.sh
+++ b/core/tabs/system-setup/system-cleanup.sh
@@ -23,8 +23,7 @@ cleanup_system() {
             ;;
         pacman)
             "$ESCALATION_TOOL" "$PACKAGER" -Sc --noconfirm
-            # -Rns will return 1 if there are no packages provided
-            "$PACKAGER" -Qtdq | "$ESCALATION_TOOL" "$PACKAGER" -Rns --noconfirm - > /dev/null 2>&1 || true
+            "$ESCALATION_TOOL" "$PACKAGER" -Rns $(pacman -Qtdq) --noconfirm > /dev/null 2>&1
             ;;
         *)
             printf "%b\n" "${RED}Unsupported package manager: ""$PACKAGER""${RC}"

--- a/core/tabs/system-setup/system-cleanup.sh
+++ b/core/tabs/system-setup/system-cleanup.sh
@@ -23,7 +23,8 @@ cleanup_system() {
             ;;
         pacman)
             "$ESCALATION_TOOL" "$PACKAGER" -Sc --noconfirm
-            "$ESCALATION_TOOL" "$PACKAGER" -Rns "$(pacman -Qtdq)" --noconfirm
+            # -Rns will return 1 if there are no packages provided
+            "$PACKAGER" -Qtdq | "$ESCALATION_TOOL" "$PACKAGER" -Rns --noconfirm -- &> /dev/null 2>&1 || true
             ;;
         *)
             printf "%b\n" "${RED}Unsupported package manager: ""$PACKAGER""${RC}"

--- a/core/tabs/system-setup/system-cleanup.sh
+++ b/core/tabs/system-setup/system-cleanup.sh
@@ -24,7 +24,7 @@ cleanup_system() {
         pacman)
             "$ESCALATION_TOOL" "$PACKAGER" -Sc --noconfirm
             # -Rns will return 1 if there are no packages provided
-            "$PACKAGER" -Qtdq | "$ESCALATION_TOOL" "$PACKAGER" -Rns --noconfirm -- &> /dev/null 2>&1 || true
+            "$PACKAGER" -Qtdq | "$ESCALATION_TOOL" "$PACKAGER" -Rns --noconfirm - > /dev/null 2>&1 || true
             ;;
         *)
             printf "%b\n" "${RED}Unsupported package manager: ""$PACKAGER""${RC}"


### PR DESCRIPTION
## Type of Change]
- [x] Bug fix
- [x] Hotfix

## Description
As you can see below, the script fails because:
1. Command structure for package removal is wrong
2. `-R` returns `1` when there are no packages provided

All fixed here
Redirecting the output to `/dev/null` so the script's output doesn't get flooded. 

## Testing
Works :)

## Issues / other PRs related
<!--[What issue/discussion is related to this PR (if any)]-->
- Resolves #741

## Additional Information
![image](https://github.com/user-attachments/assets/5b0ef99d-4663-4d21-a683-2b126b2843f1)

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no errors/warnings/merge conflicts.

(📃 is a shell script btw)