### PR TITLE
ci: Seperate preview from Linutil Release

### DIFF
--- a/.github/workflows/linutil.yml
+++ b/.github/workflows/linutil.yml
@@ -89,23 +89,10 @@ jobs:
           version: ${{ env.version }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Setup Preview
-        run: |
-          echo "$(pwd)/build" >> $GITHUB_PATH
-      
-      - name: Generate preview 
-        uses: charmbracelet/vhs-action@v2.1.0
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
         with:
-          path: "docs/assets/preview.tape"
-
-      - name: Move preview
-        run: |
-          mv preview.gif docs/assets/preview.gif
-
-      - name: Upload preview
-        uses: stefanzweifel/git-auto-commit-action@v5
-        with:
-          commit_message: Preview for ${{ env.version }}
-          file_pattern: "docs/assets/preview.gif"
-          add_options: "--force"
-        if: success()
+          name: linutil-artifact
+          path: build/linutil
+          compression-level: 0
+          overwrite: true

--- a/.github/workflows/linutil.yml
+++ b/.github/workflows/linutil.yml
@@ -93,6 +93,6 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: linutil-artifact
-          path: build/linutil
+          path: build/x86_64-unknown-linux-musl/release/linutil
           compression-level: 0
           overwrite: true

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -44,8 +44,7 @@ jobs:
           path: "docs/assets/preview.tape"
 
       - name: Move preview
-        run: |
-          mv preview.gif docs/assets/preview.gif
+        run: mv preview.gif docs/assets/preview.gif
 
       - name: Upload preview
         uses: stefanzweifel/git-auto-commit-action@v5

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,56 @@
+name: LinUtil Preview
+
+on:
+  workflow_dispatch:
+    inputs:
+        run_id:
+          description: 'Run ID of LinUtil Release'
+          required: true
+  workflow_run:
+    workflows: ["LinUtil Release"]
+    types:
+      - completed
+
+jobs:
+  generate_preview:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set Run ID
+        run: |
+          if [ "${{ github.event_name }}" == "workflow_run" ]; then
+            echo "run_id=${{ github.event.workflow_run.id }}" >> $GITHUB_ENV
+          else
+            echo "run_id=${{ github.event.inputs.run_id }}" >> $GITHUB_ENV
+          fi
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: linutil-artifact
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ env.run_id }}
+
+      - name: Set env
+        run: |
+          chmod +x linutil
+          echo "${{ github.workspace }}" >> $GITHUB_PATH
+
+      - name: Generate preview
+        uses: charmbracelet/vhs-action@v2.1.0
+        with:
+          path: "docs/assets/preview.tape"
+
+      - name: Move preview
+        run: |
+          mv preview.gif docs/assets/preview.gif
+
+      - name: Upload preview
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: Preview for ${{ github.sha }}
+          file_pattern: "docs/assets/preview.gif"
+          add_options: "--force"
+        if: success()

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Upload preview
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
-          commit_message: Preview for ${{ github.sha }}
+          commit_message: Preview for ${{ env.run_id }}
           file_pattern: "docs/assets/preview.gif"
           add_options: "--force"
         if: success()


### PR DESCRIPTION
## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation update
- [x] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
- Separate preview generation from linutil release.

- Auto runs with Linutil Release workflow.
- We can trigger the preview generation for any specific release with Linutil Release workflow run id that is created after this PR.
- Run ID can be obtained from the URL of the workflow run.
- Preview commit message contains the run id which can be used to browse the files at the specific commit.
- Doesn't have a `x` in linutil.yml if the preview generation fails.

## Testing
- Auto run with Linutil Release workflow https://github.com/jeevithakannan2/linutil_ci/actions/runs/11260453100
- Manual run with Linutil Release run id https://github.com/jeevithakannan2/linutil_ci/actions/runs/11260675235

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
