### PR TITLE
feat: Drastically increase the operating system support for USB creation script

### DIFF
--- a/core/tabs/utils/create-bootable-usb.sh
+++ b/core/tabs/utils/create-bootable-usb.sh
@@ -125,6 +125,10 @@ get_architecture() {
     esac
 }
 
+comma_delimited_list() {
+    echo "${1}" | tr '\n' ',' | sed 's/,/, /g; s/, $//'
+}
+
 get_online_iso() {
     get_architecture
     printf "%b\n" "${YELLOW}Fetching available operating systems...${RC}"
@@ -145,7 +149,7 @@ get_online_iso() {
     fi
 
     printf "%b\n" "${YELLOW}Available Operating Systems:${RC}"
-    echo "${OS_JSON}" | jq -r '.[].name' | tr '\n' ' '
+    comma_delimited_list "$(echo "${OS_JSON}" | jq -r '.[].name')"
     printf "\n%b" "Select an operating system: "
     read -r OS
 
@@ -157,7 +161,7 @@ get_online_iso() {
     PRETTY_NAME="$(echo "${OS_JSON}" | jq -r '.pretty_name')"
 
     printf "\n%b\n" "${YELLOW}Available releases for ${PRETTY_NAME}:${RC}"
-    echo "${OS_JSON}" | jq -r '.releases[].release' | sort -Vur | tr '\n' ' '
+    comma_delimited_list "$(echo "${OS_JSON}" | jq -r '.releases[].release' | sort -Vur)"
     printf "\n%b" "Select a release: "
     read -r RELEASE
     printf "\n"
@@ -170,7 +174,7 @@ get_online_iso() {
 
     if echo "${OS_JSON}" | jq -e '.releases[] | select(.edition != null) | any' >/dev/null; then
         printf "%b\n" "${YELLOW}Available editions for ${PRETTY_NAME} ${RELEASE}:${RC}"
-        echo "${OS_JSON}" | jq -r '.releases[].edition' | sort -Vur | tr '\n' ' '
+        comma_delimited_list "$(echo "${OS_JSON}" | jq -r '.releases[].edition' | sort -Vur)"
         printf "\n%b" "Select an edition: "
         read -r EDITION
         ENTRY="$(echo "${OS_JSON}" | jq --arg edition "${EDITION}" -c '.releases[] | select(.edition == $edition)')"

--- a/core/tabs/utils/create-bootable-usb.sh
+++ b/core/tabs/utils/create-bootable-usb.sh
@@ -125,7 +125,6 @@ get_architecture() {
     esac
 }
 
-# Function to fetch ISO URLs
 get_online_iso() {
     get_architecture
     printf "%b\n" "${YELLOW}Fetching available operating systems...${RC}"

--- a/core/tabs/utils/create-bootable-usb.sh
+++ b/core/tabs/utils/create-bootable-usb.sh
@@ -134,7 +134,7 @@ get_online_iso() {
     # Download available operating systems, filter to to those that match requirements
     # Remove entries with more than 1 ISO or any other medium, they could cause issues
     OS_JSON="$(curl -L -s "$CONFIGURATION_URL" | jq -c "[.[] | \
-        .releases |= map(select((.arch // \"x86_64\") == "\"${ARCH}\"" \
+        .releases |= map(select(.arch // \"x86_64\" == "\"${ARCH}\"" \
         and (.iso | length == 1) and (.iso[0] | has(\"web\")) \
         and .img == null and .fixed_iso == null and .floppy == null and .disk_images == null)) \
         | select(.releases | length > 0)]")"

--- a/core/tabs/utils/create-bootable-usb.sh
+++ b/core/tabs/utils/create-bootable-usb.sh
@@ -169,7 +169,7 @@ get_online_iso() {
     fi
 
     if echo "${OS_JSON}" | jq -e '.releases[] | select(.edition != null) | any' >/dev/null; then
-        printf "%b\n" "${YELLOW}Available editions for ${PRETTY_NAME}:${RC}"
+        printf "%b\n" "${YELLOW}Available editions for ${PRETTY_NAME} ${RELEASE}:${RC}"
         echo "${OS_JSON}" | jq -r '.releases[].edition' | sort -Vur | tr '\n' ' '
         printf "\n%b" "Select an edition: "
         read -r EDITION


### PR DESCRIPTION
## Type of Change
- [x] New feature

## Description
Remove inbuilt logic for finding debian & arch ISO URLs from the USB creation script. Instead, if the user selects the online ISO option, download JSON data containing the necessary information from a project I started and brought into the quickemu project, [quickget_configs](https://github.com/quickemu-project/quickget_configs). This project was created to eventually be used to fully replace functionality in the quickget bash script, similar to that present in this script. Thus, it provides the data necessary to download images of various operating systems. The data is produced daily in CI, where invalid or unresolvable URLs (and their accompanying entries) are thrown out, and other useful information, like SHA256 checksums to verify validity, are included. 

jq is used to filter through this JSON data, and ensure that we're only taking entries with 1 ISO file and nothing else.  The user is prompted for the Architecture, OS, Release, and Edition (if necessary), and the ISO is downloaded, verified, and unarchived as applicable.  This change will additionally reduce the maintenance burden on this script, since the logic to find URLs is contained within a different project.

I also found and removed an unused usage function. I suppose someone forgot to remove that after asking an LLM to write an entire script for them... @guruswarupa 

https://github.com/user-attachments/assets/132f27af-28a9-4c1b-9cba-71cba7cdd5ca

## Impact
jq is added as a dependency for the script, along with a few archiving tools (xz, bzip2, gzip).

## Issues / other PRs related
<!--[What issue/discussion is related to this PR (if any)]-->
- Functionality supersedes that in #699. 
- New installDependencies function would have to be updated on event of #821 merge.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no errors/warnings/merge conflicts.
