### PR TITLE
fix(fedora): Recent syntax changes with DNF5

### DIFF
--- a/core/tabs/applications-setup/Developer-tools/sublime-setup.sh
+++ b/core/tabs/applications-setup/Developer-tools/sublime-setup.sh
@@ -23,7 +23,7 @@ installSublime() {
                 ;;
             dnf)
                 "$ESCALATION_TOOL" rpm -v --import https://download.sublimetext.com/sublimehq-rpm-pub.gpg
-                "$ESCALATION_TOOL" "$PACKAGER" config-manager addrepo https://download.sublimetext.com/rpm/stable/x86_64/sublime-text.repo
+                "$ESCALATION_TOOL" "$PACKAGER" config-manager addrepo --from-repofile=https://download.sublimetext.com/rpm/stable/x86_64/sublime-text.repo
                 "$ESCALATION_TOOL" "$PACKAGER" install -y sublime-text
                 ;;
             *)

--- a/core/tabs/applications-setup/Developer-tools/sublime-setup.sh
+++ b/core/tabs/applications-setup/Developer-tools/sublime-setup.sh
@@ -23,10 +23,11 @@ installSublime() {
                 ;;
             dnf)
                 "$ESCALATION_TOOL" rpm -v --import https://download.sublimetext.com/sublimehq-rpm-pub.gpg
-                if command -v dnf5 >/dev/null 2>&1; then
-                    "$ESCALATION_TOOL" "$PACKAGER" config-manager addrepo --from-repofile=https://download.sublimetext.com/rpm/dev/x86_64/sublime-text.repo
-                elif command -v dnf >/dev/null 2>&1; then
+                dnf_version=$(dnf --version | head -n 1 | cut -d '.' -f 1)
+                if [ "$dnf_version" -eq 4 ]; then
                     "$ESCALATION_TOOL" "$PACKAGER" config-manager --add-repo https://download.sublimetext.com/rpm/dev/x86_64/sublime-text.repo
+                else
+                    "$ESCALATION_TOOL" "$PACKAGER" config-manager addrepo --from-repofile=https://download.sublimetext.com/rpm/dev/x86_64/sublime-text.repo
                 fi
                 "$ESCALATION_TOOL" "$PACKAGER" install -y sublime-text
                 ;;

--- a/core/tabs/applications-setup/Developer-tools/sublime-setup.sh
+++ b/core/tabs/applications-setup/Developer-tools/sublime-setup.sh
@@ -23,7 +23,7 @@ installSublime() {
                 ;;
             dnf)
                 "$ESCALATION_TOOL" rpm -v --import https://download.sublimetext.com/sublimehq-rpm-pub.gpg
-                "$ESCALATION_TOOL" "$PACKAGER" config-manager --addrepo https://download.sublimetext.com/rpm/stable/x86_64/sublime-text.repo
+                "$ESCALATION_TOOL" "$PACKAGER" config-manager addrepo https://download.sublimetext.com/rpm/stable/x86_64/sublime-text.repo
                 "$ESCALATION_TOOL" "$PACKAGER" install -y sublime-text
                 ;;
             *)

--- a/core/tabs/applications-setup/Developer-tools/sublime-setup.sh
+++ b/core/tabs/applications-setup/Developer-tools/sublime-setup.sh
@@ -23,7 +23,11 @@ installSublime() {
                 ;;
             dnf)
                 "$ESCALATION_TOOL" rpm -v --import https://download.sublimetext.com/sublimehq-rpm-pub.gpg
-                "$ESCALATION_TOOL" "$PACKAGER" config-manager addrepo --from-repofile=https://download.sublimetext.com/rpm/stable/x86_64/sublime-text.repo
+                if command -v dnf5 >/dev/null 2>&1; then
+                    "$ESCALATION_TOOL" "$PACKAGER" config-manager addrepo --from-repofile=https://download.sublimetext.com/rpm/dev/x86_64/sublime-text.repo
+                elif command -v dnf >/dev/null 2>&1; then
+                    "$ESCALATION_TOOL" "$PACKAGER" config-manager --add-repo https://download.sublimetext.com/rpm/dev/x86_64/sublime-text.repo
+                fi
                 "$ESCALATION_TOOL" "$PACKAGER" install -y sublime-text
                 ;;
             *)

