### PR TITLE
Delist Firewall setup on systems with Firewalld installed, such as fedora

### DIFF
--- a/core/tabs/security/tab_data.toml
+++ b/core/tabs/security/tab_data.toml
@@ -5,3 +5,8 @@ name = "Firewall Baselines (CTT)"
 description = "Developed to ease iptables firewall configuration, UFW provides a user friendly way to create an IPv4 or IPv6 host-based firewall.\nThis command installs UFW and configures UFW based on CTT's recommended rules.\nFor more information visit: https://christitus.com/linux-security-mistakes"
 script = "firewall-baselines.sh"
 task_list = "I SS"
+
+[[data.preconditions]]
+matches = false
+data = "command_exists"
+values = [ "dnf" ]

--- a/core/tabs/security/tab_data.toml
+++ b/core/tabs/security/tab_data.toml
@@ -9,4 +9,4 @@ task_list = "I SS"
 [[data.preconditions]]
 matches = false
 data = "command_exists"
-values = [ "dnf" ]
+values = [ "firewalld" ]


### PR DESCRIPTION
## Type of Change
- [x] Bug Fix

## Description
As Fedora comes with Firewalld preinstalled & preconfigured with rules set for fedora desktop out of the box. Installing ufw on it might conflict with it & is really not needed.

## Testing
I have tested it

## Impact
Hides firewall setup on fedora systems

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
