### PR TITLE
fix: getting locked out when running script

### DIFF
--- a/tui/src/state.rs
+++ b/tui/src/state.rs
@@ -186,7 +186,9 @@ impl AppState {
     pub fn draw(&mut self, frame: &mut Frame) {
         let terminal_size = frame.area();
 
-        if terminal_size.width < MIN_WIDTH || terminal_size.height < MIN_HEIGHT {
+        if !matches!(self.focus, Focus::FloatingWindow(_)) && terminal_size.width < MIN_WIDTH
+            || terminal_size.height < MIN_HEIGHT
+        {
             let warning = Paragraph::new(format!(
                 "Terminal size too small:\nWidth = {} Height = {}\n\nMinimum size:\nWidth = {}  Height = {}",
                 terminal_size.width,


### PR DESCRIPTION
## Type of Change
- [x] Bug fix

## Description
- Prevents getting locked out when running scripts ( Might happen when using tty fonts, alacritty, kitty )
- Min TUI prompt will open once the floating window is closed.

## Testing
https://github.com/user-attachments/assets/03843582-b71e-4ff4-ad65-16110514b2e1

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no errors/warnings/merge conflicts.
