### PR TITLE
implement a greater extent of mouse interaction within the tui

### DIFF
--- a/tui/src/confirmation.rs
+++ b/tui/src/confirmation.rs
@@ -3,7 +3,7 @@ use std::borrow::Cow;
 use crate::{float::FloatContent, hint::Shortcut};
 
 use ratatui::{
-    crossterm::event::{KeyCode, KeyEvent, MouseEvent, MouseEventKind},
+    crossterm::event::{KeyCode, KeyEvent, MouseButton, MouseEvent, MouseEventKind},
     layout::Alignment,
     prelude::*,
     widgets::{Block, Borders, Clear, List},
@@ -87,15 +87,20 @@ impl FloatContent for ConfirmPrompt {
 
     fn handle_mouse_event(&mut self, event: &MouseEvent) -> bool {
         match event.kind {
+            MouseEventKind::Down(MouseButton::Left) => {
+                self.status = ConfirmStatus::Confirm;
+                true
+            }
             MouseEventKind::ScrollDown => {
                 self.scroll_down();
+                false
             }
             MouseEventKind::ScrollUp => {
                 self.scroll_up();
+                false
             }
-            _ => {}
+            _ => false,
         }
-        false
     }
 
     fn handle_key_event(&mut self, key: &KeyEvent) -> bool {

--- a/tui/src/confirmation.rs
+++ b/tui/src/confirmation.rs
@@ -91,6 +91,10 @@ impl FloatContent for ConfirmPrompt {
                 self.status = ConfirmStatus::Confirm;
                 true
             }
+            MouseEventKind::Down(MouseButton::Right) => {
+                self.status = ConfirmStatus::Abort;
+                false
+            }
             MouseEventKind::ScrollDown => {
                 self.scroll_down();
                 false

--- a/tui/src/float.rs
+++ b/tui/src/float.rs
@@ -56,7 +56,10 @@ impl<Content: FloatContent + ?Sized> Float<Content> {
 
     pub fn handle_mouse_event(&mut self, event: &MouseEvent) -> bool {
         match event.kind {
-            MouseEventKind::Down(MouseButton::Right) => true,
+            MouseEventKind::Down(MouseButton::Right) => {
+                self.content.handle_mouse_event(event);
+                true
+            }
             _ => self.content.handle_mouse_event(event),
         }
     }

--- a/tui/src/float.rs
+++ b/tui/src/float.rs
@@ -4,9 +4,7 @@ use ratatui::{
     Frame,
 };
 
-use crate::event::MouseButton;
-use crate::event::MouseEventKind;
-use crate::hint::Shortcut;
+use crate::{event::MouseButton, event::MouseEventKind, hint::Shortcut};
 
 pub trait FloatContent {
     fn draw(&mut self, frame: &mut Frame, area: Rect);

--- a/tui/src/float.rs
+++ b/tui/src/float.rs
@@ -4,6 +4,8 @@ use ratatui::{
     Frame,
 };
 
+use crate::event::MouseButton;
+use crate::event::MouseEventKind;
 use crate::hint::Shortcut;
 
 pub trait FloatContent {
@@ -54,8 +56,11 @@ impl<Content: FloatContent + ?Sized> Float<Content> {
         self.content.draw(frame, popup_area);
     }
 
-    pub fn handle_mouse_event(&mut self, event: &MouseEvent) {
-        self.content.handle_mouse_event(event);
+    pub fn handle_mouse_event(&mut self, event: &MouseEvent) -> bool {
+        match event.kind {
+            MouseEventKind::Down(MouseButton::Right) => true,
+            _ => self.content.handle_mouse_event(event),
+        }
     }
 
     // Returns true if the floating window is finished.

--- a/tui/src/running_command.rs
+++ b/tui/src/running_command.rs
@@ -113,7 +113,7 @@ impl FloatContent for RunningCommand {
             }
             _ => {}
         }
-        true
+        false
     }
     /// Handle key events of the running command "window". Returns true when the "window" should be
     /// closed

--- a/tui/src/state.rs
+++ b/tui/src/state.rs
@@ -495,6 +495,23 @@ impl AppState {
             return true;
         }
 
+        match &mut self.focus {
+            Focus::FloatingWindow(float) => {
+                if float.handle_mouse_event(event) {
+                    self.focus = Focus::List;
+                }
+                return true;
+            }
+            Focus::ConfirmationPrompt(prompt) => {
+                if prompt.handle_mouse_event(event) {
+                    self.focus = Focus::List;
+                    self.selected_commands.clear();
+                }
+                return true;
+            }
+            _ => {}
+        }
+
         if matches!(self.focus, Focus::TabList | Focus::List | Focus::Search) {
             let position = Position::new(event.column, event.row);
             let mouse_in_tab_list = self.areas.as_ref().unwrap().tab_list.contains(position);
@@ -561,7 +578,7 @@ impl AppState {
                             if matches!(self.focus, Focus::Search) {
                                 self.exit_search();
                             }
-                            self.focus = Focus::List;
+                            self.focus = Focus::TabList;
                         }
                     }
                     MouseButton::Right if mouse_in_list => {
@@ -597,15 +614,6 @@ impl AppState {
                 }
                 _ => {}
             }
-        }
-        match &mut self.focus {
-            Focus::FloatingWindow(float) => {
-                float.content.handle_mouse_event(event);
-            }
-            Focus::ConfirmationPrompt(confirm) => {
-                confirm.content.handle_mouse_event(event);
-            }
-            _ => {}
         }
         true
     }

--- a/tui/src/state.rs
+++ b/tui/src/state.rs
@@ -519,6 +519,7 @@ impl AppState {
                         ConfirmStatus::None => {}
                     }
                 }
+                return true;
             }
             _ => {}
         }

--- a/tui/src/state.rs
+++ b/tui/src/state.rs
@@ -508,7 +508,12 @@ impl AppState {
                             let list_start = areas.list.y + 4;
                             let relative_y = position.y.saturating_sub(list_start);
                             let list_len = self.filter.item_list().len();
-                            if relative_y < list_len as u16 {
+                            let adjusted_len = if self.at_root() {
+                                list_len
+                            } else {
+                                list_len + 1
+                            };
+                            if relative_y < adjusted_len as u16 {
                                 self.selection.select(Some(relative_y as usize));
                             }
                         }

--- a/tui/src/state.rs
+++ b/tui/src/state.rs
@@ -505,7 +505,8 @@ impl AppState {
                     if mouse_in_list {
                         self.focus = Focus::List;
                         if let Some(areas) = &self.areas {
-                            let relative_y = position.y.saturating_sub(areas.list.y + 1);
+                            let list_start = areas.list.y + 4;
+                            let relative_y = position.y.saturating_sub(list_start);
                             let list_len = self.filter.item_list().len();
                             if relative_y < list_len as u16 {
                                 self.selection.select(Some(relative_y as usize));

--- a/tui/src/state.rs
+++ b/tui/src/state.rs
@@ -548,21 +548,36 @@ impl AppState {
                         }
                     }
                 }
-                MouseEventKind::Down(MouseButton::Left) => {
-                    if mouse_in_search {
-                        self.enter_search();
-                    } else if mouse_in_list {
-                        if matches!(self.focus, Focus::Search) {
-                            self.exit_search();
+                MouseEventKind::Down(button) => match button {
+                    MouseButton::Left => {
+                        if mouse_in_search {
+                            self.enter_search();
+                        } else if mouse_in_list {
+                            if matches!(self.focus, Focus::Search) {
+                                self.exit_search();
+                            }
+                            self.handle_enter();
+                        } else if mouse_in_tab_list {
+                            if matches!(self.focus, Focus::Search) {
+                                self.exit_search();
+                            }
+                            self.focus = Focus::List;
                         }
-                        self.handle_enter();
-                    } else if mouse_in_tab_list {
-                        if matches!(self.focus, Focus::Search) {
-                            self.exit_search();
-                        }
-                        self.focus = Focus::List;
                     }
-                }
+                    MouseButton::Right if mouse_in_list => {
+                        if matches!(self.focus, Focus::Search) {
+                            self.exit_search();
+                        }
+                        self.enable_preview();
+                    }
+                    MouseButton::Middle if mouse_in_list => {
+                        if matches!(self.focus, Focus::Search) {
+                            self.exit_search();
+                        }
+                        self.enable_description();
+                    }
+                    _ => {}
+                },
                 MouseEventKind::ScrollDown | MouseEventKind::ScrollUp => {
                     if matches!(self.focus, Focus::Search) {
                         self.exit_search();

--- a/tui/src/state.rs
+++ b/tui/src/state.rs
@@ -509,11 +509,9 @@ impl AppState {
                             self.focus = Focus::List;
                             if !self.multi_select {
                                 self.selected_commands.clear()
-                            } else {
-                                if let Some(node) = self.get_selected_node() {
-                                    if !node.multi_select {
-                                        self.selected_commands.retain(|cmd| cmd.name != node.name);
-                                    }
+                            } else if let Some(node) = self.get_selected_node() {
+                                if !node.multi_select {
+                                    self.selected_commands.retain(|cmd| cmd.name != node.name);
                                 }
                             }
                         }


### PR DESCRIPTION
## Type of Change
- [x] Refactoring

## Description
features included in this pr:

- Allows for clicking entries with LMB (left mouse button)
- Allows for navigating through individual entries via moving the mouse up and down instead of using the scroll wheel
- Allows for selection of the search bar.
- Allows for description interaction via pressing down on the scrollwheel
- Allows for script preview interaction via RMB (Right Mouse Button)
- Allows for click and drag meaning holding down LMB (left mouse button) and dragging the mouse up and down inside of either the descriptions or script previews
- Allows for closing floating windows via RMB (right mouse button) only when a floating window is on screen for instance: descriptions, previews, confirmation, root check, and so on
- Allows for confirmation prompt accepting via LMB (left mouse button) after LMB is pressed it will continue on and run the script, after the script finished RMB (right mouse button) can be pressed to then close the floating window

Missing features:
- Scrolldown / Scroll up on last item / first item in list ( big issue on small windows where scrolldown is possible ), ( not to mention that it'll desync due to item padding. ) - > does not matter on bigger window sizes

closes #942 
closes #936 
closes #938 

## @ChrisTitusTech This PR Should be merged with: #937 

## Testing
tested
video is a little bit laggy, **You are warned !!**

https://github.com/user-attachments/assets/d85eea9d-72a4-474f-82e3-10b8688e3627




