### PR TITLE
fix(startdev): grep error

### DIFF
--- a/startdev.sh
+++ b/startdev.sh
@@ -8,8 +8,9 @@ RED='\033[0;31m'
 # Function to fetch the latest release tag from the GitHub API
 get_latest_release() {
   latest_release=$(curl -s https://api.github.com/repos/ChrisTitusTech/linutil/releases | 
-    grep -oP '"tag_name": "\K[^"]*' | 
-    head -n 1)
+    grep "tag_name" | 
+    head -n 1 | 
+    sed -E 's/.*"tag_name": "([^"]+)".*/\1/')
   if [ -z "$latest_release" ]; then
     printf "%b\n" "Error fetching release data" >&2
     return 1


### PR DESCRIPTION
## Type of Change
- [x] Bug fix

## Description
This can be resolved without changing anything by running `apk add --no-cache grep`. But we cannot ask the user to do so while we can solve this ourselves.

## Testing
Tested without any issues in alpine VM

## Issues / other PRs related
- Resolves #978

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no errors/warnings/merge conflicts.
