### PR TITLE
refact: minor fixes

### DIFF
--- a/tui/src/floating_text.rs
+++ b/tui/src/floating_text.rs
@@ -171,7 +171,7 @@ impl<'a> FloatingText<'a> {
     }
 }
 
-impl<'a> FloatContent for FloatingText<'a> {
+impl FloatContent for FloatingText<'_> {
     fn draw(&mut self, frame: &mut Frame, area: Rect, _theme: &Theme) {
         let block = Block::default()
             .borders(Borders::ALL)

--- a/tui/src/hint.rs
+++ b/tui/src/hint.rs
@@ -36,7 +36,7 @@ pub fn create_shortcut_list(
         .unwrap_or(0);
 
     let columns = (render_width as usize / (max_shortcut_width + 4)).max(1);
-    let rows = (shortcut_spans.len() + columns - 1) / columns;
+    let rows = shortcut_spans.len().div_ceil(columns);
 
     let mut lines: Vec<Line<'static>> = Vec::with_capacity(rows);
 

--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -5,7 +5,7 @@ mod floating_text;
 mod hint;
 mod root;
 mod running_command;
-pub mod state;
+mod state;
 mod theme;
 
 #[cfg(feature = "tips")]

--- a/tui/src/state.rs
+++ b/tui/src/state.rs
@@ -480,7 +480,7 @@ impl AppState {
         }
         match &mut self.focus {
             Focus::FloatingWindow(float) => {
-                float.content.handle_mouse_event(event);
+                float.handle_mouse_event(event);
             }
             Focus::ConfirmationPrompt(confirm) => {
                 confirm.content.handle_mouse_event(event);


### PR DESCRIPTION
## Type of Change
- [x] Refactoring

## Description
- Fix unnecessary usage of pub mod appstate and unused float handle mouse function.
- Fix the below clippy warnings with new rust version.
```
warning: the following explicit lifetimes could be elided: 'a
   --> tui/src/floating_text.rs:174:6
    |
174 | impl<'a> FloatContent for FloatingText<'a> {
    |      ^^                                ^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
    = note: `#[warn(clippy::needless_lifetimes)]` on by default
help: elide the lifetimes
    |
174 - impl<'a> FloatContent for FloatingText<'a> {
174 + impl FloatContent for FloatingText<'_> {
    |

warning: manually reimplementing `div_ceil`
  --> tui/src/hint.rs:39:16
   |
39 |     let rows = (shortcut_spans.len() + columns - 1) / columns;
   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `.div_ceil()`: `shortcut_spans.len().div_ceil(columns)`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_div_ceil
   = note: `#[warn(clippy::manual_div_ceil)]` on by default

warning: `linutil_tui` (bin "linutil") generated 2 warnings (run `cargo clippy --fix --bin "linutil"` to apply 2 suggestions)
```

## Testing
- Tested on arch linux without any issues.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no errors/warnings/merge conflicts.
