### PR TITLE
Add required dependencies for dwm-titus on Arch

### DIFF
--- a/core/tabs/applications-setup/dwmtitus-setup.sh
+++ b/core/tabs/applications-setup/dwmtitus-setup.sh
@@ -6,7 +6,7 @@ setupDWM() {
     printf "%b\n" "${YELLOW}Installing DWM-Titus...${RC}"
     case "$PACKAGER" in # Install pre-Requisites
         pacman)
-            "$ESCALATION_TOOL" "$PACKAGER" -S --needed --noconfirm base-devel libx11 libxinerama libxft imlib2 libxcb git unzip flameshot lxappearance feh mate-polkit
+            "$ESCALATION_TOOL" "$PACKAGER" -S --needed --noconfirm base-devel libx11 libxinerama libxft imlib2 libxcb git unzip flameshot lxappearance feh mate-polkit meson libev uthash libconfig
             ;;
         apt-get|nala)
             "$ESCALATION_TOOL" "$PACKAGER" install -y build-essential libx11-dev libxinerama-dev libxft-dev libimlib2-dev libx11-xcb-dev libfontconfig1 libx11-6 libxft2 libxinerama1 libxcb-res0-dev git unzip flameshot lxappearance feh mate-polkit


### PR DESCRIPTION
When installing dwm-titus with slstatus from a fresh Arch-Server install, several required dependencies are missing and need to be included. These are:
- meson
- libev
- uthash
- libconfig

Tested only on another fresh Arch-Server install and script completed successfully.

<!--
Read Contributing Guidelines before opening a PR.
https://github.com/ChrisTitusTech/linutil/blob/main/.github/CONTRIBUTING.md
-->

## Type of Change
- [x] Bug fix


## Description
Added required dependencies in dwm-titus install script that were failing install attempts on a fresh arch-server install. Added packages `meson libev uthash libconfig` to setupDWM function in dwmtitus-setup.sh.

## Testing
Created a fresh Arch-Server install using official Arch October release and Archtitus install script from Linutil inside a VM. Booted into new install and started Linutil with modified dwmtitus-setup.sh for a dwm install. Newly added packages were installed and script completed successfully.

## Impact
New Dependencies for dwm-titus setup. Script fails without these required packages.

## Issues / other PRs related
none

## Additional Information
none

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
