### PR TITLE
fix: Autocpu-freq script not detecting battery on laptops

### DIFF
--- a/core/tabs/utils/power-profile.sh
+++ b/core/tabs/utils/power-profile.sh
@@ -45,7 +45,7 @@ configureAutoCpufreq() {
 
     if command_exists auto-cpufreq; then
         # Check if the system has a battery to determine if it's a laptop
-        if [ -d /sys/class/power_supply/BAT0 ]; then
+        if ls /sys/class/power_supply/BAT* >/dev/null 2>&1; then     # Check if the system has a battery (laptop) by looking for any battery directory
             printf "%b\n" "${GREEN}System detected as laptop. Updating auto-cpufreq for laptop...${RC}"
             "$ESCALATION_TOOL" auto-cpufreq --force powersave
         else

--- a/core/tabs/utils/power-profile.sh
+++ b/core/tabs/utils/power-profile.sh
@@ -45,7 +45,7 @@ configureAutoCpufreq() {
 
     if command_exists auto-cpufreq; then
         # Check if the system has a battery to determine if it's a laptop
-        if ls /sys/class/power_supply/BAT* >/dev/null 2>&1; then     # Check if the system has a battery (laptop) by looking for any battery directory
+        if ls /sys/class/power_supply/BAT* >/dev/null 2>&1; then
             printf "%b\n" "${GREEN}System detected as laptop. Updating auto-cpufreq for laptop...${RC}"
             "$ESCALATION_TOOL" auto-cpufreq --force powersave
         else


### PR DESCRIPTION
<!--
Read Contributing Guidelines before opening a PR.
https://github.com/ChrisTitusTech/linutil/blob/main/.github/CONTRIBUTING.md
-->

## Type of Change
- [ ] New feature
- [X] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description

* Added better checking when searching /sys/class/power_supply/ directory
* Uses ls with * wildcard to find all battery entries not limited to BAT0. (e.g. BAT1, BAT2)

## Testing
I have tested this on my Arch Linux install on DESKTOP. (no battery) 
However it should work.

## Impact
All this does is if there is any battery it will run the function for laptops and not desktops. 
It fixes the issue of not detecting a laptop and instead runs the power profile meant for desktops.

## Issues / other PRs related

- Resolves #871

## Checklist
- [X] My code adheres to the coding and style guidelines of the project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [X] My changes generate no errors/warnings/merge conflicts.
