### PR TITLE
feat(fedora): release upgrade script

### DIFF
--- a/core/tabs/system-setup/fedora/fedora-upgrade.sh
+++ b/core/tabs/system-setup/fedora/fedora-upgrade.sh
@@ -6,7 +6,7 @@ current_version=$(rpm -E '%{fedora}')
 next_version=$((current_version + 1))
 
 update() {
-    printf "%b\n" "${RED}Make sure your system is fully updated; if not, update it first and reboot once.${RC}"
+    printf "%b\n" "${YELLOW}Make sure your system is fully updated; if not, update it first and reboot once.${RC}"
     printf "%b\n" "${CYAN}Your current Fedora version is $current_version.${RC}"
     printf "%b\n" "${CYAN}The next available version is $next_version.${RC}"
     
@@ -32,7 +32,7 @@ update() {
 
             case "$reboot_response" in
                 y|Y)
-                    printf "%b\n" "${GREEN}Rebooting to apply the upgrade...${RC}"
+                    printf "%b\n" "${YELLOW}Rebooting to apply the upgrade...${RC}"
                     "$ESCALATION_TOOL" "$PACKAGER" system-upgrade reboot
                     ;;
                 *)

--- a/core/tabs/system-setup/fedora/fedora-upgrade.sh
+++ b/core/tabs/system-setup/fedora/fedora-upgrade.sh
@@ -1,0 +1,85 @@
+#!/bin/sh -e
+
+. ../../common-script.sh
+
+# Global version variables
+current_version=$(rpm -E '%{fedora}')
+next_version=$((current_version + 1))
+previous_version=$((current_version - 1))
+
+# Function to update Fedora
+update() {
+    printf "%b\n" "${RED}Make sure your system is fully updated; if not, update first and reboot once.${RC}"
+    printf "%b\n" "${CYAN}Your current Fedora version is $current_version.${RC}"
+    printf "%b\n" "${CYAN}The next available version is $next_version.${RC}"
+    
+    printf "%b\n" "${YELLOW}Do you want to update to Fedora version $next_version? (y/n): ${RC}"  
+    read -r response
+    
+    if [[ "$response" =~ ^[Yy]$ ]]; then
+        printf "%b\n" "${CYAN}Preparing to update to Fedora version $next_version...${RC}"
+        
+        # Install the system upgrade plugin
+        if ! "$ESCALATION_TOOL" "$PACKAGER" install dnf-plugin-system-upgrade -y; then
+            printf "%b\n" "${RED}Failed to install dnf-plugin-system-upgrade.${RC}"
+            exit 1
+        fi
+        
+        # Download the upgrade packages
+        if ! "$ESCALATION_TOOL" "$PACKAGER" system-upgrade download --releasever="$next_version"; then
+            printf "%b\n" "${RED}Failed to download the upgrade packages.${RC}"
+            exit 1
+        fi
+
+        #Asking for rebooting
+        printf "%b\n" "${YELLOW}Do you want to reboot now to apply the upgrade? (y/n): ${RC}"
+        read -r reboot_response
+
+        if [[ "$reboot_response" =~ ^[Yy]$ ]]; then
+            printf "%b\n" "${GREEN}Rebooting to apply the upgrade...${RC}"
+            "$ESCALATION_TOOL" "$PACKAGER" system-upgrade reboot
+        else
+            printf "%b\n" "${YELLOW}You can reboot later to apply the upgrade.${RC}"
+        fi
+    else
+        printf "%b\n" "${RED}No upgrade performed.${RC}"
+    fi
+}
+
+# Function to run post-upgrade tasks
+post_upgrade() {
+    printf "%b\n" "${YELLOW}Running post-upgrade tasks...${RC}"
+    
+    case "$PACKAGER" in
+        dnf)
+            "$ESCALATION_TOOL" "$PACKAGER" autoremove  
+            "$ESCALATION_TOOL" "$PACKAGER" distro-sync -y
+            ;;
+        *)
+            printf "%b\n" "${RED}Unsupported package manager: $PACKAGER.${RC}"
+            exit 1
+            ;;
+    esac
+}
+
+# Main menu
+checkEnv
+checkEscalationTool
+
+printf "%b\n" "${YELLOW}Select an option:${RC}"
+printf "%b\n" "${GREEN}1. Upgrade to the next Fedora version${RC}"
+printf "%b\n" "${GREEN}2. Run post-upgrade tasks${RC}"
+read -r choice
+
+case "$choice" in
+    1)
+        update
+        ;;
+    2)
+        post_upgrade
+        ;;
+    *)
+        printf "%b\n" "${RED}Invalid option. Please select 1 or 2.${RC}"
+        exit 1
+        ;;
+esac

--- a/core/tabs/system-setup/fedora/fedora-upgrade.sh
+++ b/core/tabs/system-setup/fedora/fedora-upgrade.sh
@@ -44,7 +44,6 @@ update() {
     fi
 }
 
