### PR TITLE
fix: reflector returning mirrors that are down

### DIFF
--- a/core/tabs/system-setup/arch/server-setup.sh
+++ b/core/tabs/system-setup/arch/server-setup.sh
@@ -316,7 +316,11 @@ echo -ne "
                     Setting up $iso mirrors for faster downloads
 -------------------------------------------------------------------------
 "
-reflector -a 48 -c "$iso" -f 5 -l 20 --sort rate --save /etc/pacman.d/mirrorlist
+reflector -a 48 -c "$iso" --score 5 -f 5 -l 20 --sort rate --save /etc/pacman.d/mirrorlist
+if [[ $(grep -c "Server =" /etc/pacman.d/mirrorlist) -lt 5 ]]; then #check if there are less than 5 mirrors
+    cp /etc/pacman.d/mirrorlist.bak /etc/pacman.d/mirrorlist
+fi
+
 if [ ! -d "/mnt" ]; then
     mkdir /mnt
 fi

--- a/core/tabs/system-setup/arch/server-setup.sh
+++ b/core/tabs/system-setup/arch/server-setup.sh
@@ -183,6 +183,7 @@ keymap () {
     echo -ne "
     Please select key board layout from this list"
     # These are default key maps as presented in official arch repo archinstall
+    # shellcheck disable=SC1010
     options=(us by ca cf cz de dk es et fa fi fr gr hu il it lt lv mk nl no pl ro ru se sg ua uk)
 
     select_option "${options[@]}"


### PR DESCRIPTION
## Type of Change
- [x] Bug fix

## Description
Add --score 5 to return mirrors that have score less than 5 making sure that most of the returned mirrors are active

## Issues / other PRs related
- Resolves #1035 

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no errors/warnings/merge conflicts.
