### PR TITLE
✅ ci: add a spellcheck typos CI

### DIFF
--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -1,0 +1,24 @@
+name: Check for typos
+
+on:
+  [pull_request, merge_group, workflow_dispatch]
+
+jobs:
+  check-typos:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - run: git fetch origin ${{ github.base_ref }}
+
+      - name: Get a list of changed files
+        id: get_files
+        run: |
+          changed_files=$(git diff --name-only origin/${{ github.base_ref }} HEAD)
+          existing_files=$(echo "$changed_files" | xargs -I {} bash -c 'if [ -f "{}" ]; then echo "./{}"; fi')
+          echo "files=$existing_files" >> GITHUB_OUTPUT
+
+      - name: Run spellcheck
+        uses: crate-ci/typos@v1.25.0
+        with:
+          files: ${{ steps.get_files.outputs.files }}

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -1,7 +1,7 @@
 name: Check for typos
 
 on:
-  [pull_request, merge_group, workflow_dispatch]
+  [push, pull_request, workflow_dispatch]
 
 jobs:
   check-typos:
@@ -11,14 +11,5 @@ jobs:
       - uses: actions/checkout@v4
       - run: git fetch origin ${{ github.base_ref }}
 
-      - name: Get a list of changed files
-        id: get_files
-        run: |
-          changed_files=$(git diff --name-only origin/${{ github.base_ref }} HEAD)
-          existing_files=$(echo "$changed_files" | xargs -I {} bash -c 'if [ -f "{}" ]; then echo "./{}"; fi')
-          echo "files=$existing_files" >> GITHUB_OUTPUT
-
       - name: Run spellcheck
         uses: crate-ci/typos@v1.25.0
-        with:
-          files: ${{ steps.get_files.outputs.files }}

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,7 @@
+[files]
+extend-exclude = ["tui/cool_tips.txt"]
+
+[default]
+extend-ignore-identifiers-re = [
+    "ratatui",
+]


### PR DESCRIPTION
# Merge #775 first!

## Description
This uses [typos](https://github.com/crate-ci/typos).
I first wanted it to check only changed files but I've decided not to do that because
- now it can be ran on push & workflow dispatch
- the action didn't work with a list of files for some reason

## Testing
Works as expected.

## Impact
This will fail if there are **any** typos on the **whole** branch.
## Additional Information

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no errors/warnings/merge conflicts.
