### PR TITLE
Move ZapZap entry to communication apps, remove redundant zoom entry

### DIFF
--- a/core/tabs/applications-setup/tab_data.toml
+++ b/core/tabs/applications-setup/tab_data.toml
@@ -40,6 +40,12 @@ script = "communication-apps/thunderbird-setup.sh"
 task_list = "I"
 
 [[data.entries]]
+name = "ZapZap"
+description = "ZapZap is an open source whatsapp desktop client for Linux users developed by rafatosta."
+script = "communication-apps/zapzap-setup.sh"
+task_list = "I"
+
+[[data.entries]]
 name = "Zoom"
 description = "Zoom is a widely-used video conferencing platform that allows users to host virtual meetings, webinars, and online collaboration with features like screen sharing and recording."
 script = "communication-apps/zoom-setup.sh"
@@ -83,17 +89,6 @@ name = "Sublime Text"
 description = "Sublime Text is a fast, lightweight, and customizable text editor known for its simplicity, powerful features, and wide range of plugins for various programming languages."
 script = "Developer-tools/sublime-setup.sh"
 task_list = "I"
-
-[[data.entries]]
-name = "ZapZap"
-description = "ZapZap is an open source whatsapp desktop client for Linux users developed by rafatosta."
-script = "communication-apps/zapzap-setup.sh"
-task_list = "I"
-
-[[data.entries]]
-name = "Zoom"
-description = "Zoom is a widely-used video conferencing platform that allows users to host virtual meetings, webinars, and online collaboration with features like screen sharing and recording."
-script = "communication-apps/zoom-setup.sh"
 
 [[data.entries]]
 name = "VS Code"

--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -12,6 +12,7 @@
 - **Slack**: Slack is a collaboration platform designed for team communication, featuring channels, direct messaging, file sharing, and integrations with various productivity tools.
 - **Telegram**: Telegram is a cloud-based messaging app known for its speed and security, offering features like group chats, channels, and end-to-end encrypted calls.
 - **Thunderbird**: Thunderbird is a free, open-source email client that offers powerful features like customizable email management, a built-in calendar, and extensive add-ons for enhanced functionality.
+- **ZapZap**: ZapZap is an open source whatsapp desktop client for Linux users developed by rafatosta.
 - **Zoom**: Zoom is a widely-used video conferencing platform that allows users to host virtual meetings, webinars, and online collaboration with features like screen sharing and recording.
 
 ### Developer Tools

--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -12,7 +12,6 @@
 - **Slack**: Slack is a collaboration platform designed for team communication, featuring channels, direct messaging, file sharing, and integrations with various productivity tools.
 - **Telegram**: Telegram is a cloud-based messaging app known for its speed and security, offering features like group chats, channels, and end-to-end encrypted calls.
 - **Thunderbird**: Thunderbird is a free, open-source email client that offers powerful features like customizable email management, a built-in calendar, and extensive add-ons for enhanced functionality.
-- **ZapZap**: ZapZap is an open source whatsapp desktop client for Linux users developed by rafatosta.
 - **Zoom**: Zoom is a widely-used video conferencing platform that allows users to host virtual meetings, webinars, and online collaboration with features like screen sharing and recording.
 
 ### Developer Tools


### PR DESCRIPTION
## Type of Change
- [x] Documentation update
- [x] Refactoring

## Description
- Remove redundant zoom entry and move zapzap from developer tools to communication.

## Testing

**Before**

![image](https://github.com/user-attachments/assets/bcde129b-b25c-4d73-b4d6-58a32211db08)
![image](https://github.com/user-attachments/assets/d925f2f4-2edc-468c-91a8-a48d8a5b346f)

**After**

![image](https://github.com/user-attachments/assets/6eb71547-ce8a-4cdc-9945-9c9f8d9d7885)
![image](https://github.com/user-attachments/assets/2412b69a-f488-4f9b-896d-7af4b419a854)

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