--- a/core/tabs/applications-setup/Developer-tools/sublime-setup.sh
+++ b/core/tabs/applications-setup/Developer-tools/sublime-setup.sh
@@ -23,7 +23,7 @@ installSublime() {
                 ;;
             dnf)
                 "$ESCALATION_TOOL" rpm -v --import https://download.sublimetext.com/sublimehq-rpm-pub.gpg
-                "$ESCALATION_TOOL" "$PACKAGER" config-manager --add-repo https://download.sublimetext.com/rpm/stable/x86_64/sublime-text.repo
+                "$ESCALATION_TOOL" "$PACKAGER" config-manager --addrepo https://download.sublimetext.com/rpm/stable/x86_64/sublime-text.repo
                 "$ESCALATION_TOOL" "$PACKAGER" install -y sublime-text
                 ;;
             *)

--- a/core/tabs/applications-setup/browsers/brave.sh
+++ b/core/tabs/applications-setup/browsers/brave.sh
@@ -25,7 +25,7 @@ installBrave() {
                 ;;
             dnf)
                 "$ESCALATION_TOOL" "$PACKAGER" install -y dnf-plugins-core
-                "$ESCALATION_TOOL" "$PACKAGER" config-manager addrepo https://brave-browser-rpm-release.s3.brave.com/brave-browser.repo
+                "$ESCALATION_TOOL" "$PACKAGER" config-manager addrepo --from-repofile=https://brave-browser-rpm-release.s3.brave.com/brave-browser.repo
                 "$ESCALATION_TOOL" rpm --import https://brave-browser-rpm-release.s3.brave.com/brave-core.asc
                 "$ESCALATION_TOOL" "$PACKAGER" install -y brave-browser
                 ;;

--- a/core/tabs/applications-setup/browsers/brave.sh
+++ b/core/tabs/applications-setup/browsers/brave.sh
@@ -25,7 +25,11 @@ installBrave() {
                 ;;
             dnf)
                 "$ESCALATION_TOOL" "$PACKAGER" install -y dnf-plugins-core
-                "$ESCALATION_TOOL" "$PACKAGER" config-manager addrepo --from-repofile=https://brave-browser-rpm-release.s3.brave.com/brave-browser.repo
+                if command -v dnf5 >/dev/null 2>&1; then
+                    "$ESCALATION_TOOL" "$PACKAGER" config-manager addrepo --from-repofile=https://brave-browser-rpm-release.s3.brave.com/brave-browser.repo
+                elif command -v dnf >/dev/null 2>&1; then
+                    "$ESCALATION_TOOL" "$PACKAGER" config-manager --add-repo https://brave-browser-rpm-release.s3.brave.com/brave-browser.repo
+                fi
                 "$ESCALATION_TOOL" rpm --import https://brave-browser-rpm-release.s3.brave.com/brave-core.asc
                 "$ESCALATION_TOOL" "$PACKAGER" install -y brave-browser
                 ;;

--- a/core/tabs/applications-setup/browsers/brave.sh
+++ b/core/tabs/applications-setup/browsers/brave.sh
@@ -25,10 +25,11 @@ installBrave() {
                 ;;
             dnf)
                 "$ESCALATION_TOOL" "$PACKAGER" install -y dnf-plugins-core
-                if command -v dnf5 >/dev/null 2>&1; then
-                    "$ESCALATION_TOOL" "$PACKAGER" config-manager addrepo --from-repofile=https://brave-browser-rpm-release.s3.brave.com/brave-browser.repo
-                elif command -v dnf >/dev/null 2>&1; then
+                dnf_version=$(dnf --version | head -n 1 | cut -d '.' -f 1)
+                if [ "$dnf_version" -eq 4 ]; then
                     "$ESCALATION_TOOL" "$PACKAGER" config-manager --add-repo https://brave-browser-rpm-release.s3.brave.com/brave-browser.repo
