### PR TITLE
feat: Add automation based on config file

### DIFF
--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -1,0 +1,28 @@
+use serde::Deserialize;
+use std::path::Path;
+use std::process;
+
+#[derive(Deserialize)]
+pub struct Config {
+    pub auto_execute: Vec<String>,
+}
+
+impl Config {
+    pub fn from_file(path: &Path) -> Self {
+        let content = match std::fs::read_to_string(path) {
+            Ok(content) => content,
+            Err(e) => {
+                eprintln!("Failed to read config file {}: {}", path.display(), e);
+                process::exit(1);
+            }
+        };
+
+        match toml::from_str(&content) {
+            Ok(config) => config,
+            Err(e) => {
+                eprintln!("Failed to parse config file: {}", e);
+                process::exit(1);
+            }
+        }
+    }
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,3 +1,4 @@
+mod config;
 mod inner;
 
 use std::rc::Rc;
@@ -5,6 +6,7 @@ use std::rc::Rc;
 use ego_tree::Tree;
 use std::path::PathBuf;
 
+pub use config::Config;
 pub use inner::get_tabs;
 
 #[derive(Clone, Hash, Eq, PartialEq)]
@@ -32,4 +34,17 @@ pub struct ListNode {
     pub description: String,
     pub command: Command,
     pub task_list: String,
+}
+
+impl Tab {
+    pub fn find_command(&self, name: &str) -> Option<Rc<ListNode>> {
+        self.tree.root().descendants().find_map(|node| {
+            let value = node.value();
+            if value.name == name && !node.has_children() {
+                Some(value.clone())
+            } else {
+                None
+            }
+        })
+    }
 }

--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -9,6 +9,7 @@ mod theme;
 
 use std::{
     io::{self, stdout},
+    path::PathBuf,
     time::Duration,
 };
 
@@ -26,6 +27,11 @@ use state::AppState;
 // Linux utility toolbox
 #[derive(Debug, Parser)]
 struct Args {
+    #[arg(
+        long,
+        help = "Path to the configuration file for automatic command selection"
+    )]
+    config: Option<PathBuf>,
     #[arg(short, long, value_enum)]
     #[arg(default_value_t = Theme::Default)]
     #[arg(help = "Set the theme to use in the application")]
@@ -38,7 +44,7 @@ struct Args {
 fn main() -> io::Result<()> {
     let args = Args::parse();
 
-    let mut state = AppState::new(args.theme, args.override_validation);
+    let mut state = AppState::new(args.theme, args.override_validation, args.config);
 
     stdout().execute(EnterAlternateScreen)?;
     enable_raw_mode()?;

--- a/tui/src/state.rs
+++ b/tui/src/state.rs
@@ -9,6 +9,7 @@ use crate::{
 };
 use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 use ego_tree::NodeId;
+use linutil_core::Config;
 use linutil_core::{ListNode, Tab};
 #[cfg(feature = "tips")]
 use rand::Rng;
@@ -19,6 +20,7 @@ use ratatui::{
     widgets::{Block, Borders, List, ListState, Paragraph},
     Frame,
 };
+use std::path::PathBuf;
 use std::rc::Rc;
 use temp_dir::TempDir;
 
@@ -79,9 +81,11 @@ pub struct ListEntry {
 }
 
 impl AppState {
-    pub fn new(theme: Theme, override_validation: bool) -> Self {
+    pub fn new(theme: Theme, override_validation: bool, config_path: Option<PathBuf>) -> Self {
         let (temp_dir, tabs) = linutil_core::get_tabs(!override_validation);
         let root_id = tabs[0].tree.root().id();
+
+        let auto_execute_commands = config_path.map(|path| Config::from_file(&path).auto_execute);
 
         let mut state = Self {
             _temp_dir: temp_dir,
@@ -100,7 +104,29 @@ impl AppState {
         };
 
         state.update_items();
+        if let Some(auto_execute_commands) = auto_execute_commands {
+            state.handle_initial_auto_execute(&auto_execute_commands);
+        }
+
         state
+    }
+
+    fn handle_initial_auto_execute(&mut self, auto_execute_commands: &[String]) {
+        self.selected_commands = auto_execute_commands
+            .iter()
+            .filter_map(|name| self.tabs.iter().find_map(|tab| tab.find_command(name)))
+            .collect();
+
+        if !self.selected_commands.is_empty() {
+            let cmd_names: Vec<_> = self
+                .selected_commands
+                .iter()
+                .map(|node| node.name.as_str())
+                .collect();
+
+            let prompt = ConfirmPrompt::new(&cmd_names);
+            self.focus = Focus::ConfirmationPrompt(Float::new(Box::new(prompt), 40, 40));
+        }
     }
 
     fn get_list_item_shortcut(&self) -> Box<[Shortcut]> {


### PR DESCRIPTION
## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
- This PR introduces the ability to pre-select commands upon opening the TUI by providing a configuration file.
- It implements a basic structure for optionally passing a config file to linutil.
- This feature can be useful for automating system setups using a single config file (for non-interactive scripts), eliminating the need to repeatedly selecting the same set of commands for each system setup.
- Users can now pass a config file to linutil, and the specified commands will be pre-selected for execution
- The config file is based on toml structure.
- If used with #834 the pre-selected commands are executed when opening linutil.

https://github.com/user-attachments/assets/b1a91462-ea6f-48f9-a3c5-ca13f9bd3dde

Example toml file used in video:
```toml
auto_select = [
    "Fastfetch",
    "Alacritty",
    "Kitty"
]
```

## Testing
- Tested on Arch Linux. No issues.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
