### PR TITLE
Smaller font(TTY Font): makes font size 18. 

### DIFF
--- a/core/tabs/system-setup/terminus-tty.sh
+++ b/core/tabs/system-setup/terminus-tty.sh
@@ -40,8 +40,8 @@ InstallTermiusFonts() {
 }
 
 SetTermiusFonts() {
-        case "$DTYPE" in
-            arch|fedora|void|solus|opensuse-*)
+        case "$PACKAGER" in
+            pacman|xbps-install|dnf|eopkg|zypper)
                 printf "%b\n" "${YELLOW}Updating FONT= line in /etc/vconsole.conf...${RC}"
                 "$ESCALATION_TOOL" sed -i 's/^FONT=.*/FONT=ter-v18b/' /etc/vconsole.conf
                 if [ -z "$DISPLAY" ] && [ -z "$WAYLAND_DISPLAY" ]; then
@@ -49,7 +49,7 @@ SetTermiusFonts() {
                 fi
                 printf "%b\n" "${GREEN}Terminus font set for TTY.${RC}"
                 ;;
-            alpine)
+            apk)
                 printf "%b\n" "${YELLOW}Updating console font configuration for Alpine...${RC}"
                 if [ -z "$DISPLAY" ] && [ -z "$WAYLAND_DISPLAY" ]; then
                     "$ESCALATION_TOOL" setfont -C /dev/tty1 /usr/share/consolefonts/ter-v18b.psf.gz
@@ -58,7 +58,7 @@ SetTermiusFonts() {
                 "$ESCALATION_TOOL" rc-update add consolefont boot
                 printf "%b\n" "${GREEN}Terminus font set for TTY.${RC}"
                 ;;
-            debian)
+            apt-get|nala)
                 printf "%b\n" "${YELLOW}Updating console-setup configuration...${RC}"
                 "$ESCALATION_TOOL" sed -i 's/^CODESET=.*/CODESET="guess"/' /etc/default/console-setup
                 "$ESCALATION_TOOL" sed -i 's/^FONTFACE=.*/FONTFACE="TerminusBold"/' /etc/default/console-setup
@@ -70,6 +70,10 @@ SetTermiusFonts() {
                    "$ESCALATION_TOOL" setfont -C /dev/tty1 /usr/share/consolefonts/Uni3-TerminusBold18x10.psf.gz
                 fi
                 printf "%b\n" "${GREEN}Terminus font has been set for TTY.${RC}"
+                ;;
+            *)
+                printf "%b\n" "${RED}Unsupported package manager for font configuration: ""$PACKAGER""${RC}"
+                exit 1
                 ;;
         esac
 }

--- a/core/tabs/system-setup/terminus-tty.sh
+++ b/core/tabs/system-setup/terminus-tty.sh
@@ -43,18 +43,18 @@ SetTermiusFonts() {
         case "$DTYPE" in
             arch|fedora|void|solus|opensuse-*)
                 printf "%b\n" "${YELLOW}Updating FONT= line in /etc/vconsole.conf...${RC}"
-                "$ESCALATION_TOOL" sed -i 's/^FONT=.*/FONT=ter-v32b/' /etc/vconsole.conf
+                "$ESCALATION_TOOL" sed -i 's/^FONT=.*/FONT=ter-v18b/' /etc/vconsole.conf
                 if [ -z "$DISPLAY" ] && [ -z "$WAYLAND_DISPLAY" ]; then
-                   "$ESCALATION_TOOL" setfont -C /dev/tty1 ter-v32b
+                   "$ESCALATION_TOOL" setfont -C /dev/tty1 ter-v18b
                 fi
                 printf "%b\n" "${GREEN}Terminus font set for TTY.${RC}"
                 ;;
             alpine)
                 printf "%b\n" "${YELLOW}Updating console font configuration for Alpine...${RC}"
                 if [ -z "$DISPLAY" ] && [ -z "$WAYLAND_DISPLAY" ]; then
-                    "$ESCALATION_TOOL" setfont -C /dev/tty1 /usr/share/consolefonts/ter-v32b.psf.gz
+                    "$ESCALATION_TOOL" setfont -C /dev/tty1 /usr/share/consolefonts/ter-v18b.psf.gz
                 fi
-                echo 'consolefont="/usr/share/consolefonts/ter-v32b.psf.gz"' | "$ESCALATION_TOOL" tee /etc/conf.d/consolefont > /dev/null
+                echo 'consolefont="/usr/share/consolefonts/ter-v18b.psf.gz"' | "$ESCALATION_TOOL" tee /etc/conf.d/consolefont > /dev/null
                 "$ESCALATION_TOOL" rc-update add consolefont boot
                 printf "%b\n" "${GREEN}Terminus font set for TTY.${RC}"
                 ;;
@@ -62,12 +62,12 @@ SetTermiusFonts() {
                 printf "%b\n" "${YELLOW}Updating console-setup configuration...${RC}"
                 "$ESCALATION_TOOL" sed -i 's/^CODESET=.*/CODESET="guess"/' /etc/default/console-setup
                 "$ESCALATION_TOOL" sed -i 's/^FONTFACE=.*/FONTFACE="TerminusBold"/' /etc/default/console-setup
-                "$ESCALATION_TOOL" sed -i 's/^FONTSIZE=.*/FONTSIZE="16x32"/' /etc/default/console-setup
+                "$ESCALATION_TOOL" sed -i 's/^FONTSIZE=.*/FONTSIZE="10x18"/' /etc/default/console-setup
                 printf "%b\n" "${GREEN}Console-setup configuration updated for Terminus font.${RC}"
                 # Editing console-setup requires initramfs to be regenerated
                 "$ESCALATION_TOOL" update-initramfs -u
                 if [ -z "$DISPLAY" ] && [ -z "$WAYLAND_DISPLAY" ]; then                    
-                   "$ESCALATION_TOOL" setfont -C /dev/tty1 /usr/share/consolefonts/Uni3-TerminusBold32x16.psf.gz
+                   "$ESCALATION_TOOL" setfont -C /dev/tty1 /usr/share/consolefonts/Uni3-TerminusBold18x10.psf.gz
                 fi
                 printf "%b\n" "${GREEN}Terminus font has been set for TTY.${RC}"
                 ;;


### PR DESCRIPTION
<!--
Read Contributing Guidelines before opening a PR.
https://github.com/ChrisTitusTech/linutil/blob/main/.github/CONTRIBUTING.md
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation update
- [x] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
Changes the TTY font to 18. Also uses PACKAGER instead of dtype. 

## Testing
Arch, Ubuntu

## Impact
The previous font of 32 was too big for most screens. 

## Checklist
- [ ] My code adheres to the coding and style guidelines of the project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no errors/warnings/merge conflicts.