+                else
+                    "$ESCALATION_TOOL" "$PACKAGER" config-manager addrepo --from-repofile=https://brave-browser-rpm-release.s3.brave.com/brave-browser.repo
                 fi
                 "$ESCALATION_TOOL" rpm --import https://brave-browser-rpm-release.s3.brave.com/brave-core.asc
                 "$ESCALATION_TOOL" "$PACKAGER" install -y brave-browser

--- a/core/tabs/applications-setup/browsers/brave.sh
+++ b/core/tabs/applications-setup/browsers/brave.sh
@@ -25,7 +25,7 @@ installBrave() {
                 ;;
             dnf)
                 "$ESCALATION_TOOL" "$PACKAGER" install -y dnf-plugins-core
-                "$ESCALATION_TOOL" "$PACKAGER" config-manager --add-repo https://brave-browser-rpm-release.s3.brave.com/brave-browser.repo
+                "$ESCALATION_TOOL" "$PACKAGER" config-manager --addrepo https://brave-browser-rpm-release.s3.brave.com/brave-browser.repo
                 "$ESCALATION_TOOL" rpm --import https://brave-browser-rpm-release.s3.brave.com/brave-core.asc
                 "$ESCALATION_TOOL" "$PACKAGER" install -y brave-browser
                 ;;

--- a/core/tabs/applications-setup/browsers/brave.sh
+++ b/core/tabs/applications-setup/browsers/brave.sh
@@ -25,7 +25,7 @@ installBrave() {
                 ;;
             dnf)
                 "$ESCALATION_TOOL" "$PACKAGER" install -y dnf-plugins-core
-                "$ESCALATION_TOOL" "$PACKAGER" config-manager --addrepo https://brave-browser-rpm-release.s3.brave.com/brave-browser.repo
+                "$ESCALATION_TOOL" "$PACKAGER" config-manager addrepo https://brave-browser-rpm-release.s3.brave.com/brave-browser.repo
                 "$ESCALATION_TOOL" rpm --import https://brave-browser-rpm-release.s3.brave.com/brave-core.asc
                 "$ESCALATION_TOOL" "$PACKAGER" install -y brave-browser
                 ;;

--- a/core/tabs/applications-setup/browsers/vivaldi.sh
+++ b/core/tabs/applications-setup/browsers/vivaldi.sh
@@ -15,7 +15,7 @@ installVivaldi() {
                 ;;
             dnf)
                 "$ESCALATION_TOOL" "$PACKAGER" install -y dnf-plugins-core
-                "$ESCALATION_TOOL" "$PACKAGER" config-manager addrepo https://repo.vivaldi.com/stable/vivaldi-fedora.repo
+                "$ESCALATION_TOOL" "$PACKAGER" config-manager addrepo --from-repofile=https://repo.vivaldi.com/stable/vivaldi-fedora.repo
                 "$ESCALATION_TOOL" "$PACKAGER" install -y vivaldi-stable
                 ;;
             zypper)

--- a/core/tabs/applications-setup/browsers/vivaldi.sh
+++ b/core/tabs/applications-setup/browsers/vivaldi.sh
@@ -15,7 +15,7 @@ installVivaldi() {
                 ;;
             dnf)
                 "$ESCALATION_TOOL" "$PACKAGER" install -y dnf-plugins-core
-                "$ESCALATION_TOOL" "$PACKAGER" config-manager --add-repo https://repo.vivaldi.com/stable/vivaldi-fedora.repo
+                "$ESCALATION_TOOL" "$PACKAGER" config-manager --addrepo https://repo.vivaldi.com/stable/vivaldi-fedora.repo
                 "$ESCALATION_TOOL" "$PACKAGER" install -y vivaldi-stable
                 ;;
             zypper)

--- a/core/tabs/applications-setup/browsers/vivaldi.sh
+++ b/core/tabs/applications-setup/browsers/vivaldi.sh
@@ -15,7 +15,11 @@ installVivaldi() {
                 ;;
             dnf)
                 "$ESCALATION_TOOL" "$PACKAGER" install -y dnf-plugins-core
