### PR TITLE
fix: pr remote rejection due to name restriction

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -54,6 +54,7 @@ jobs:
           mkdir -p build
           mv linutil build/linutil
           echo "${{ github.workspace }}/build" >> $GITHUB_PATH
+          echo "branch_name=${{ env.tag_name }}" | tr . - >> $GITHUB_ENV
 
       - name: Generate preview
         uses: charmbracelet/vhs-action@v2.1.0
@@ -67,11 +68,11 @@ jobs:
         uses: peter-evans/create-pull-request@v7.0.5
         with:
           commit-message: Preview for ${{ env.tag_name }}
-          branch: feature/preview-${{ env.tag_name }}
+          branch: preview-${{ env.branch_name }}
           title: "Update preview for ${{ env.tag_name }}"
           labels: |
             documentation
           body: |
             Automated PR to update preview gif for version ${{ env.tag_name }}
-            ![preview](https://raw.githubusercontent.com/${{ github.repository }}/feature/preview-${{ env.tag_name }}/.github/preview.gif)
+            ![preview](https://raw.githubusercontent.com/${{ github.repository }}/preview-${{ env.branch_name }}/.github/preview.gif)
         if: success()


### PR DESCRIPTION
## Type of Change
- [x] Bug fix

## Description
Not sure whether this fixes the issue but it's worth a try.
The action is failing because it cannot push the refs to the branch due to name restrictions.
Branch name that contains `feature/\d+-(.*)` gets rejected, not sure why.

Change the branch name from some thing like this `feature/preview-15.02.2025` -> `preview-15-02-2025`.

Found this https://github.com/orgs/community/discussions/61107#discussioncomment-6591355

## Issues / other PRs related
- Resolves #1030 