### PR TITLE
fix: Run rust checks on all Cargo.toml changes

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -5,7 +5,7 @@ on:
     branches: ["main"]
     paths:
       - '**/*.rs'
-      - 'Cargo.toml'
+      - '**/Cargo.toml'
       - 'Cargo.lock'
 
 env:


### PR DESCRIPTION
## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
- Rust checks runs only on root `Cargo.toml` changes only.
- This should run on every `Cargo.toml` changes also.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
