### PR TITLE
🦀 allow exiting out of search mode with `Ctrl-C`

### DIFF
--- a/tui/src/filter.rs
+++ b/tui/src/filter.rs
@@ -1,5 +1,5 @@
 use crate::{state::ListEntry, theme::Theme};
-use crossterm::event::{KeyCode, KeyEvent};
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use ego_tree::NodeId;
 use linutil_core::Tab;
 use ratatui::{
@@ -116,21 +116,27 @@ impl Filter {
     pub fn handle_key(&mut self, event: &KeyEvent) -> SearchAction {
         //Insert user input into the search bar
         match event.code {
+            KeyCode::Char('c') if event.modifiers.contains(KeyModifiers::CONTROL) => {
+                return self.exit_search()
+            }
             KeyCode::Char(c) => self.insert_char(c),
             KeyCode::Backspace => self.remove_previous(),
             KeyCode::Delete => self.remove_next(),
             KeyCode::Left => return self.cursor_left(),
             KeyCode::Right => return self.cursor_right(),
-            KeyCode::Esc => {
-                self.input_position = 0;
-                self.search_input.clear();
-                return SearchAction::Exit;
-            }
             KeyCode::Enter => return SearchAction::Exit,
+            KeyCode::Esc => return self.exit_search(),
             _ => return SearchAction::None,
         };
         SearchAction::Update
     }
+
+    fn exit_search(&mut self) -> SearchAction {
+        self.input_position = 0;
+        self.search_input.clear();
+        SearchAction::Exit
+    }
+
     fn cursor_left(&mut self) -> SearchAction {
         self.input_position = self.input_position.saturating_sub(1);
         SearchAction::None

--- a/tui/src/state.rs
+++ b/tui/src/state.rs
@@ -120,7 +120,10 @@ impl AppState {
         match self.focus {
             Focus::Search => (
                 "Search bar",
-                Box::new([Shortcut::new("Finish search", ["Enter"])]),
+                Box::new([
+                    Shortcut::new("Abort search", ["Esc", "CTRL-c"]),
+                    Shortcut::new("Search", ["Enter"]),
+                ]),
             ),
 
             Focus::List => {


### PR DESCRIPTION
## Type of Change
- [x] UI/UX improvement

## Description
Added an option to abort the search with `Ctrl-C` and fixed up the shortcut tooltip a bit.

## Testing
Works perfectly.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no errors/warnings/merge conflicts.