-# Function to run post-upgrade tasks
 post_upgrade() {
     printf "%b\n" "${YELLOW}Running post-upgrade tasks...${RC}"
     

--- a/core/tabs/system-setup/fedora/fedora-upgrade.sh
+++ b/core/tabs/system-setup/fedora/fedora-upgrade.sh
@@ -6,7 +6,6 @@ current_version=$(rpm -E '%{fedora}')
 next_version=$((current_version + 1))
 previous_version=$((current_version - 1))
 
-# Function to update Fedora
 update() {
     printf "%b\n" "${RED}Make sure your system is fully updated; if not, update first and reboot once.${RC}"
     printf "%b\n" "${CYAN}Your current Fedora version is $current_version.${RC}"

--- a/core/tabs/system-setup/fedora/fedora-upgrade.sh
+++ b/core/tabs/system-setup/fedora/fedora-upgrade.sh
@@ -2,7 +2,6 @@
 
 . ../../common-script.sh
 
-# Global version variables
 current_version=$(rpm -E '%{fedora}')
 next_version=$((current_version + 1))
 previous_version=$((current_version - 1))

--- a/core/tabs/system-setup/fedora/fedora-upgrade.sh
+++ b/core/tabs/system-setup/fedora/fedora-upgrade.sh
@@ -16,7 +16,7 @@ update() {
     printf "%b\n" "${YELLOW}Do you want to update to Fedora version $next_version? (y/n): ${RC}"  
     read -r response
     
-    if [[ "$response" =~ ^[Yy]$ ]]; then
+    if [ "$response" =~ ^[Yy]$ ]; then
         printf "%b\n" "${CYAN}Preparing to update to Fedora version $next_version...${RC}"
         
         # Install the system upgrade plugin
@@ -35,7 +35,7 @@ update() {
         printf "%b\n" "${YELLOW}Do you want to reboot now to apply the upgrade? (y/n): ${RC}"
         read -r reboot_response
 
-        if [[ "$reboot_response" =~ ^[Yy]$ ]]; then
+        if [ "$reboot_response" =~ ^[Yy]$ ]; then
             printf "%b\n" "${GREEN}Rebooting to apply the upgrade...${RC}"
             "$ESCALATION_TOOL" "$PACKAGER" system-upgrade reboot
         else

--- a/core/tabs/system-setup/fedora/fedora-upgrade.sh
+++ b/core/tabs/system-setup/fedora/fedora-upgrade.sh
@@ -14,34 +14,38 @@ update() {
     printf "%b\n" "${YELLOW}Do you want to update to $next_version? (y/n): ${RC}"  
     read -r response
     
-    if [ "$response" =~ ^[Yy]$ ]; then
-        printf "%b\n" "${CYAN}Preparing to update to Fedora version $next_version...${RC}"
+    case "$response" in
+        y|Y)
+            printf "%b\n" "${CYAN}Preparing to update to $next_version...${RC}"
         
-        # Install the system upgrade plugin
-        if ! "$ESCALATION_TOOL" "$PACKAGER" install dnf-plugin-system-upgrade -y; then
-            printf "%b\n" "${RED}Failed to install dnf-plugin-system-upgrade.${RC}"
-            exit 1
-        fi
+            if ! "$ESCALATION_TOOL" "$PACKAGER" install dnf-plugin-system-upgrade -y; then
+                printf "%b\n" "${RED}Failed to install dnf-plugin-system-upgrade.${RC}"
+                exit 1
+            fi
         
-        # Download the upgrade packages
-        if ! "$ESCALATION_TOOL" "$PACKAGER" system-upgrade download --releasever="$next_version"; then
-            printf "%b\n" "${RED}Failed to download the upgrade packages.${RC}"
-            exit 1
-        fi
+            if ! "$ESCALATION_TOOL" "$PACKAGER" system-upgrade download --releasever="$next_version"; then
+                printf "%b\n" "${RED}Failed to download the upgrade packages.${RC}"
+                exit 1
+            fi
 
-        #Asking for rebooting
-        printf "%b\n" "${YELLOW}Do you want to reboot now to apply the upgrade? (y/n): ${RC}"
-        read -r reboot_response
+            printf "%b\n" "${YELLOW}Do you want to reboot now to apply the upgrade? (y/n): ${RC}"
+            read -r reboot_response
 
-        if [ "$reboot_response" =~ ^[Yy]$ ]; then
-            printf "%b\n" "${GREEN}Rebooting to apply the upgrade...${RC}"
-            "$ESCALATION_TOOL" "$PACKAGER" system-upgrade reboot
-        else
-            printf "%b\n" "${YELLOW}You can reboot later to apply the upgrade.${RC}"
-        fi
-    else
-        printf "%b\n" "${RED}No upgrade performed.${RC}"
-    fi
+            case "$reboot_response" in
+                y|Y)
+                    printf "%b\n" "${GREEN}Rebooting to apply the upgrade...${RC}"
+                    "$ESCALATION_TOOL" "$PACKAGER" system-upgrade reboot
+                    ;;
+                *)
+                    printf "%b\n" "${YELLOW}You can reboot later to apply the upgrade.${RC}"
+                    ;;
+            esac
+            ;;
+        *)
+            printf "%b\n" "${RED}No upgrade performed.${RC}"
+            ;;
+    esac
+}
 }
 
 post_upgrade() {

--- a/core/tabs/system-setup/fedora/fedora-upgrade.sh
+++ b/core/tabs/system-setup/fedora/fedora-upgrade.sh
@@ -22,7 +22,7 @@ update() {
                 exit 1
             fi
         
-            if ! "$ESCALATION_TOOL" "$PACKAGER" system-upgrade download --releasever="$next_version"; then
+            if ! "$ESCALATION_TOOL" "$PACKAGER" system-upgrade download --releasever="$next_version" -y ; then
                 printf "%b\n" "${RED}Failed to download the upgrade packages.${RC}"
                 exit 1
             fi

--- a/core/tabs/system-setup/fedora/fedora-upgrade.sh
+++ b/core/tabs/system-setup/fedora/fedora-upgrade.sh
@@ -7,7 +7,7 @@ next_version=$((current_version + 1))
 previous_version=$((current_version - 1))
 
 update() {
-    printf "%b\n" "${RED}Make sure your system is fully updated; if not, update first and reboot once.${RC}"
+    printf "%b\n" "${RED}Make sure your system is fully updated; if not, update it first and reboot once.${RC}"
     printf "%b\n" "${CYAN}Your current Fedora version is $current_version.${RC}"
     printf "%b\n" "${CYAN}The next available version is $next_version.${RC}"
     

--- a/core/tabs/system-setup/fedora/fedora-upgrade.sh
+++ b/core/tabs/system-setup/fedora/fedora-upgrade.sh
@@ -11,7 +11,7 @@ update() {
     printf "%b\n" "${CYAN}Your current Fedora version is $current_version.${RC}"
     printf "%b\n" "${CYAN}The next available version is $next_version.${RC}"
     
-    printf "%b\n" "${YELLOW}Do you want to update to Fedora version $next_version? (y/n): ${RC}"  
+    printf "%b\n" "${YELLOW}Do you want to update to $next_version? (y/n): ${RC}"  
     read -r response
     
     if [ "$response" =~ ^[Yy]$ ]; then

--- a/core/tabs/system-setup/fedora/fedora-upgrade.sh
+++ b/core/tabs/system-setup/fedora/fedora-upgrade.sh
@@ -59,7 +59,6 @@ post_upgrade() {
     esac
 }
 
-# Main menu
 checkEnv
 checkEscalationTool
 

--- a/core/tabs/system-setup/fedora/fedora-upgrade.sh
+++ b/core/tabs/system-setup/fedora/fedora-upgrade.sh
@@ -4,7 +4,6 @@
 
 current_version=$(rpm -E '%{fedora}')
 next_version=$((current_version + 1))
-previous_version=$((current_version - 1))
 
 update() {
     printf "%b\n" "${RED}Make sure your system is fully updated; if not, update it first and reboot once.${RC}"

--- a/core/tabs/system-setup/fedora/fedora-upgrade.sh
+++ b/core/tabs/system-setup/fedora/fedora-upgrade.sh
@@ -45,7 +45,6 @@ update() {
             ;;
     esac
 }
-}
 
 post_upgrade() {
     printf "%b\n" "${YELLOW}Running post-upgrade tasks...${RC}"

--- a/core/tabs/system-setup/tab_data.toml
+++ b/core/tabs/system-setup/tab_data.toml
@@ -60,6 +60,12 @@ script = "fedora/rpm-fusion-setup.sh"
 task_list = "MP"
 
 [[data.entries]]
+name = "Upgrade to a New Fedora Release"
+description = "Upgrades the System to next fedora release"
+script = "fedora/fedora-upgrade.sh"
+task_list = "MP"
+
+[[data.entries]]
 name = "Virtualization"
 description = "Enables Virtualization through dnf"
 script = "fedora/virtualization.sh"

--- a/core/tabs/system-setup/tab_data.toml
+++ b/core/tabs/system-setup/tab_data.toml
@@ -61,7 +61,7 @@ task_list = "MP"
 
 [[data.entries]]
 name = "Upgrade to a New Fedora Release"
-description = "Upgrades the System to the next fedora release"
+description = "Upgrades system to the next Fedora release"
 script = "fedora/fedora-upgrade.sh"
 task_list = "MP"
 

--- a/core/tabs/system-setup/tab_data.toml
+++ b/core/tabs/system-setup/tab_data.toml
@@ -61,7 +61,7 @@ task_list = "MP"
 
 [[data.entries]]
 name = "Upgrade to a New Fedora Release"
-description = "Upgrades the System to next fedora release"
+description = "Upgrades the System to the next fedora release"
 script = "fedora/fedora-upgrade.sh"
 task_list = "MP"
 


### PR DESCRIPTION
## Type of Change
- [x] New feature


## Description
An easy way to upgrade to the next version of fedora, not recommended (by me) for gnome and KDE spin because they support upgrades through their software store.

## Testing
I have tested everything except the upgrade itself, I am currently on fedora 41 and in no mood of reinstalling my install, but the code is good so it will work.

## Additional Information
I couldn't understand what task_list =  means in tab data, so If someone could explain what it is, I would really appreciate it
## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
