### PR TITLE
chore: bump ratatui -> 0.29.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,7 +51,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67555e1f1ece39d737e28c8a017721287753af3f93225e4a445b29ccb0f5912c"
 dependencies = [
  "nom",
- "ratatui 0.29.0",
+ "ratatui",
  "simdutf8",
  "smallvec",
  "thiserror",
@@ -515,7 +515,7 @@ dependencies = [
  "oneshot",
  "portable-pty",
  "rand",
- "ratatui 0.29.0",
+ "ratatui",
  "temp-dir",
  "tree-sitter-bash",
  "tree-sitter-highlight",
@@ -745,26 +745,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
-]
-
-[[package]]
-name = "ratatui"
-version = "0.28.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdef7f9be5c0122f890d58bdf4d964349ba6a6161f705907526d891efabba57d"
-dependencies = [
- "bitflags 2.6.0",
- "cassowary",
- "compact_str",
- "instability",
- "itertools",
- "lru",
- "paste",
- "strum",
- "strum_macros",
- "unicode-segmentation",
- "unicode-truncate",
- "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -1156,11 +1136,11 @@ checksum = "2545046bd1473dac6c626659cc2567c6c0ff302fc8b84a56c4243378276f7f57"
 
 [[package]]
 name = "tui-term"
-version = "0.1.13"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07f0233f0d4795d2dc6663cfc3ce56b87bebcee66d6bcc088aa6aff5c072361"
+checksum = "72af159125ce32b02ceaced6cffae6394b0e6b6dfd4dc164a6c59a2db9b3c0b0"
 dependencies = [
- "ratatui 0.28.1",
+ "ratatui",
  "vt100",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,12 +46,12 @@ dependencies = [
 
 [[package]]
 name = "ansi-to-tui"
-version = "6.0.0"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00c4af0bef1b514c9b6a32a773caf604c1390fa7913f4eaa23bfe76f251d6a42"
+checksum = "67555e1f1ece39d737e28c8a017721287753af3f93225e4a445b29ccb0f5912c"
 dependencies = [
  "nom",
- "ratatui",
+ "ratatui 0.29.0",
  "simdutf8",
  "smallvec",
  "thiserror",
@@ -423,6 +423,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
+
+[[package]]
 name = "instability"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -509,7 +515,7 @@ dependencies = [
  "oneshot",
  "portable-pty",
  "rand",
- "ratatui",
+ "ratatui 0.29.0",
  "temp-dir",
  "tree-sitter-bash",
  "tree-sitter-highlight",
@@ -750,7 +756,6 @@ dependencies = [
  "bitflags 2.6.0",
  "cassowary",
  "compact_str",
- "crossterm",
  "instability",
  "itertools",
  "lru",
@@ -760,6 +765,27 @@ dependencies = [
  "unicode-segmentation",
  "unicode-truncate",
  "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "ratatui"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+dependencies = [
+ "bitflags 2.6.0",
+ "cassowary",
+ "compact_str",
+ "crossterm",
+ "indoc",
+ "instability",
+ "itertools",
+ "lru",
+ "paste",
+ "strum",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -1134,7 +1160,7 @@ version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d07f0233f0d4795d2dc6663cfc3ce56b87bebcee66d6bcc088aa6aff5c072361"
 dependencies = [
- "ratatui",
+ "ratatui 0.28.1",
  "vt100",
 ]
 

--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -29,7 +29,7 @@ linutil_core = { path = "../core", version = "24.9.28" }
 tree-sitter-highlight = "0.24.2"
 tree-sitter-bash = "0.23.1"
 anstyle = "1.0.8"
-ansi-to-tui = "6.0.0"
+ansi-to-tui = "7.0.0"
 zips = "0.1.7"
 
 [build-dependencies]

--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -20,7 +20,7 @@ crossterm = "0.28.1"
 ego-tree = { workspace = true }
 oneshot = "0.1.8"
 portable-pty = "0.8.1"
-ratatui = "0.28.1"
+ratatui = "0.29.0"
 tui-term = "0.1.12"
 temp-dir = "0.1.14"
 unicode-width = "0.2.0"

--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -21,7 +21,7 @@ ego-tree = { workspace = true }
 oneshot = "0.1.8"
 portable-pty = "0.8.1"
 ratatui = "0.29.0"
-tui-term = "0.1.12"
+tui-term = "0.2.0"
 temp-dir = "0.1.14"
 unicode-width = "0.2.0"
 rand = { version = "0.8.5", optional = true }


### PR DESCRIPTION
## Type of Change
- [x] Dependency update

## Description
> [!CAUTION]
> ~~Should not be merged before `ansi-to-tui` and `tui-term` new release~~

- **ratatui** `0.28.1` -> `0.29.0`
- **ansi-to-tui** ~~update not yet released~~ `6.0.0` -> `7.0.0`
- **tui-term** ~~update not yet released~~ `0.1.12` -> `0.2.0`

## Testing
- ~~Will only work with `ansi-to-tui` and `tui-term` crates updates~~
- Works without issues.

## Issues / other PRs related
- Closes #864 

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no errors/warnings/merge conflicts.