-                "$ESCALATION_TOOL" "$PACKAGER" config-manager addrepo --from-repofile=https://repo.vivaldi.com/stable/vivaldi-fedora.repo
+                if command -v dnf5 >/dev/null 2>&1; then
+                    "$ESCALATION_TOOL" "$PACKAGER" config-manager addrepo --from-repofile=https://repo.vivaldi.com/stable/vivaldi-fedora.repo
+                elif command -v dnf >/dev/null 2>&1; then
+                    "$ESCALATION_TOOL" "$PACKAGER" config-manager --add-repo https://repo.vivaldi.com/stable/vivaldi-fedora.repo
+                fi
                 "$ESCALATION_TOOL" "$PACKAGER" install -y vivaldi-stable
                 ;;
             zypper)

--- a/core/tabs/applications-setup/browsers/vivaldi.sh
+++ b/core/tabs/applications-setup/browsers/vivaldi.sh
@@ -15,7 +15,7 @@ installVivaldi() {
                 ;;
             dnf)
                 "$ESCALATION_TOOL" "$PACKAGER" install -y dnf-plugins-core
-                "$ESCALATION_TOOL" "$PACKAGER" config-manager --addrepo https://repo.vivaldi.com/stable/vivaldi-fedora.repo
+                "$ESCALATION_TOOL" "$PACKAGER" config-manager addrepo https://repo.vivaldi.com/stable/vivaldi-fedora.repo
                 "$ESCALATION_TOOL" "$PACKAGER" install -y vivaldi-stable
                 ;;
             zypper)

--- a/core/tabs/applications-setup/browsers/vivaldi.sh
+++ b/core/tabs/applications-setup/browsers/vivaldi.sh
@@ -15,10 +15,11 @@ installVivaldi() {
                 ;;
             dnf)
                 "$ESCALATION_TOOL" "$PACKAGER" install -y dnf-plugins-core
-                if command -v dnf5 >/dev/null 2>&1; then
-                    "$ESCALATION_TOOL" "$PACKAGER" config-manager addrepo --from-repofile=https://repo.vivaldi.com/stable/vivaldi-fedora.repo
-                elif command -v dnf >/dev/null 2>&1; then
+                dnf_version=$(dnf --version | head -n 1 | cut -d '.' -f 1)
+                if [ "$dnf_version" -eq 4 ]; then
                     "$ESCALATION_TOOL" "$PACKAGER" config-manager --add-repo https://repo.vivaldi.com/stable/vivaldi-fedora.repo
+                else
+                    "$ESCALATION_TOOL" "$PACKAGER" config-manager addrepo --from-repofile=https://repo.vivaldi.com/stable/vivaldi-fedora.repo
                 fi
                 "$ESCALATION_TOOL" "$PACKAGER" install -y vivaldi-stable
                 ;;

--- a/core/tabs/applications-setup/docker-setup.sh
+++ b/core/tabs/applications-setup/docker-setup.sh
@@ -28,7 +28,11 @@ install_docker() {
             ;;
         dnf)
             "$ESCALATION_TOOL" "$PACKAGER" -y install dnf-plugins-core
-            "$ESCALATION_TOOL" "$PACKAGER" config-manager addrepo --from-repofile=https://download.docker.com/linux/fedora/docker-ce.repo
+            if command -v dnf5 >/dev/null 2>&1; then
+                "$ESCALATION_TOOL" "$PACKAGER" config-manager addrepo --from-repofile=https://download.docker.com/linux/fedora/docker-ce.repo
+            elif command -v dnf >/dev/null 2>&1; then
+                "$ESCALATION_TOOL" "$PACKAGER" config-manager --add-repo https://download.docker.com/linux/fedora/docker-ce.repo
+            fi
             "$ESCALATION_TOOL" "$PACKAGER" -y install docker-ce docker-ce-cli containerd.io docker-buildx-plugin
             "$ESCALATION_TOOL" systemctl enable --now docker
             ;;
