### PR TITLE
Add greeter install for lightdm during dwm-titus setup

### DIFF
--- a/core/tabs/applications-setup/dwmtitus-setup.sh
+++ b/core/tabs/applications-setup/dwmtitus-setup.sh
@@ -218,6 +218,9 @@ setupDisplayManager() {
         case "$PACKAGER" in
             pacman)
                 "$ESCALATION_TOOL" "$PACKAGER" -S --needed --noconfirm "$DM"
+                if [ "$DM" = "lightdm" ]; then
+                    "$ESCALATION_TOOL" "$PACKAGER" -S --needed --noconfirm lightdm-gtk-greeter # greeter is required for lightdm to start without autologin enabled
+                fi
                 ;;
             apt-get|nala)
                 "$ESCALATION_TOOL" "$PACKAGER" install -y "$DM"

--- a/core/tabs/applications-setup/dwmtitus-setup.sh
+++ b/core/tabs/applications-setup/dwmtitus-setup.sh
@@ -219,7 +219,7 @@ setupDisplayManager() {
             pacman)
                 "$ESCALATION_TOOL" "$PACKAGER" -S --needed --noconfirm "$DM"
                 if [ "$DM" = "lightdm" ]; then
-                    "$ESCALATION_TOOL" "$PACKAGER" -S --needed --noconfirm lightdm-gtk-greeter # greeter is required for lightdm to start without autologin enabled
+                    "$ESCALATION_TOOL" "$PACKAGER" -S --needed --noconfirm lightdm-gtk-greeter
                 fi
                 ;;
             apt-get|nala)


### PR DESCRIPTION

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
After fresh Arch-Server install, using Linutil to install and configure dwm-titus, a display manager must be chosen. When choosing lightdm, a greeter is required without autologin configured. This adds the most common greeter `lightdm-gtk-greeter` to the install in case lightdm is chosen as a DM.

## Testing
Tested for fresh Arch-Server install using Linutil. Boots cleanly into login screen after dwm-titus setup.

## Impact
Fixes dwmtitus-setup.sh for lightdm choice

## Issues / other PRs related
- Resolves #829 

## Additional Information
none

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no errors/warnings/merge conflicts.
