### PR TITLE
BugFix/Refactor: Various fixes for server-setup.sh

### DIFF
--- a/core/tabs/system-setup/arch/server-setup.sh
+++ b/core/tabs/system-setup/arch/server-setup.sh
@@ -385,16 +385,16 @@ else
 fi
 
 if [[ "${FS}" == "btrfs" ]]; then
-    mkfs.vfat -F32 -n "EFIBOOT" "${partition2}"
+    mkfs.fat -F32 -n "EFIBOOT" "${partition2}"
     mkfs.btrfs -f "${partition3}"
     mount -t btrfs "${partition3}" /mnt
     subvolumesetup
 elif [[ "${FS}" == "ext4" ]]; then
-    mkfs.vfat -F32 -n "EFIBOOT" "${partition2}"
+    mkfs.fat -F32 -n "EFIBOOT" "${partition2}"
     mkfs.ext4 "${partition3}"
     mount -t ext4 "${partition3}" /mnt
 elif [[ "${FS}" == "luks" ]]; then
-    mkfs.vfat -F32 "${partition2}"
+    mkfs.fat -F32 "${partition2}"
 # enter luks password to cryptsetup and format root partition
     echo -n "${LUKS_PASSWORD}" | cryptsetup -y -v luksFormat "${partition3}" -
 # open luks container and ROOT will be place holder
@@ -414,8 +414,8 @@ if ! mountpoint -q /mnt; then
     echo "ERROR! Failed to mount ${partition3} to /mnt after multiple attempts."
     exit 1
 fi
-mkdir -p /mnt/boot/efi
-mount -t vfat -U "${BOOT_UUID}" /mnt/boot/
+mkdir -p /mnt/boot
+mount -U "${BOOT_UUID}" /mnt/boot/
 
 if ! grep -qs '/mnt' /proc/mounts; then
     echo "Drive is not mounted can not continue"

--- a/core/tabs/system-setup/arch/server-setup.sh
+++ b/core/tabs/system-setup/arch/server-setup.sh
@@ -302,7 +302,7 @@ logo
 keymap
 
 echo "Setting up mirrors for optimal download"
-iso=$(curl -4 ifconfig.co/country-iso)
+iso=$(curl -4 ifconfig.io/country_code)
 timedatectl set-ntp true
 pacman -Sy
 pacman -S --noconfirm archlinux-keyring #update keyrings to latest to prevent packages failing to install

--- a/core/tabs/system-setup/arch/server-setup.sh
+++ b/core/tabs/system-setup/arch/server-setup.sh
@@ -481,8 +481,8 @@ echo -ne "
                     Network Setup
 -------------------------------------------------------------------------
 "
-pacman -S --noconfirm --needed networkmanager dhclient
-systemctl enable --now NetworkManager
+pacman -S --noconfirm --needed networkmanager dhcpcd
+systemctl enable NetworkManager
 echo -ne "
 -------------------------------------------------------------------------
                     Setting up mirrors for optimal download
@@ -492,7 +492,7 @@ pacman -S --noconfirm --needed pacman-contrib curl
 pacman -S --noconfirm --needed reflector rsync grub arch-install-scripts git ntp wget
 cp /etc/pacman.d/mirrorlist /etc/pacman.d/mirrorlist.bak
 
-nc=$(grep -c ^processor /proc/cpuinfo)
+nc=$(grep -c ^"cpu cores" /proc/cpuinfo)
 echo -ne "
 -------------------------------------------------------------------------
                     You have " $nc" cores. And
@@ -660,10 +660,10 @@ systemctl enable ntpd.service
 echo "  NTP enabled"
 systemctl disable dhcpcd.service
 echo "  DHCP disabled"
-systemctl stop dhcpcd.service
-echo "  DHCP stopped"
 systemctl enable NetworkManager.service
 echo "  NetworkManager enabled"
+systemctl enable reflector.timer
+echo "  Reflector enabled"
 
 echo -ne "
 -------------------------------------------------------------------------


### PR DESCRIPTION
<!--
Read Contributing Guidelines before opening a PR.
https://github.com/ChrisTitusTech/linutil/blob/main/.github/CONTRIBUTING.md
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
Fixes some bugs and corrects a few syntax errors and erroneous commands.  Of note;

- Errors with formatting and mounting boot partition
- Switches country code curl target, fixing errors with reflector, pacman, pacstrap
- Incorrect grep target to obtain # of CPU cores
- Installing dhclient when calling for dhcpcd
- Eliminating systemctl --stop calls within chroot due to non-functionality

## Testing
Iterative testing of server-setup.sh on SBC to install Arch and eliminate error calls that do not kill the install.

## Impact
Fixes standing bugs with package downloads and restores functionality to set MAKEFLAGS.

## Checklist
- [ ] My code adheres to the coding and style guidelines of the project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no errors/warnings/merge conflicts.
