### PR TITLE
refact (ci): Linutil Preview use tags instead of runner id

### DIFF
--- a/.github/workflows/linutil.yml
+++ b/.github/workflows/linutil.yml
@@ -78,11 +78,3 @@ jobs:
         env:
           version: ${{ env.version }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: linutil-artifact
-          path: build/x86_64-unknown-linux-musl/release/linutil
-          compression-level: 0
-          overwrite: true

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -3,8 +3,8 @@ name: LinUtil Preview
 on:
   workflow_dispatch:
     inputs:
-        run_id:
-          description: 'Run ID of LinUtil Release'
+        tag_name:
+          description: 'Tag name'
           required: true
   workflow_run:
     workflows: ["LinUtil Release"]
@@ -14,24 +14,38 @@ on:
 jobs:
   generate_preview:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout source
+        uses: actions/checkout@v4
 
-      - name: Set Run ID
-        run: |
-          if [ "${{ github.event_name }}" == "workflow_run" ]; then
-            echo "run_id=${{ github.event.workflow_run.id }}" >> $GITHUB_ENV
-          else
-            echo "run_id=${{ github.event.inputs.run_id }}" >> $GITHUB_ENV
-          fi
-
-      - name: Download build artifacts
-        uses: actions/download-artifact@v4
+      - name: Get tag name ( Workflow Run )
+        id: latest_tag
+        uses: actions/github-script@v7
+        if: ${{ github.event_name }} == 'workflow_run'
         with:
-          name: linutil-artifact
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          run-id: ${{ env.run_id }}
+          script: |
+            const releases = await github.rest.repos.listReleases({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              per_page: 1
+            });
+            return releases.data[0].tag_name;
+          result-encoding: string
+
+      - name: Set tag name ( Workflow Run )
+        if: ${{ github.event_name }} == 'workflow_run'
+        run: echo "tag_name=${{ steps.latest_tag.outputs.result }}" >> $GITHUB_ENV
+
+      - name: Set tag name ( Workflow Dispatch )
+        if: ${{ github.event_name }} == 'workflow_dispatch'
+        run: echo "tag_name=${{ github.event.inputs.tag_name }}" >> $GITHUB_ENV
+
+      - name: Download binary
+        run: |
+          curl -LO "https://github.com/${{ github.repository }}/releases/download/${{ env.tag_name }}/linutil"
 
       - name: Set env
         run: |
@@ -49,7 +63,7 @@ jobs:
       - name: Upload preview
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
-          commit_message: Preview for ${{ env.run_id }}
+          commit_message: Preview for ${{ env.tag_name }}
           file_pattern: "docs/assets/preview.gif"
           add_options: "--force"
         if: success()


### PR DESCRIPTION
### This will only work if branch rules are changed to allow github actions. If you don't want to change branch rules then merge #901 

## Type of Change
- [x] Refactoring

## Description
- Use tags instead of runner id.

## Testing
- Works
- Workflow trigger: https://github.com/jeevithakannan2/linutil_ci/actions/runs/11632985539
- Manual run: https://github.com/jeevithakannan2/linutil_ci/actions/runs/11632985539

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no errors/warnings/merge conflicts.
