### PR TITLE
fix(fedora): multimedia setup

### DIFF
--- a/core/tabs/system-setup/fedora/multimedia-codecs.sh
+++ b/core/tabs/system-setup/fedora/multimedia-codecs.sh
@@ -8,8 +8,6 @@ multimedia() {
             if [ -e /etc/yum.repos.d/rpmfusion-free.repo ] && [ -e /etc/yum.repos.d/rpmfusion-nonfree.repo ]; then
                 printf "%b\n" "${YELLOW}Installing Multimedia Codecs...${RC}"
                 "$ESCALATION_TOOL" "$PACKAGER" swap ffmpeg-free ffmpeg --allowerasing -y
-                "$ESCALATION_TOOL" "$PACKAGER" update @multimedia --setopt="install_weak_deps=False" --exclude=PackageKit-gstreamer-plugin -y
-                "$ESCALATION_TOOL" "$PACKAGER" update @sound-and-video -y
                 printf "%b\n" "${GREEN}Multimedia Codecs Installed...${RC}"
             else
                 printf "%b\n" "${RED}RPM Fusion repositories not found. Please set up RPM Fusion first!${RC}"


### PR DESCRIPTION
## Type of Change
- [x] Bug fix

## Description
Removing **multimedia** and s**ound and video** group as it no longer exist. Therefore the script results as failed and can give the wrong impression that it has failed

## Testing
Tested by me 

## Issues / other PRs related
- Resolves #803

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
