### PR TITLE
Adds continue anyway when linux headers fails to install while downloading Nvidia Drivers on Arch. Fixes my Issue #1056

### DIFF
--- a/core/tabs/system-setup/arch/nvidia-drivers.sh
+++ b/core/tabs/system-setup/arch/nvidia-drivers.sh
@@ -13,7 +13,17 @@ installDeps() {
     for kernel in $installed_kernels; do
         header="${kernel}-headers"
         printf "%b\n" "${CYAN}Installing headers for $kernel...${RC}"
-        "$ESCALATION_TOOL" "$PACKAGER" -S --needed --noconfirm "$header"
+        
+        if ! "$ESCALATION_TOOL" "$PACKAGER" -S --needed --noconfirm "$header" ; then
+            printf "%b\n" "${RED}Failed to install headers. ${RC}"
+            printf "%b" "${YELLOW}Do you want to continue anyway? [y/N]: ${RC}"
+            read -r continue_anyway
+            if ! [ "$continue_anyway" = "y" ] && ! [ "$continue_anyway" = "Y" ]; then
+                printf "%b\n" "${RED}Aborting installation. ${RC}"
+                exit 1
+            fi
+            printf "%b\n" "${YELLOW}Warning: Continuing. ${RC}"
+        fi    
     done
 }
 


### PR DESCRIPTION
…ading deps for nvidia drivers on arch. Fixes my Issue #1056

<!--
Read Contributing Guidelines before opening a PR.
https://github.com/ChrisTitusTech/linutil/blob/main/.github/CONTRIBUTING.md
-->

## Type of Change
- [X] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
Added a simple if statement so when download of linux-headers fails for some reason you can continue the installation anyway.

## Testing
Booted up my arch with linux-tkg build the project and tried to download nvidia drivers through linux utility and it worked

## Impact
no effects on performance 0 new deps

## Issues / other PRs related
My Issue
Issue #1056

## Additional Information
My english can be bad in the messages

## Checklist
- [ ] My code adheres to the coding and style guidelines of the project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [X] My changes generate no errors/warnings/merge conflicts.
