### PR TITLE
Replace `BUILD_DATE` with `CARGO_PKG_VERSION`

### DIFF
--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -7,8 +7,7 @@ edition = "2021"
 license.workspace = true
 repository = "https://github.com/ChrisTitusTech/linutil/tree/main/tui"
 version.workspace = true
-include = ["src/*.rs", "Cargo.toml", "build.rs", "cool_tips.txt", "../man/linutil.1"]
-build = "build.rs"
+include = ["src/*.rs", "Cargo.toml", "cool_tips.txt", "../man/linutil.1"]
 
 [features]
 default = ["tips"]
@@ -31,9 +30,6 @@ tree-sitter-bash = "0.23.1"
 anstyle = "1.0.8"
 ansi-to-tui = "6.0.0"
 zips = "0.1.7"
-
-[build-dependencies]
-chrono = "0.4.33"
 
 [[bin]]
 name = "linutil"

--- a/tui/build.rs
+++ b/tui/build.rs
@@ -1,7 +1,0 @@
-fn main() {
-    // Add current date as a variable to be displayed in the 'Linux Toolbox' text.
-    println!(
-        "cargo:rustc-env=BUILD_DATE={}",
-        chrono::Local::now().format("%Y-%m-%d")
-    );
-}

--- a/tui/src/state.rs
+++ b/tui/src/state.rs
@@ -24,7 +24,7 @@ use temp_dir::TempDir;
 
 const MIN_WIDTH: u16 = 77;
 const MIN_HEIGHT: u16 = 19;
-const TITLE: &str = concat!("Linux Toolbox - ", env!("BUILD_DATE"));
+const TITLE: &str = concat!("Linux Toolbox - ", env!("CARGO_PKG_VERSION"));
 const ACTIONS_GUIDE: &str = "List of important tasks performed by commands' names:
 
 D  - disk modifications (ex. partitioning) (privileged)


### PR DESCRIPTION
Replace `BUILD_DATE` with `CARGO_PKG_VERSION`
to make builds reproducible.
See https://reproducible-builds.org/ for why this is good.

This is an alternative solution to #869 

<!--
Read Contributing Guidelines before opening a PR.
https://github.com/ChrisTitusTech/linutil/blob/main/.github/CONTRIBUTING.md
-->

## Type of Change
- [ ] New feature
- [X] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
<!--[Provide a detailed explanation of the changes you have made. Include the reasons behind these changes and any relevant context. Link any related issues.]-->

## Testing
<!--[Detail the testing you have performed to ensure that these changes function as intended. Include information about any added tests.]-->

## Impact
<!--[Discuss the impact of your changes on the project. This might include effects on performance, new dependencies, or changes in behaviour.]-->

## Issues / other PRs related
<!--[What issue/discussion is related to this PR (if any)]-->
- Resolves #

## Additional Information
<!--[Any additional information that reviewers should be aware of.]-->

## Checklist
- [X] My code adheres to the coding and style guidelines of the project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no errors/warnings/merge conflicts.
