### PR TITLE
fix: Quit with CTRL-C when in search

### DIFF
--- a/tui/src/state.rs
+++ b/tui/src/state.rs
@@ -411,11 +411,15 @@ impl AppState {
         // This should be defined first to allow closing
         // the application even when not drawable ( If terminal is small )
         // Exit on 'q' or 'Ctrl-c' input
-        if matches!(
+        if (matches!(
             self.focus,
-            Focus::TabList | Focus::List | Focus::ConfirmationPrompt(_)
-        ) && (key.code == KeyCode::Char('q')
-            || key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('c'))
+            Focus::TabList | Focus::List | Focus::ConfirmationPrompt(_) | Focus::Search
+        ) && key.modifiers.contains(KeyModifiers::CONTROL)
+            && key.code == KeyCode::Char('c'))
+            || (matches!(
+                self.focus,
+                Focus::TabList | Focus::List | Focus::ConfirmationPrompt(_)
+            ) && key.code == KeyCode::Char('q'))
         {
             return false;
         }


### PR DESCRIPTION
## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [x] UI/UX improvement

## Description
- Allow exiting linutil with CTRL C when in search mode.

## Testing
- No issues

## Additional Information
- This PR conflicts with idealogy of #768 

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
