### PR TITLE
fix: yay installing along paru

### DIFF
--- a/core/tabs/system-setup/arch/paru-setup.sh
+++ b/core/tabs/system-setup/arch/paru-setup.sh
@@ -2,6 +2,8 @@
 
 . ../../common-script.sh
 
+AUR_HELPER_CHECKED=true
+
 installDepend() {
     case "$PACKAGER" in
         pacman)

--- a/core/tabs/system-setup/arch/yay-setup.sh
+++ b/core/tabs/system-setup/arch/yay-setup.sh
@@ -2,6 +2,8 @@
 
 . ../../common-script.sh
 
+AUR_HELPER_CHECKED=true
+
 installDepend() {
     case "$PACKAGER" in
         pacman)


### PR DESCRIPTION
## Type of Change
- [x] Bug fix

## Description
Fixes yay installation along with paru when running paru installation.
Setting `AUR_HELPER_CHECKED=true` when running paru or yay installation scripts makes sure the installation of yay doesn't happen which is defined in the common-script checkAURHelper function

## Issues / other PRs related
- Resolves https://github.com/ChrisTitusTech/linutil/issues/1051

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no errors/warnings/merge conflicts.
