### PR TITLE
fix: github release notes not working

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,23 +1,35 @@
 changelog:
   categories:
     - title: '🚀 Features'
-      label: 'enhancement'
+      labels:
+        - 'enhancement'
     - title: '🐛 Bug Fixes'
-      label: 'bug'
+      labels:
+        - 'bug'
     - title: '⚙️ Refactoring'
-      label: 'refactor'
+      labels:
+        - 'refactor'
     - title: '🧩 UI/UX'
-      label: 'UI/UX'
+      labels:
+        - 'UI/UX'
     - title: '📚 Documentation'
-      label: 'documentation'
+      labels:
+        - 'documentation'
     - title: '🔒 Security'
-      label: 'security'
+      labels:
+        - 'security'
     - title: '🧰 GitHub Actions'
-      label: 'github_actions'
+      labels:
+        - 'github_actions'
     - title: '🦀 Rust'
-      label: 'rust'
+      labels:
+        - 'rust'
     - title: '📃 Scripting'
-      label: 'script'
+      labels:
+        - 'script'
+    - title: 'Other Changes'
+      labels:
+        - "*"
   exclude:
     labels:
       - 'skip-changelog'


### PR DESCRIPTION
so apparently you can't mix stuff like `labels` and `label` in YAML (f YAML)
if i try to create a release now (yes i can), it just won't generate the notes. this will fix it
![image](https://github.com/user-attachments/assets/56cfb80f-3994-48b9-9ce9-889f62e8c4f0)