### PR TITLE
fix: Correct maximum scroll index within subdirectories

### DIFF
--- a/tui/src/state.rs
+++ b/tui/src/state.rs
@@ -597,7 +597,10 @@ impl AppState {
 
     fn scroll_down(&mut self) {
         if let Some(selected) = self.selection.selected() {
-            if selected == self.filter.item_list().len() - 1 {
+            let len = self.filter.item_list().len();
+            let max_index = if self.at_root() { len - 1 } else { len };
+
+            if selected == max_index {
                 self.selection.select_first();
             } else {
                 self.selection.select_next();


### PR DESCRIPTION
<!--
Read Contributing Guidelines before opening a PR.
https://github.com/ChrisTitusTech/linutil/blob/main/.github/CONTRIBUTING.md
-->

## Type of Change
- [x] Bug fix

## Description
A regression in #933 causes scrolling to be limited to the length of the items, disregarding the parent directory navigation option within subdirectories. This corrects the issue by restoring the previous at_root check. 

## Issues / other PRs related
<!--[What issue/discussion is related to this PR (if any)]-->
- Resolves #1009

## Additional Information
<!--[Any additional information that reviewers should be aware of.]-->

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no errors/warnings/merge conflicts.
