### PR TITLE
make mouse interaction wrap back

### DIFF
--- a/tui/src/state.rs
+++ b/tui/src/state.rs
@@ -508,22 +508,38 @@ impl AppState {
                 }
                 MouseEventKind::ScrollDown => {
                     if mouse_in_tab_list {
-                        if self.current_tab.selected().unwrap() != self.tabs.len() - 1 {
+                        if self.current_tab.selected().unwrap() == self.tabs.len() - 1 {
+                            self.current_tab.select_first();
+                        } else {
                             self.current_tab.select_next();
                         }
                         self.refresh_tab();
                     } else if mouse_in_list {
-                        self.selection.select_next()
+                        let len = self.filter.item_list().len();
+                        if len > 0 {
+                            let current = self.selection.selected().unwrap_or(0);
+                            let max_index = if self.at_root() { len - 1 } else { len };
+                            let next = if current + 1 > max_index { 0 } else { current + 1 };
+                            self.selection.select(Some(next));
+                        }
                     }
                 }
                 MouseEventKind::ScrollUp => {
                     if mouse_in_tab_list {
-                        if self.current_tab.selected().unwrap() != 0 {
+                        if self.current_tab.selected().unwrap() == 0 {
+                            self.current_tab.select(Some(self.tabs.len() - 1));
+                        } else {
                             self.current_tab.select_previous();
                         }
                         self.refresh_tab();
                     } else if mouse_in_list {
-                        self.selection.select_previous()
+                        let len = self.filter.item_list().len();
+                        if len > 0 {
+                            let current = self.selection.selected().unwrap_or(0);
+                            let max_index = if self.at_root() { len - 1 } else { len };
+                            let next = if current == 0 { max_index } else { current - 1 };
+                            self.selection.select(Some(next));
+                        }
                     }
                 }
                 _ => {}

--- a/tui/src/state.rs
+++ b/tui/src/state.rs
@@ -519,7 +519,11 @@ impl AppState {
                         if len > 0 {
                             let current = self.selection.selected().unwrap_or(0);
                             let max_index = if self.at_root() { len - 1 } else { len };
-                            let next = if current + 1 > max_index { 0 } else { current + 1 };
+                            let next = if current + 1 > max_index {
+                                0
+                            } else {
+                                current + 1
+                            };
                             self.selection.select(Some(next));
                         }
                     }


### PR DESCRIPTION
<!--
Read Contributing Guidelines before opening a PR.
https://github.com/ChrisTitusTech/linutil/blob/main/.github/CONTRIBUTING.md
-->

## Type of Change
- [x] New feature

## Description
makes mouse interaction wrap back on last / first entry when scroll is attempted again in that direction, see video for a better explanation

we have this same feature for regular keyboard movement, btw

resolves #939 

## Testing
video is pretty laggy, you are warned !!

https://github.com/user-attachments/assets/2d040821-ba7c-41cf-8a74-e446155d3e6d

