### PR TITLE
ci: Run typos.yml on pushes only in main branch

### DIFF
--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -1,7 +1,10 @@
 name: Check for typos
 
 on:
-  [push, pull_request, workflow_dispatch]
+  push:
+    branches: ["main"]
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   check-typos:


### PR DESCRIPTION
## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
- Currenly typos.yml runs on all branches which causes the workflow to run twice when opening a PR https://github.com/jeevithakannan2/linutil_ci/pull/8
- If Chris wants to run the workflow on a new branch, he can always do it by dispatching workflow for that specific branch or by creating a PR.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
