### PR TITLE
perf: increase rendering efficiency

### DIFF
--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -28,7 +28,6 @@ use running_command::TERMINAL_UPDATED;
 use state::AppState;
 use std::{
     io::{stdout, Result, Stdout},
-    path::PathBuf,
     sync::atomic::Ordering,
     time::Duration,
 };


### PR DESCRIPTION
<!--
Read Contributing Guidelines before opening a PR.
https://github.com/ChrisTitusTech/linutil/blob/main/.github/CONTRIBUTING.md
-->

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [x] UI/UX improvement

## Description
This small PR, makes, so that the UI is not re-rendered, unless an event is detected. The event might be a terminal event (keypress, mouse moved, resize, etc.)
Or if a terminal is open, if some new input came in from the terminal

## Testing
Before: 50% CPU usage on my machine with debug on
After: 1% CPU usage on my machine with debug on

## Impact
It doesn't impact the performance of the app, it will run just as fast as before, but it affects it's efficiency, so it's not re-rendered unless it should be.


## Additional Information
I am not aware of any possible side effects this might create, but if in the future we want to implement something like an animation system, it will complicate it a little.
