### PR TITLE
docs: Change numlock description

### DIFF
--- a/core/tabs/utils/numlock.sh
+++ b/core/tabs/utils/numlock.sh
@@ -2,11 +2,6 @@
 
 . ../common-script.sh
 
-# setleds can be used in all distros
-# This method works by calling a script using systemd service
-
-# Create a script to toggle numlock
-
 create_file() {
   printf "%b\n" "Creating script..."
   "$ESCALATION_TOOL" tee "/usr/local/bin/numlock" >/dev/null <<'EOF'
@@ -21,7 +16,6 @@ EOF
   "$ESCALATION_TOOL" chmod +x /usr/local/bin/numlock
 }
 
-# Create a systemd service to run the script on boot
 create_service() {
   printf "%b\n" "Creating service..."
   "$ESCALATION_TOOL" tee "/etc/systemd/system/numlock.service" >/dev/null <<'EOF'
@@ -39,7 +33,6 @@ EOF
 }
 
 numlockSetup() {
-  # Check if the script and service files exists
   if [ ! -f "/usr/local/bin/numlock" ]; then
     create_file
   fi

--- a/core/tabs/utils/tab_data.toml
+++ b/core/tabs/utils/tab_data.toml
@@ -133,7 +133,7 @@ task_list = "I FM"
 
 [[data]]
 name = "Numlock on Startup"
-description = "This utility is designed to configure auto enabling of numlock on boot"
+description = "This utility is designed to enable Num Lock at boot, rather than within desktop environments like KDE or GNOME"
 script = "numlock.sh"
 task_list = "PFM SS"
 

--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -145,7 +145,7 @@ For more information visit: https://rpmfusion.org/
 
 - **Auto Mount Drive**: This utility is designed to help with automating the process of mounting a drive on to your system.
 - **Bluetooth Manager**: This utility is designed to manage bluetooth in your system
-- **Numlock on Startup**: This utility is designed to configure auto enabling of numlock on boot
+- **Numlock on Startup**: This utility is designed to enable Num Lock at boot, rather than within desktop environments like KDE or GNOME
 - **Ollama**: This utility is designed to manage ollama in your system
 - **Service Manager**: This utility is designed to manage services in your system
 - **WiFi Manager**: This utility is designed to manage wifi in your system


### PR DESCRIPTION
## Type of Change
- [ ] New feature
- [ ] Bug fix
- [x] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
- `numlock.sh` only works in display managers and tty.
- DE have their own rule for enabling numlock on user login.
- See #777 for more information.
- Stripped comments from the script.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
