### PR TITLE
fix (dwmtitus-setup): dm picking

### DIFF
--- a/core/tabs/applications-setup/dwmtitus-setup.sh
+++ b/core/tabs/applications-setup/dwmtitus-setup.sh
@@ -214,7 +214,22 @@ setupDisplayManager() {
         printf "%b\n" "${YELLOW}3. GDM ${RC}" 
         printf "%b\n" "${YELLOW} ${RC}" 
         printf "%b" "${YELLOW}Please select one: ${RC}"
-        read -r DM
+        read -r choice
+        case "$choice" in
+        1)
+            DM="sddm"
+            ;;
+        2)
+            DM="lightdm"
+            ;;
+        3)
+            DM="gdm"
+            ;;
+        *)
+            printf "%b\n" "${RED}Invalid selection! Please choose 1, 2, or 3.${RC}"
+            exit 1
+            ;;
+        esac
         case "$PACKAGER" in
             pacman)
                 "$ESCALATION_TOOL" "$PACKAGER" -S --needed --noconfirm "$DM"


### PR DESCRIPTION
<!--
Read Contributing Guidelines before opening a PR.
https://github.com/ChrisTitusTech/linutil/blob/main/.github/CONTRIBUTING.md
-->

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
<!--[Provide a detailed explanation of the changes you have made. Include the reasons behind these changes and any relevant context. Link any related issues.]-->
I could not install dwm-titus for fresh virtual machine. On the step of selection a desktop manager i got unexpected behavior. I assumed that it was some bug with corresponding script case statement.

![linutil_dwm_error2](https://github.com/user-attachments/assets/80d8ccba-2e45-4228-b2a8-598fe9fc8e85)
![linutil_dwm_error](https://github.com/user-attachments/assets/4c671986-c9f2-4e30-aa3b-66dbc2a62d19)


## Testing
<!--[Detail the testing you have performed to ensure that these changes function as intended. Include information about any added tests.]-->
I reproduced it for both [debian-12-nocloud-amd64](https://cloud.debian.org/images/cloud/bookworm-backports/20241004-1890/debian-12-backports-nocloud-amd64-20241004-1890.qcow2) and [Arch-Linux-x86_64-basic](https://gitlab.archlinux.org/archlinux/arch-boxes/-/package_files/7649/download) and this successfully passed.
It is possible that there is no available package 'gdm' for debian, but this is another story.

## Impact
<!--[Discuss the impact of your changes on the project. This might include effects on performance, new dependencies, or changes in behaviour.]-->
Apparently, there is no block now to install dwm-titus from scatch on this point.
## Issues / other PRs related
<!--[What issue/discussion is related to this PR (if any)]-->
I failed to find any relate issues.
## Additional Information
<!--[Any additional information that reviewers should be aware of.]-->

## Checklist
- [ ] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no errors/warnings/merge conflicts.
