### PR TITLE
security patch: temp-dir

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -329,12 +329,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
-
-[[package]]
 name = "getrandom"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -496,7 +490,7 @@ dependencies = [
  "ego-tree",
  "include_dir",
  "serde",
- "tempdir",
+ "temp-dir",
  "toml",
  "which",
 ]
@@ -514,8 +508,9 @@ dependencies = [
  "linutil_core",
  "oneshot",
  "portable-pty",
- "rand 0.8.5",
+ "rand",
  "ratatui",
+ "temp-dir",
  "tree-sitter-bash",
  "tree-sitter-highlight",
  "tui-term",
@@ -718,26 +713,13 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core 0.6.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -747,23 +729,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.4",
+ "rand_core",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -793,15 +760,6 @@ dependencies = [
  "unicode-segmentation",
  "unicode-truncate",
  "unicode-width 0.1.14",
-]
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -841,15 +799,6 @@ name = "regex-syntax"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
-
-[[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "rustix"
@@ -1063,14 +1012,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "tempdir"
-version = "0.3.7"
+name = "temp-dir"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
-dependencies = [
- "rand 0.4.6",
- "remove_dir_all",
-]
+checksum = "bc1ee6eef34f12f765cb94725905c6312b6610ab2b0940889cfe58dae7bc3c72"
 
 [[package]]
 name = "termios"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -13,7 +13,7 @@ include = [
 
 [dependencies]
 include_dir = "0.7.4"
-tempdir = "0.3.7"
+temp-dir = "0.1.14"
 serde = { version = "1.0.205", features = ["derive"], default-features = false }
 toml = { version = "0.8.19", features = ["parse"], default-features = false }
 which = "6.0.3"

--- a/core/src/inner.rs
+++ b/core/src/inner.rs
@@ -10,24 +10,29 @@ use crate::{Command, ListNode, Tab};
 use ego_tree::{NodeMut, Tree};
 use include_dir::{include_dir, Dir};
 use serde::Deserialize;
-use tempdir::TempDir;
+use temp_dir::TempDir;
 
 const TAB_DATA: Dir = include_dir!("$CARGO_MANIFEST_DIR/tabs");
 
-pub fn get_tabs(validate: bool) -> Vec<Tab> {
-    let tab_files = TabList::get_tabs();
-    let tabs = tab_files.into_iter().map(|path| {
-        let directory = path.parent().unwrap().to_owned();
-        let data = std::fs::read_to_string(path).expect("Failed to read tab data");
-        let mut tab_data: TabEntry = toml::from_str(&data).expect("Failed to parse tab data");
+pub fn get_tabs(validate: bool) -> (TempDir, Vec<Tab>) {
+    let (temp_dir, tab_files) = TabList::get_tabs();
 
-        if validate {
-            filter_entries(&mut tab_data.data);
-        }
-        (tab_data, directory)
-    });
+    let tabs: Vec<_> = tab_files
+        .into_iter()
+        .map(|path| {
+            let directory = path.parent().unwrap().to_owned();
+            let data = std::fs::read_to_string(path).expect("Failed to read tab data");
+            let mut tab_data: TabEntry = toml::from_str(&data).expect("Failed to parse tab data");
+
+            if validate {
+                filter_entries(&mut tab_data.data);
+            }
+            (tab_data, directory)
+        })
+        .collect();
 
     let tabs: Vec<Tab> = tabs
+        .into_iter()
         .map(
             |(
                 TabEntry {
@@ -57,7 +62,7 @@ pub fn get_tabs(validate: bool) -> Vec<Tab> {
     if tabs.is_empty() {
         panic!("No tabs found");
     }
-    tabs
+    (temp_dir, tabs)
 }
 
 #[derive(Deserialize)]
@@ -248,19 +253,20 @@ fn is_executable(path: &Path) -> bool {
 }
 
 impl TabList {
-    fn get_tabs() -> Vec<PathBuf> {
-        let temp_dir = TempDir::new("linutil_scripts").unwrap().into_path();
+    fn get_tabs() -> (TempDir, Vec<PathBuf>) {
+        let temp_dir = TempDir::new().unwrap();
         TAB_DATA
             .extract(&temp_dir)
             .expect("Failed to extract the saved directory");
 
-        let tab_files =
-            std::fs::read_to_string(temp_dir.join("tabs.toml")).expect("Failed to read tabs.toml");
+        let tab_files = std::fs::read_to_string(temp_dir.path().join("tabs.toml"))
+            .expect("Failed to read tabs.toml");
         let data: Self = toml::from_str(&tab_files).expect("Failed to parse tabs.toml");
-
-        data.directories
+        let tab_paths = data
+            .directories
             .iter()
-            .map(|path| temp_dir.join(path).join("tab_data.toml"))
-            .collect()
+            .map(|path| temp_dir.path().join(path).join("tab_data.toml"))
+            .collect();
+        (temp_dir, tab_paths)
     }
 }

--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -22,6 +22,7 @@ oneshot = "0.1.8"
 portable-pty = "0.8.1"
 ratatui = "0.28.1"
 tui-term = "0.1.12"
+temp-dir = "0.1.14"
 unicode-width = "0.2.0"
 rand = { version = "0.8.5", optional = true }
 linutil_core = { path = "../core", version = "24.9.28" }

--- a/tui/src/state.rs
+++ b/tui/src/state.rs
@@ -21,6 +21,7 @@ use ratatui::{
     widgets::{Block, Borders, List, ListState, Paragraph},
     Frame,
 };
+use temp_dir::TempDir;
 
 const MIN_WIDTH: u16 = 77;
 const MIN_HEIGHT: u16 = 19;
@@ -33,13 +34,15 @@ FM - file modification
 I  - installation (privileged)
 MP - package manager actions
 SI - full system installation
-SS - systemd actions (privileged) 
+SS - systemd actions (privileged)
 RP - package removal
 
 P* - privileged *
 ";
 
 pub struct AppState {
+    /// This must be passed to retain the temp dir until the end of the program
+    _temp_dir: TempDir,
     /// Selected theme
     theme: Theme,
     /// Currently focused area
@@ -78,10 +81,11 @@ pub struct ListEntry {
 
 impl AppState {
     pub fn new(theme: Theme, override_validation: bool) -> Self {
-        let tabs = linutil_core::get_tabs(!override_validation);
+        let (temp_dir, tabs) = linutil_core::get_tabs(!override_validation);
         let root_id = tabs[0].tree.root().id();
 
         let mut state = Self {
+            _temp_dir: temp_dir,
             theme,
             focus: Focus::List,
             tabs,


### PR DESCRIPTION
## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [x] Security patch
- [ ] UI/UX improvement

## Description
- `tempdir` crate is not maintained and contains security vulnerabilities.
- `tempdir` depends on old version of `remove_dir_all` and is heavy weight.
- ![temp-dir](https://docs.rs/temp-dir/0.1.14/temp_dir/) an alternative to `tempdir` is light weight and is actively maintained.
- Found this security vulnerability in private linutil repo ( Not forked , used for CI testing sometimes )
![alert](https://github.com/user-attachments/assets/83d88727-ee5d-4b37-83e4-a7ea2267686a)

## Testing
- Works without issues.

## Impact
- TempDir is now needed to be passed into the AppState to retain the tempdir until the end of the program.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
