### PR TITLE
Remove dependabot ignores

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,10 +8,3 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-ignore:
-  - dependency-name: "actions/stale"
-    versions: '>= 9'
-  - dependency-name: "actions/setup-python"
-    versions: '> 4'
-  - dependency-name: "crossterm"
-    versions: '> 0.27.0'


### PR DESCRIPTION
## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [x] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
- `stale` github action is not used in the repo
- `setup-python` github action is already above version `4` ( current version `5` )
- `crossterm` crate is already above version `0.27.0` ( current version `0.28.1` )

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
