### PR TITLE
Change libvirtd service to start instead of enabling

### DIFF
--- a/core/tabs/system-setup/arch/virtualization.sh
+++ b/core/tabs/system-setup/arch/virtualization.sh
@@ -60,7 +60,7 @@ setupLibvirt() {
         fi
     done
 
-    "$ESCALATION_TOOL" systemctl enable --now libvirtd.service
+    "$ESCALATION_TOOL" systemctl start libvirtd.service
     "$ESCALATION_TOOL" virsh net-autostart default
 
     checkKVM


### PR DESCRIPTION
## Type of Change
- [x] Refactoring

## Description
- A 5-second delay in shutdown or reboot is caused by a libvirt issue when libvirtd service is running.
- Refactored to start the service without enabling it by default, giving users the flexibility to decide whether to enable it.
https://bbs.archlinux.org/viewtopic.php?id=301825

## Testing
- Tested on Arch Linux

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no errors/warnings/merge conflicts.
