### PR TITLE
refact(ci): bashisms.yml

### DIFF
--- a/.github/workflows/bashisms.yml
+++ b/.github/workflows/bashisms.yml
@@ -3,7 +3,7 @@ name: Check for bashisms
 on:
   pull_request:
     paths:
-      - core/tabs/**
+      - '**/*.sh'
   merge_group:
   workflow_dispatch:
 
@@ -15,31 +15,33 @@ jobs:
       - uses: actions/checkout@v4
       - run: git fetch origin ${{ github.base_ref }}
 
-      - name: Get a list of changed script files
-        id: get_sh_files
-        run: |
-          sh_files=$(git diff --name-only origin/${{ github.base_ref }} HEAD core/tabs | grep '\.sh$' || true)
-          if [ -n "$sh_files" ]; then
-            echo "$sh_files" > changed_files
-            echo "changed=1" >> $GITHUB_OUTPUT
-          else
-            echo "changed=0" >> $GITHUB_OUTPUT
-          fi
-      
       - name: Install devscripts
-        if: steps.get_sh_files.outputs.changed == 1
-        run: sudo apt-get update && sudo apt-get install devscripts
+        run: sudo apt-get update && sudo apt-get install -y devscripts
+
+      - name: Get changed .sh files (PR only)
+        id: changed-sh-files
+        if: github.event_name == 'pull_request'
+        uses: tj-actions/changed-files@v45
+        with:
+          files: '**/*.sh'
+
+      - name: Get all .sh files (if workflow dispatched)
+        id: sh-files
+        if: github.event_name != 'pull_request'
+        run: |
+          files=$(find . -type f -name "*.sh" | tr '\n' ' ')
+          echo "files=${files:-none}" >> $GITHUB_ENV
+
+      - name: Set FILES for bashism check
+        id: set-files
+        run: |
+          if [[ "${{ steps.changed-sh-files.outputs.any_changed }}" == 'true' ]]; then
+            echo "FILES=${{ steps.changed-sh-files.outputs.all_changed_files }}" >> $GITHUB_ENV
+          else
+            echo "FILES=${{ env.files }}" >> $GITHUB_ENV
+          fi
 
       - name: Check for bashisms
-        if: steps.get_sh_files.outputs.changed == 1
         run: |
-          echo "Running for:\n$(cat changed_files)\n"
-          for file in $(cat changed_files); do
-            if [[ -f "$file" ]]; then
-              checkbashisms "$file"
-            fi
-          done
-
-      - name: Remove the created file
-        if: steps.get_sh_files.outputs.changed == 1
-        run: rm changed_files
+          IFS=' ' read -r -a file_array <<< "$FILES"
+          checkbashisms "${file_array[@]}"

--- a/.github/workflows/bashisms.yml
+++ b/.github/workflows/bashisms.yml
@@ -3,7 +3,7 @@ name: Check for bashisms
 on:
   pull_request:
     paths:
-      - '**/*.sh'
+      - 'core/tabs/**/*.sh'
   merge_group:
   workflow_dispatch:
 


### PR DESCRIPTION
## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [x] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
- Fixed bashisms not working when manually ran.
- Trigger bashisms workflow only when sh files are changed in PRs ( Previously changes to any file inside tabs dir triggered the workflow ).
- Use [tj-actions/changed-files](https://github.com/tj-actions/changed-files) action to get the changed files in PRs.

## Testing
- https://github.com/jeevithakannan2/linutil_ci/pull/8
- https://github.com/jeevithakannan2/linutil_ci/actions/runs/11262488127

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