@@ -57,7 +61,11 @@ install_docker_compose() {
             ;;
         dnf)
             "$ESCALATION_TOOL" "$PACKAGER" -y install dnf-plugins-core
-            "$ESCALATION_TOOL" "$PACKAGER" config-manager addrepo --from-repofile=https://download.docker.com/linux/fedora/docker-ce.repo
+            if command -v dnf5 >/dev/null 2>&1; then
+                "$ESCALATION_TOOL" "$PACKAGER" config-manager addrepo --from-repofile=https://download.docker.com/linux/fedora/docker-ce.repo
+            elif command -v dnf >/dev/null 2>&1; then
+                "$ESCALATION_TOOL" "$PACKAGER" config-manager --add-repo https://download.docker.com/linux/fedora/docker-ce.repo
+            fi
             "$ESCALATION_TOOL" "$PACKAGER" install -y docker-compose-plugin
             ;;
         zypper)

--- a/core/tabs/applications-setup/docker-setup.sh
+++ b/core/tabs/applications-setup/docker-setup.sh
@@ -28,7 +28,7 @@ install_docker() {
             ;;
         dnf)
             "$ESCALATION_TOOL" "$PACKAGER" -y install dnf-plugins-core
-            "$ESCALATION_TOOL" "$PACKAGER" config-manager addrepo https://download.docker.com/linux/fedora/docker-ce.repo
+            "$ESCALATION_TOOL" "$PACKAGER" config-manager addrepo --from-repofile=https://download.docker.com/linux/fedora/docker-ce.repo
             "$ESCALATION_TOOL" "$PACKAGER" -y install docker-ce docker-ce-cli containerd.io docker-buildx-plugin
             "$ESCALATION_TOOL" systemctl enable --now docker
             ;;
@@ -57,7 +57,7 @@ install_docker_compose() {
             ;;
         dnf)
             "$ESCALATION_TOOL" "$PACKAGER" -y install dnf-plugins-core
-            "$ESCALATION_TOOL" "$PACKAGER" config-manager addrepo https://download.docker.com/linux/fedora/docker-ce.repo
+            "$ESCALATION_TOOL" "$PACKAGER" config-manager addrepo --from-repofile=https://download.docker.com/linux/fedora/docker-ce.repo
             "$ESCALATION_TOOL" "$PACKAGER" install -y docker-compose-plugin
             ;;
         zypper)

--- a/core/tabs/applications-setup/docker-setup.sh
+++ b/core/tabs/applications-setup/docker-setup.sh
@@ -28,10 +28,11 @@ install_docker() {
             ;;
         dnf)
             "$ESCALATION_TOOL" "$PACKAGER" -y install dnf-plugins-core
-            if command -v dnf5 >/dev/null 2>&1; then
-                "$ESCALATION_TOOL" "$PACKAGER" config-manager addrepo --from-repofile=https://download.docker.com/linux/fedora/docker-ce.repo
-            elif command -v dnf >/dev/null 2>&1; then
+            dnf_version=$(dnf --version | head -n 1 | cut -d '.' -f 1)
+            if [ "$dnf_version" -eq 4 ]; then
                 "$ESCALATION_TOOL" "$PACKAGER" config-manager --add-repo https://download.docker.com/linux/fedora/docker-ce.repo
+            else
+                "$ESCALATION_TOOL" "$PACKAGER" config-manager addrepo --from-repofile=https://download.docker.com/linux/fedora/docker-ce.repo
             fi
             "$ESCALATION_TOOL" "$PACKAGER" -y install docker-ce docker-ce-cli containerd.io docker-buildx-plugin
             "$ESCALATION_TOOL" systemctl enable --now docker
@@ -61,10 +62,11 @@ install_docker_compose() {
             ;;
         dnf)
             "$ESCALATION_TOOL" "$PACKAGER" -y install dnf-plugins-core
-            if command -v dnf5 >/dev/null 2>&1; then
-                "$ESCALATION_TOOL" "$PACKAGER" config-manager addrepo --from-repofile=https://download.docker.com/linux/fedora/docker-ce.repo
-            elif command -v dnf >/dev/null 2>&1; then
+            dnf_version=$(dnf --version | head -n 1 | cut -d '.' -f 1)
+            if [ "$dnf_version" -eq 4 ]; then
                 "$ESCALATION_TOOL" "$PACKAGER" config-manager --add-repo https://download.docker.com/linux/fedora/docker-ce.repo
