### PR TITLE
fix(system-cleanup): failing with no orphan packages on arch

### DIFF
--- a/core/tabs/system-setup/system-cleanup.sh
+++ b/core/tabs/system-setup/system-cleanup.sh
@@ -23,7 +23,11 @@ cleanup_system() {
             ;;
         pacman)
             "$ESCALATION_TOOL" "$PACKAGER" -Sc --noconfirm
-            "$ESCALATION_TOOL" "$PACKAGER" -Rns $(pacman -Qtdq) --noconfirm > /dev/null 2>&1
+            if pacman -Qtdq > /dev/null 2>&1; then
+                printf "%b\n" "${YELLOW}Detected Unused Packages. Removing.${RC}"
+                "$ESCALATION_TOOL" "$PACKAGER" -Rns $(pacman -Qtdq) --noconfirm > /dev/null 2>&1
+            fi
+            printf "%b\n" "${RED}No unused packages found. Skipping.${RC}"
             ;;
         *)
             printf "%b\n" "${RED}Unsupported package manager: ${PACKAGER}. Skipping.${RC}"

--- a/core/tabs/system-setup/system-cleanup.sh
+++ b/core/tabs/system-setup/system-cleanup.sh
@@ -23,11 +23,7 @@ cleanup_system() {
             ;;
         pacman)
             "$ESCALATION_TOOL" "$PACKAGER" -Sc --noconfirm
-            if pacman -Qtdq > /dev/null 2>&1; then
-                printf "%b\n" "${YELLOW}Detected Unused Packages. Removing.${RC}"
-                "$ESCALATION_TOOL" "$PACKAGER" -Rns $(pacman -Qtdq) --noconfirm > /dev/null 2>&1
-            fi
-            printf "%b\n" "${RED}No unused packages found. Skipping.${RC}"
+            "$ESCALATION_TOOL" "$PACKAGER" -Rns $(pacman -Qtdq) --noconfirm > /dev/null || true
             ;;
         *)
             printf "%b\n" "${RED}Unsupported package manager: ${PACKAGER}. Skipping.${RC}"


### PR DESCRIPTION

![bugfix1](https://github.com/user-attachments/assets/106d0d12-00f4-4336-a44d-0ea83dc43d26)
![nobug](https://github.com/user-attachments/assets/9044069c-b777-4453-826a-ba3b12e4c4b1)
<!--
Read Contributing Guidelines before opening a PR.
https://github.com/ChrisTitusTech/linutil/blob/main/.github/CONTRIBUTING.md
-->

## Type of Change
- [ ] New feature
- [X] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
When running the system cleanup option on Arch Linux (pacman), if the user has no orphaned (unused) packages the command will return 1 so the TUI think it failed and aborts. The issue is (pacman -Qtdq). So I added a check which runs it first and if the command executes sucessfully (returns 0) then it will continue with cleanup. 

I also added a output if it found any packages and if not it will let the user know it skipped. (see screenshot below)

## Testing
I tested this on my Arch with pacman and it works. I also don't have any orphaned pkgs.

## Impact
Without this check it will fail and not do the rest of the cleanup (logs, temp files, etc) and just aborts and skips the whole process because the control flow think it fail.

## Issues / other PRs related
N/A

## Additional Information
If anyone has any unused packages, check it it will detect it.

## Checklist
- [X] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [X] My changes generate no errors/warnings/merge conflicts.
