### PR TITLE
fix builds essentials for debian based systems

### DIFF
--- a/core/tabs/system-setup/compile-setup.sh
+++ b/core/tabs/system-setup/compile-setup.sh
@@ -53,10 +53,10 @@ installDepend() {
             "$ESCALATION_TOOL" "$PACKAGER" -y glibc-32bit gcc-multilib
             ;;
         eopkg)
-            SOLUS_DEPENDENCIES='tar tree unzip cmake make jq'
             COMPILEDEPS='-c system.devel'
             "$ESCALATION_TOOL" "$PACKAGER" update-repo
-            "$ESCALATION_TOOL" "$PACKAGER" install -y $SOLUS_DEPENDENCIES $COMPILEDEPS
+            "$ESCALATION_TOOL" "$PACKAGER" install -y tar tree unzip cmake make jq
+            "$ESCALATION_TOOL" "$PACKAGER" "$COMPILEDEPS"
             ;;
         *)
             "$ESCALATION_TOOL" "$PACKAGER" install -y $DEPENDENCIES

--- a/core/tabs/system-setup/compile-setup.sh
+++ b/core/tabs/system-setup/compile-setup.sh
@@ -1,4 +1,5 @@
 #!/bin/sh -e
+# shellcheck disable=SC2086
 
 . ../common-script.sh
 
@@ -15,21 +16,20 @@ installDepend() {
             else
                 printf "%b\n" "${GREEN}Multilib is already enabled.${RC}"
             fi
-            "$AUR_HELPER" -S --needed --noconfirm "$DEPENDENCIES"
+            "$AUR_HELPER" -S --needed --noconfirm $DEPENDENCIES
             ;;
         apt-get|nala)
             COMPILEDEPS='build-essential'
             "$ESCALATION_TOOL" "$PACKAGER" update
             "$ESCALATION_TOOL" dpkg --add-architecture i386
             "$ESCALATION_TOOL" "$PACKAGER" update
-            "$ESCALATION_TOOL" "$PACKAGER" install -y "$DEPENDENCIES" "$COMPILEDEPS"
+            "$ESCALATION_TOOL" "$PACKAGER" install -y $DEPENDENCIES $COMPILEDEPS
             ;;
         dnf)
             "$ESCALATION_TOOL" "$PACKAGER" update -y
             if ! "$ESCALATION_TOOL" "$PACKAGER" config-manager --enable powertools 2>/dev/null; then
                 "$ESCALATION_TOOL" "$PACKAGER" config-manager --enable crb 2>/dev/null || true
             fi
-            # shellcheck disable=SC2086
             "$ESCALATION_TOOL" "$PACKAGER" -y install $DEPENDENCIES
             if ! "$ESCALATION_TOOL" "$PACKAGER" -y group install "Development Tools" 2>/dev/null; then
                 "$ESCALATION_TOOL" "$PACKAGER" -y group install development-tools
@@ -47,20 +47,19 @@ installDepend() {
             ;;
         xbps-install)
             COMPILEDEPS='base-devel'
-            # shellcheck disable=SC2086
-            "$ESCALATION_TOOL" "$PACKAGER" -Sy $DEPENDENCIES $COMPILEDEPS
-            "$ESCALATION_TOOL" "$PACKAGER" -Sy void-repo-multilib
-            "$ESCALATION_TOOL" "$PACKAGER" -Sy glibc-32bit gcc-multilib
+            "$ESCALATION_TOOL" "$PACKAGER" -y $DEPENDENCIES $COMPILEDEPS
+            "$ESCALATION_TOOL" "$PACKAGER" -y void-repo-multilib
+            "$ESCALATION_TOOL" "$PACKAGER" -Sy
+            "$ESCALATION_TOOL" "$PACKAGER" -y glibc-32bit gcc-multilib
             ;;
         eopkg)
-            # shellcheck disable=SC2086
+            SOLUS_DEPENDENCIES='tar tree unzip cmake make jq'
             COMPILEDEPS='-c system.devel'
             "$ESCALATION_TOOL" "$PACKAGER" update-repo
-            "$ESCALATION_TOOL" "$PACKAGER" install -y tar tree unzip cmake make jq
-            "$ESCALATION_TOOL" "$PACKAGER" "$COMPILEDEPS"
+            "$ESCALATION_TOOL" "$PACKAGER" install -y $SOLUS_DEPENDENCIES $COMPILEDEPS
             ;;
         *)
-            "$ESCALATION_TOOL" "$PACKAGER" install -y "$DEPENDENCIES"
+            "$ESCALATION_TOOL" "$PACKAGER" install -y $DEPENDENCIES
             ;;
     esac
 }

--- a/core/tabs/system-setup/compile-setup.sh
+++ b/core/tabs/system-setup/compile-setup.sh
@@ -55,7 +55,7 @@ installDepend() {
             COMPILEDEPS='-c system.devel'
             "$ESCALATION_TOOL" "$PACKAGER" update-repo
             "$ESCALATION_TOOL" "$PACKAGER" install -y tar tree unzip cmake make jq
-            "$ESCALATION_TOOL" "$PACKAGER" $COMPILEDEPS
+            "$ESCALATION_TOOL" "$PACKAGER" install -y $COMPILEDEPS
             ;;
         *)
             "$ESCALATION_TOOL" "$PACKAGER" install -y $DEPENDENCIES

--- a/core/tabs/system-setup/compile-setup.sh
+++ b/core/tabs/system-setup/compile-setup.sh
@@ -55,7 +55,7 @@ installDepend() {
             COMPILEDEPS='-c system.devel'
             "$ESCALATION_TOOL" "$PACKAGER" update-repo
             "$ESCALATION_TOOL" "$PACKAGER" install -y tar tree unzip cmake make jq
-            "$ESCALATION_TOOL" "$PACKAGER" "$COMPILEDEPS"
+            "$ESCALATION_TOOL" "$PACKAGER" $COMPILEDEPS
             ;;
         *)
             "$ESCALATION_TOOL" "$PACKAGER" install -y $DEPENDENCIES

--- a/core/tabs/system-setup/compile-setup.sh
+++ b/core/tabs/system-setup/compile-setup.sh
@@ -47,10 +47,9 @@ installDepend() {
             ;;
         xbps-install)
             COMPILEDEPS='base-devel'
-            "$ESCALATION_TOOL" "$PACKAGER" -y $DEPENDENCIES $COMPILEDEPS
-            "$ESCALATION_TOOL" "$PACKAGER" -y void-repo-multilib
-            "$ESCALATION_TOOL" "$PACKAGER" -Sy
-            "$ESCALATION_TOOL" "$PACKAGER" -y glibc-32bit gcc-multilib
+            "$ESCALATION_TOOL" "$PACKAGER" -Sy $DEPENDENCIES $COMPILEDEPS
+            "$ESCALATION_TOOL" "$PACKAGER" -Sy void-repo-multilib
+            "$ESCALATION_TOOL" "$PACKAGER" -Sy glibc-32bit gcc-multilib
             ;;
         eopkg)
             COMPILEDEPS='-c system.devel'


### PR DESCRIPTION
<!--
Read Contributing Guidelines before opening a PR.
https://github.com/ChrisTitusTech/linutil/blob/main/.github/CONTRIBUTING.md
-->

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
Fixes build essentials install for debian based system. Shellcheck (quotes) was causing errors. 

## Testing
Debian, Ubuntu

## Impact
Double quotes were messing up most of the builds on the script. I disabled [shellcheck](https://www.shellcheck.net/wiki/SC2086)

## Issues / other PRs related
<!--[What issue/discussion is related to this PR (if any)]-->
- Resolves #1065 

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
