### PR TITLE
clear the search bar if the user changes categories

### DIFF
--- a/tui/src/filter.rs
+++ b/tui/src/filter.rs
@@ -158,4 +158,8 @@ impl Filter {
             self.search_input.remove(current);
         }
     }
+    pub fn clear_search(&mut self) {
+        self.search_input.clear();
+        self.input_position = 0;
+    }
 }

--- a/tui/src/state.rs
+++ b/tui/src/state.rs
@@ -723,6 +723,7 @@ impl AppState {
             .root()
             .id()];
         self.selection.select(Some(0));
+        self.filter.clear_search();
         self.update_items();
     }
 


### PR DESCRIPTION
the current search functionality searches through all categories instead of just 1, so not clearing the bar when the user decides to switch categories or stops using the search bar can worsen UX because they then have to clear it manually.

<!--
Read Contributing Guidelines before opening a PR.
https://github.com/ChrisTitusTech/linutil/blob/main/.github/CONTRIBUTING.md
-->

## Type of Change
- [x] New feature
- [x] UI/UX improvement

## Description
### before:

https://github.com/user-attachments/assets/af8308be-f552-4933-a46f-0e31a83896b4




### after:

https://github.com/user-attachments/assets/ebece83c-ed42-419b-be18-782ae2c5ff29


