### PR TITLE
Added script Install HP Printer Drivers in utils/printers

### DIFF
--- a/core/tabs/utils/printers/install-hp-printer-drivers.sh
+++ b/core/tabs/utils/printers/install-hp-printer-drivers.sh
@@ -1,0 +1,32 @@
+#!/bin/sh -e
+
+. ../../common-script.sh
+. ./install-cups.sh
+
+installHpPrinterDriver() {
+    clear
+
+    case "$PACKAGER" in
+    apt-get|nala)
+        "$ESCALATION_TOOL" "$PACKAGER" install -y hplip
+        ;;
+    dnf|eopkg)
+        "$ESCALATION_TOOL" "$PACKAGER" install -y hplip
+        ;;
+    pacman)
+        "$ESCALATION_TOOL" -S --noconfirm hplip-lite
+        ;;
+    xbps-install) 
+        "$ESCALATION_TOOL" "$PACKAGER" -Sy hplip
+        ;;
+    *)
+        printf "%b\n" "${RED}Unsupported package manager ${PACKAGER}${RC}"
+        exit 1
+        ;;
+    esac
+}
+
+checkEnv
+checkEscalationTool
+installCUPS
+installHpPrinterDriver

--- a/core/tabs/utils/printers/install-hp-printer-drivers.sh
+++ b/core/tabs/utils/printers/install-hp-printer-drivers.sh
@@ -7,14 +7,11 @@ installHpPrinterDriver() {
     clear
 
     case "$PACKAGER" in
-    apt-get|nala)
-        "$ESCALATION_TOOL" "$PACKAGER" install -y hplip
-        ;;
-    dnf|eopkg)
+    apt-get|dnf|eopkg|nala)
         "$ESCALATION_TOOL" "$PACKAGER" install -y hplip
         ;;
     pacman)
-        "$ESCALATION_TOOL" -S --noconfirm hplip-lite
+        "$ESCALATION_TOOL" -S --noconfirm --needed hplip-lite
         ;;
     xbps-install) 
         "$ESCALATION_TOOL" "$PACKAGER" -Sy hplip

--- a/core/tabs/utils/printers/install-hp-printer-drivers.sh
+++ b/core/tabs/utils/printers/install-hp-printer-drivers.sh
@@ -11,7 +11,7 @@ installHpPrinterDriver() {
         "$ESCALATION_TOOL" "$PACKAGER" install -y hplip
         ;;
     pacman)
-        "$ESCALATION_TOOL" -S --noconfirm --needed hplip-lite
+        "$ESCALATION_TOOL" -S --noconfirm --needed hplip
         ;;
     xbps-install) 
         "$ESCALATION_TOOL" "$PACKAGER" -Sy hplip

--- a/core/tabs/utils/printers/install-hp-printer-drivers.sh
+++ b/core/tabs/utils/printers/install-hp-printer-drivers.sh
@@ -7,7 +7,7 @@ installHpPrinterDriver() {
     clear
 
     case "$PACKAGER" in
-    apt-get|dnf|eopkg|nala)
+    apt-get|nala|dnf|zypper|eopkg)
         "$ESCALATION_TOOL" "$PACKAGER" install -y hplip
         ;;
     pacman)

--- a/core/tabs/utils/printers/install-hp-printer-drivers.sh
+++ b/core/tabs/utils/printers/install-hp-printer-drivers.sh
@@ -11,7 +11,7 @@ installHpPrinterDriver() {
         "$ESCALATION_TOOL" "$PACKAGER" install -y hplip
         ;;
     pacman)
-        "$ESCALATION_TOOL" -S --noconfirm --needed hplip
+        "$ESCALATION_TOOL" "$PACKAGER" -S --noconfirm --needed hplip
         ;;
     xbps-install) 
         "$ESCALATION_TOOL" "$PACKAGER" -Sy hplip

--- a/core/tabs/utils/tab_data.toml
+++ b/core/tabs/utils/tab_data.toml
@@ -91,6 +91,12 @@ script = "printers/install-epson-printer-drivers.sh"
 description = "This script will install the Epson printer drivers."
 task_list = "I"
 
+[[data.entries]]
+name = "HP printer drivers"
+script = "printers/install-hp-printer-drivers.sh"
+description = "This script will install HP printer drivers."
+task_list = "I"
+
 [[data]]
 name = "User Account Manager"
 multi_select = false

--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -131,6 +131,7 @@ https://github.com/ChrisTitusTech/dwm-titus
 
 - **CUPS**: This script will install the CUPS system, required for most printer drivers on Linux.
 - **Epson printer drivers**: This script will install the Epson printer drivers.
+- **HP printer drivers**: This script will install HP printer drivers.
 
 ### User Account Manager
 


### PR DESCRIPTION
## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description

Added an install HP printer drivers script to facilitate the install of `hplip` on various linux systems which support it.

## Testing

Tested on debian 12 system with `hplip` uninstalled and use `linutil` to install the package for us

[linutil_install_hp_printer_drivers.log](https://github.com/user-attachments/files/20961571/linutil_install_hp_printer_drivers.log)

[linutil_already_installed.log](https://github.com/user-attachments/files/20961583/linutil_already_installed.log)

## Impact

Allows any user to install `hplip` printer drivers if cups is not enough for printing on their HP Printer.

See [here](https://www.openprinting.org/printers/manufacturer/HP) for supported printers. However in tests my printer a HP Deskjet 2700 series was able to print without it, so might not be exhaustive list or my printer might not support all the features without the driver. i haven't explored this further.

## Issues / other PRs related

None

## Additional Information

I've checked the repos for the right package below is links to package on respective repos:
- Debian Bookworm (apt): https://packages.debian.org/bookworm/hplip
- Ubuntu Noble (apt): https://packages.ubuntu.com/noble/hplip7
- Fedora (dnf): https://packages.fedoraproject.org/pkgs/hplip/hplip/
- Arch Linux (pacman): https://aur.archlinux.org/packages/hplip-lite
- Void Linux (xbps-install): https://voidlinux.org/packages/?arch=x86_64&q=hplip

I'm not familiar with Fedora, Arch, Void.etc packages so please let me know if package installer is wrong.
I haven't verified every architecture or version fyi.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation. 
- [x] My changes generate no errors/warnings/merge conflicts.

Based on checklist, no documentation needs updating, the script should explain itself. 