+            else
+                "$ESCALATION_TOOL" "$PACKAGER" config-manager addrepo --from-repofile=https://download.docker.com/linux/fedora/docker-ce.repo
             fi
             "$ESCALATION_TOOL" "$PACKAGER" install -y docker-compose-plugin
             ;;

--- a/core/tabs/applications-setup/docker-setup.sh
+++ b/core/tabs/applications-setup/docker-setup.sh
@@ -28,7 +28,7 @@ install_docker() {
             ;;
         dnf)
             "$ESCALATION_TOOL" "$PACKAGER" -y install dnf-plugins-core
-            "$ESCALATION_TOOL" "$PACKAGER" config-manager --add-repo https://download.docker.com/linux/fedora/docker-ce.repo
+            "$ESCALATION_TOOL" "$PACKAGER" config-manager --addrepo https://download.docker.com/linux/fedora/docker-ce.repo
             "$ESCALATION_TOOL" "$PACKAGER" -y install docker-ce docker-ce-cli containerd.io docker-buildx-plugin
             "$ESCALATION_TOOL" systemctl enable --now docker
             ;;
@@ -57,7 +57,7 @@ install_docker_compose() {
             ;;
         dnf)
             "$ESCALATION_TOOL" "$PACKAGER" -y install dnf-plugins-core
-            "$ESCALATION_TOOL" "$PACKAGER" config-manager --add-repo https://download.docker.com/linux/fedora/docker-ce.repo
+            "$ESCALATION_TOOL" "$PACKAGER" config-manager --addrepo https://download.docker.com/linux/fedora/docker-ce.repo
             "$ESCALATION_TOOL" "$PACKAGER" install -y docker-compose-plugin
             ;;
         zypper)

--- a/core/tabs/applications-setup/docker-setup.sh
+++ b/core/tabs/applications-setup/docker-setup.sh
@@ -28,7 +28,7 @@ install_docker() {
             ;;
         dnf)
             "$ESCALATION_TOOL" "$PACKAGER" -y install dnf-plugins-core
-            "$ESCALATION_TOOL" "$PACKAGER" config-manager --addrepo https://download.docker.com/linux/fedora/docker-ce.repo
+            "$ESCALATION_TOOL" "$PACKAGER" config-manager addrepo https://download.docker.com/linux/fedora/docker-ce.repo
             "$ESCALATION_TOOL" "$PACKAGER" -y install docker-ce docker-ce-cli containerd.io docker-buildx-plugin
             "$ESCALATION_TOOL" systemctl enable --now docker
             ;;
@@ -57,7 +57,7 @@ install_docker_compose() {
             ;;
         dnf)
             "$ESCALATION_TOOL" "$PACKAGER" -y install dnf-plugins-core
-            "$ESCALATION_TOOL" "$PACKAGER" config-manager --addrepo https://download.docker.com/linux/fedora/docker-ce.repo
+            "$ESCALATION_TOOL" "$PACKAGER" config-manager addrepo https://download.docker.com/linux/fedora/docker-ce.repo
             "$ESCALATION_TOOL" "$PACKAGER" install -y docker-compose-plugin
             ;;
         zypper)


### PR DESCRIPTION
## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
There have been a recent syntax change in dnf5 which comes preinstalled with every distro based on fedora 41 or later, therefore I have updated all the setup scripts which requires **--add-repo** and replaced it with **addrepo --from-repofile="https://..."**. Also @jeevithakannan2 has added a version check so it doesn't conflict with systems that are not on dnf5.  

## Testing
Works. Although there is an issue with upstream braves repo file, I have created an issue on their GitHub page. It will start working again once they update the upstream repo file. I think this should be merged regardless as currently no script is working with dnf5 after this 3 out of 4 will start working and after brave fixes the issue all 4 will work. 

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
