### PR TITLE
fix: fedora timeshift

### DIFF
--- a/core/tabs/utils/tab_data.toml
+++ b/core/tabs/utils/tab_data.toml
@@ -158,6 +158,11 @@ name = "Timeshift Backup"
 script = "timeshift.sh"
 task_list = "I"
 
+[[data.preconditions]]
+matches = false
+data = "command_exists"
+values = [ "dnf" ]
+
 [[data]]
 name = "WiFi Manager"
 description = "This utility is designed to manage wifi in your system"


### PR DESCRIPTION
### @ChrisTitusTech this does not make timeshift fedora only, this only makes it so timeshift cannot be seen by fedora users, please look at #773 for more information
<!--
Read Contributing Guidelines before opening a PR.
https://github.com/ChrisTitusTech/linutil/blob/main/.github/CONTRIBUTING.md
-->

closes #773 

## Type of Change
- [x] Bug fix

## Description
since fedora does not support the use of timeshift, it should be excluded.

more information is in this issue #773 

## testing
Tested using a fedora container and my main system (Arch Linux), and the precondition works flawlessly

![image](https://github.com/user-attachments/assets/c6074c43-4ecb-45ab-b4ba-78212d01d562)
