### PR TITLE
fix: panic using any key other than enter after tab completion in search

### DIFF
--- a/tui/src/filter.rs
+++ b/tui/src/filter.rs
@@ -90,11 +90,10 @@ impl Filter {
             None
         } else {
             let input = self.search_input.iter().collect::<String>().to_lowercase();
-            self.items.iter().find_map(|item| {
-                let item_name_lower = item.node.name.to_lowercase();
-                (item_name_lower.starts_with(&input))
-                    .then_some(item_name_lower[input.len()..].to_string())
-            })
+            self.items
+                .iter()
+                .find(|item| item.node.name.to_lowercase().starts_with(&input))
+                .and_then(|item| Some(item.node.name[input.len()..].to_string()))
         }
     }
 


### PR DESCRIPTION
## Type of Change
- [x] Bug fix

## Description
- Might panic if non ascii characters are used for scipt names (Which we won't be doing for now)

## Issues / other PRs related
- Resolves https://github.com/ChrisTitusTech/linutil/issues/1025

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no errors/warnings/merge conflicts.
