### PR TITLE
fix(zen-browser): remove redundant AVX2 check

### DIFF
--- a/core/tabs/applications-setup/browsers/zen-browser.sh
+++ b/core/tabs/applications-setup/browsers/zen-browser.sh
@@ -7,11 +7,7 @@ installZenBrowser() {
         printf "%b\n" "${YELLOW}Installing Zen Browser...${RC}"
         case "$PACKAGER" in
         pacman)
-            if grep -q avx2 /proc/cpuinfo; then
-                "$AUR_HELPER" -S --needed --noconfirm zen-browser-avx2-bin
-            else
-                "$AUR_HELPER" -S --needed --noconfirm zen-browser-bin
-            fi
+            "$AUR_HELPER" -S --needed --noconfirm zen-browser-bin
             ;;
         *)
             checkFlatpak


### PR DESCRIPTION
This update removes the AVX2-specific logic from the installZenBrowser function. The Zen Browser team discontinued AVX2-optimized releases due to recurring build issues in GitHub workflows, so we now only install zen-browser-bin from AUR. This change streamlines the installation process.

<!--
Read Contributing Guidelines before opening a PR.
https://github.com/ChrisTitusTech/linutil/blob/main/.github/CONTRIBUTING.md
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation update
- [x] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
This refactor removes the AVX2-specific logic from the `installZenBrowser` function. The Zen Browser dev team discontinued AVX2-optimized releases due to recurring build issues in GitHub workflows. As a result, the only available package on AUR is `zen-browser-bin`. This update ensures we always install `zen-browser-bin`, streamlining the process and eliminating unnecessary complexity.

## Testing
- Ran the installer on a system using the `paru` AUR helper and confirmed that `zen-browser-bin` installs as expected.
- No errors or warnings were produced during execution.

## Impact
- Maintains consistency in package installation regardless of CPU capabilities.
- No new dependencies or performance impacts.

## Additional Information
- This refactor aligns our code with the current release strategy from the Zen Browser team and improves maintainability.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
