### PR TITLE
properly escape $ in destop entry

### DIFF
--- a/linutil.desktop
+++ b/linutil.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=Linutil
 Comment=Distro-agnostic toolbox designed to simplify everyday Linux tasks
-Exec=sh -c '/usr/bin/linutil || $HOME/.cargo/bin/linutil || linutil'
+Exec=sh -c '/usr/bin/linutil || \\$HOME/.cargo/bin/linutil || linutil'
 Icon=utilities-terminal
 Type=Application
 Terminal=true


### PR DESCRIPTION
<!--
Read Contributing Guidelines before opening a PR.
https://github.com/ChrisTitusTech/linutil/blob/main/.github/CONTRIBUTING.md
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [*] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
<!--[Provide a detailed explanation of the changes you have made. Include the reasons behind these changes and any relevant context. Link any related issues.]-->
ruunning the command `desktop-file-validate ./linutil.desktop` preodces the following error:
```
./linutil.desktop: error: value "sh -c "$HOME/.local/bin/linutil"" for key "Exec" in group "Desktop Entry" contains a non-escaped character '$' in a quote, but it should be escaped with two backslashes ("\\$")
```
## Testing
<!--[Detail the testing you have performed to ensure that these changes function as intended. Include information about any added tests.]-->
after adding the 2 slashes, the commad gave no further output
## Impact
<!--[Discuss the impact of your changes on the project. This might include effects on performance, new dependencies, or changes in behaviour.]-->
n/a
## Issues / other PRs related
<!--[What issue/discussion is related to this PR (if any)]-->
- Resolves #
n/a
## Additional Information
<!--[Any additional information that reviewers should be aware of.]-->
n/a
## Checklist
- [ ] My code adheres to the coding and style guidelines of the project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [*] My changes generate no errors/warnings/merge conflicts.
