### PR TITLE
fix: aarch64 release

### DIFF
--- a/.github/workflows/linutil.yml
+++ b/.github/workflows/linutil.yml
@@ -46,7 +46,9 @@ jobs:
         run: cargo build --target-dir=build --release --verbose --target=x86_64-unknown-linux-musl --all-features
 
       - name: Build aarch64 binary
-        run: cross build --target-dir=build --release --verbose --target=aarch64-unknown-linux-musl --all-features
+        run: |
+          cross build --target-dir=build --release --verbose --target=aarch64-unknown-linux-musl --all-features
+          mv ./build/aarch64-unknown-linux-musl/release/linutil ./build/aarch64-unknown-linux-musl/release/linutil-aarch64
 
       - name: Extract Version
         id: extract_version


### PR DESCRIPTION
## Type of Change
- [x] Bug fix

## Description
- The binary name of aarch64 build was also linutil. That was the issue.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no errors/warnings/merge conflicts.
