### PR TITLE
Revert #913 "feat: Mouse scroll"

### DIFF
--- a/tui/src/confirmation.rs
+++ b/tui/src/confirmation.rs
@@ -3,7 +3,7 @@ use std::borrow::Cow;
 use crate::{float::FloatContent, hint::Shortcut};
 
 use ratatui::{
-    crossterm::event::{KeyCode, KeyEvent, MouseEvent, MouseEventKind},
+    crossterm::event::{KeyCode, KeyEvent},
     layout::Alignment,
     prelude::*,
     widgets::{Block, Borders, Clear, List},
@@ -83,19 +83,6 @@ impl FloatContent for ConfirmPrompt {
 
         frame.render_widget(Clear, inner_area);
         frame.render_widget(List::new(paths_text), inner_area);
-    }
-
-    fn handle_mouse_event(&mut self, event: &MouseEvent) -> bool {
-        match event.kind {
-            MouseEventKind::ScrollDown => {
-                self.scroll_down();
-            }
-            MouseEventKind::ScrollUp => {
-                self.scroll_up();
-            }
-            _ => {}
-        }
-        false
     }
 
     fn handle_key_event(&mut self, key: &KeyEvent) -> bool {

--- a/tui/src/float.rs
+++ b/tui/src/float.rs
@@ -1,5 +1,5 @@
 use ratatui::{
-    crossterm::event::{KeyCode, KeyEvent, MouseEvent},
+    crossterm::event::{KeyCode, KeyEvent},
     layout::{Constraint, Direction, Layout, Rect},
     Frame,
 };
@@ -9,7 +9,6 @@ use crate::hint::Shortcut;
 pub trait FloatContent {
     fn draw(&mut self, frame: &mut Frame, area: Rect);
     fn handle_key_event(&mut self, key: &KeyEvent) -> bool;
-    fn handle_mouse_event(&mut self, key: &MouseEvent) -> bool;
     fn is_finished(&self) -> bool;
     fn get_shortcut_list(&self) -> (&str, Box<[Shortcut]>);
 }
@@ -52,10 +51,6 @@ impl<Content: FloatContent + ?Sized> Float<Content> {
     pub fn draw(&mut self, frame: &mut Frame, parent_area: Rect) {
         let popup_area = self.floating_window(parent_area);
         self.content.draw(frame, popup_area);
-    }
-
-    pub fn handle_mouse_event(&mut self, event: &MouseEvent) {
-        self.content.handle_mouse_event(event);
     }
 
     // Returns true if the floating window is finished.

--- a/tui/src/floating_text.rs
+++ b/tui/src/floating_text.rs
@@ -9,7 +9,7 @@ use crate::{float::FloatContent, hint::Shortcut};
 use linutil_core::Command;
 
 use ratatui::{
-    crossterm::event::{KeyCode, KeyEvent, MouseEvent, MouseEventKind},
+    crossterm::event::{KeyCode, KeyEvent},
     layout::Rect,
     style::{Style, Stylize},
     text::Line,
@@ -281,17 +281,6 @@ impl FloatContent for FloatingText {
 
         // Render the list inside the bordered area
         frame.render_widget(list, inner_area);
-    }
-
-    fn handle_mouse_event(&mut self, event: &MouseEvent) -> bool {
-        match event.kind {
-            MouseEventKind::ScrollDown => self.scroll_down(),
-            MouseEventKind::ScrollUp => self.scroll_up(),
-            MouseEventKind::ScrollLeft => self.scroll_left(),
-            MouseEventKind::ScrollRight => self.scroll_right(),
-            _ => {}
-        }
-        false
     }
 
     fn handle_key_event(&mut self, key: &KeyEvent) -> bool {

--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -20,7 +20,7 @@ use clap::Parser;
 use ratatui::{
     backend::CrosstermBackend,
     crossterm::{
-        event::{self, DisableMouseCapture, EnableMouseCapture, Event, KeyEventKind},
+        event::{self, DisableMouseCapture, Event, KeyEventKind},
         style::ResetColor,
         terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
         ExecutableCommand,
@@ -64,8 +64,6 @@ fn main() -> io::Result<()> {
     );
 
     stdout().execute(EnterAlternateScreen)?;
-    stdout().execute(EnableMouseCapture)?;
-
     enable_raw_mode()?;
     let mut terminal = Terminal::new(CrosstermBackend::new(stdout()))?;
     terminal.clear()?;
@@ -95,22 +93,15 @@ fn run(
 
         // It's guaranteed that the `read()` won't block when the `poll()`
         // function returns `true`
-        match event::read()? {
-            Event::Key(key) => {
-                if key.kind != KeyEventKind::Press && key.kind != KeyEventKind::Repeat {
-                    continue;
-                }
+        if let Event::Key(key) = event::read()? {
+            // We are only interested in Press and Repeat events
+            if key.kind != KeyEventKind::Press && key.kind != KeyEventKind::Repeat {
+                continue;
+            }
 
-                if !state.handle_key(&key) {
-                    return Ok(());
-                }
+            if !state.handle_key(&key) {
+                return Ok(());
             }
-            Event::Mouse(mouse_event) => {
-                if !state.handle_mouse(&mouse_event) {
-                    return Ok(());
-                }
-            }
-            _ => {}
         }
     }
 }

--- a/tui/src/running_command.rs
+++ b/tui/src/running_command.rs
@@ -5,7 +5,7 @@ use portable_pty::{
     ChildKiller, CommandBuilder, ExitStatus, MasterPty, NativePtySystem, PtySize, PtySystem,
 };
 use ratatui::{
-    crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseEvent, MouseEventKind},
+    crossterm::event::{KeyCode, KeyEvent, KeyModifiers},
     layout::{Rect, Size},
     style::{Color, Style, Stylize},
     text::{Line, Span},
@@ -104,18 +104,6 @@ impl FloatContent for RunningCommand {
         frame.render_widget(pseudo_term, area);
     }
 
-    fn handle_mouse_event(&mut self, event: &MouseEvent) -> bool {
-        match event.kind {
-            MouseEventKind::ScrollUp => {
-                self.scroll_offset = self.scroll_offset.saturating_add(1);
-            }
-            MouseEventKind::ScrollDown => {
-                self.scroll_offset = self.scroll_offset.saturating_sub(1);
-            }
-            _ => {}
-        }
-        true
-    }
     /// Handle key events of the running command "window". Returns true when the "window" should be
     /// closed
     fn handle_key_event(&mut self, key: &KeyEvent) -> bool {

--- a/tui/src/state.rs
+++ b/tui/src/state.rs
@@ -13,8 +13,8 @@ use linutil_core::{ego_tree::NodeId, Config, ListNode, TabList};
 #[cfg(feature = "tips")]
 use rand::Rng;
 use ratatui::{
-    crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers, MouseEvent, MouseEventKind},
-    layout::{Alignment, Constraint, Direction, Flex, Layout, Position, Rect},
+    crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers},
+    layout::{Alignment, Constraint, Direction, Flex, Layout},
     style::{Style, Stylize},
     text::{Line, Span, Text},
     widgets::{Block, Borders, List, ListState, Paragraph},
@@ -42,8 +42,6 @@ P* - privileged *
 ";
 
 pub struct AppState {
-    /// Areas of tabs
-    areas: Option<Areas>,
     /// Selected theme
     theme: Theme,
     /// Currently focused area
@@ -82,11 +80,6 @@ pub struct ListEntry {
     pub has_children: bool,
 }
 
-pub struct Areas {
-    tab_list: Rect,
-    list: Rect,
-}
-
 enum SelectedItem {
     UpDir,
     Directory,
@@ -108,7 +101,6 @@ impl AppState {
         let auto_execute_commands = config_path.map(|path| Config::from_file(&path).auto_execute);
 
         let mut state = Self {
-            areas: None,
             theme,
             focus: Focus::List,
             tabs,
@@ -329,11 +321,6 @@ impl AppState {
             .split(horizontal[0]);
         frame.render_widget(label, left_chunks[0]);
 
-        self.areas = Some(Areas {
-            tab_list: left_chunks[1],
-            list: horizontal[1],
-        });
-
         let tabs = self
             .tabs
             .iter()
@@ -486,59 +473,6 @@ impl AppState {
         }
 
         frame.render_widget(keybind_para, vertical[1]);
-    }
-
-    pub fn handle_mouse(&mut self, event: &MouseEvent) -> bool {
-        if !self.drawable {
-            return true;
-        }
-
-        if matches!(self.focus, Focus::TabList | Focus::List) {
-            let position = Position::new(event.column, event.row);
-            let mouse_in_tab_list = self.areas.as_ref().unwrap().tab_list.contains(position);
-            let mouse_in_list = self.areas.as_ref().unwrap().list.contains(position);
-
-            match event.kind {
-                MouseEventKind::Moved => {
-                    if mouse_in_list {
-                        self.focus = Focus::List
-                    } else if mouse_in_tab_list {
-                        self.focus = Focus::TabList
-                    }
-                }
-                MouseEventKind::ScrollDown => {
-                    if mouse_in_tab_list {
-                        if self.current_tab.selected().unwrap() != self.tabs.len() - 1 {
-                            self.current_tab.select_next();
-                        }
-                        self.refresh_tab();
-                    } else if mouse_in_list {
-                        self.selection.select_next()
-                    }
-                }
-                MouseEventKind::ScrollUp => {
-                    if mouse_in_tab_list {
-                        if self.current_tab.selected().unwrap() != 0 {
-                            self.current_tab.select_previous();
-                        }
-                        self.refresh_tab();
-                    } else if mouse_in_list {
-                        self.selection.select_previous()
-                    }
-                }
-                _ => {}
-            }
-        }
-        match &mut self.focus {
-            Focus::FloatingWindow(float) => {
-                float.content.handle_mouse_event(event);
-            }
-            Focus::ConfirmationPrompt(confirm) => {
-                confirm.content.handle_mouse_event(event);
-            }
-            _ => {}
-        }
-        true
     }
 
     pub fn handle_key(&mut self, key: &KeyEvent) -> bool {


### PR DESCRIPTION
Reverts ChrisTitusTech/linutil#913


@ChrisTitusTech this feature lags the tui and increases cpu usage by a crazy amount, i think this should be reverted.
debug: ( much worse )
![image](https://github.com/user-attachments/assets/678a1871-5a5f-4527-b405-b0050d995768)
release: ( a little better but still noticeable)
![image](https://github.com/user-attachments/assets/ad96c027-397e-4df2-b913-6aeb773e052e)

@ChrisTitusTech take a look at #936 for more information regarding the bugs that came with the merge of #913 

closes #938
closes #937 
closes #946 
resolves #936 
resolves #941 
resolves #939 

after merging this i think a new prerelease should be made IF this feature was included in the latest one.

Also to bake this up even more, I think tui's shouldn't have mouse interaction in the first place and I think you can agree with me on that one, BECAUSE It's ran in the terminal (1) It's too resource intensive to provide support for it (2), please consider merging this.

## @ChrisTitusTech very important !! check out #946 it provides a major improvement towards this feature that includes more mouse interaction as seen in the video provided.

If you're not willing to merge this, take a look at :
#938
#937
#946

They both provide QOL improvements towards this feature.

If you still want to keep this feature inside of Linutil then this will have to be heavily optimized and I don't think It's possible.

