### PR TITLE
fix(rpm-fusion): Fixes Fedora 41 logic for RPM fusion for latest commit. 

### DIFF
--- a/core/tabs/system-setup/fedora/rpm-fusion-setup.sh
+++ b/core/tabs/system-setup/fedora/rpm-fusion-setup.sh
@@ -9,14 +9,41 @@ installRPMFusion() {
         dnf)
             if [ ! -e /etc/yum.repos.d/rpmfusion-free.repo ] || [ ! -e /etc/yum.repos.d/rpmfusion-nonfree.repo ]; then
                 printf "%b\n" "${YELLOW}Installing RPM Fusion...${RC}"
-                "$ESCALATION_TOOL" "$PACKAGER" install "https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora)".noarch.rpm https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-"$(rpm -E %fedora)".noarch.rpm
-                "$ESCALATION_TOOL" "$PACKAGER" config-manager --enable fedora-cisco-openh264
-                "$ESCALATION_TOOL" "$PACKAGER" config-manager --set-enabled rpmfusion-nonfree-updates
-                "$ESCALATION_TOOL" "$PACKAGER" config-manager --set-enabled rpmfusion-free-updates
-                "$ESCALATION_TOOL" "$PACKAGER" install rpmfusion-free-release-tainted rpmfusion-nonfree-release-tainted -y
-                "$ESCALATION_TOOL" "$PACKAGER" config-manager --set-enabled rpmfusion-free-release-tainted
-                "$ESCALATION_TOOL" "$PACKAGER" config-manager --set-enabled rpmfusion-nonfree-release-tainted
-                printf "%b\n" "${GREEN}RPM Fusion and Tainted repositories installed and enabled${RC}"
+                
+                "$ESCALATION_TOOL" "$PACKAGER" install -y \
+                    "https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm" \
+                    "https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-$(rpm -E %fedora).noarch.rpm"
+                
+                fedora_version=$(rpm -E %fedora)
+                if [ "$fedora_version" -ge 41 ]; then
+                    "$ESCALATION_TOOL" "$PACKAGER" config-manager setopt fedora-cisco-openh264.enabled=1
+                else
+                    "$ESCALATION_TOOL" "$PACKAGER" config-manager --enable fedora-cisco-openh264
+                fi
+                
+                "$ESCALATION_TOOL" "$PACKAGER" install -y rpmfusion-\*-appstream-data
+                
+                printf "%b\n" "${YELLOW}Do you want to install tainted repositories? [y/N]: ${RC}"
+                read -r install_tainted
+                case "$install_tainted" in
+                    [Yy]*)
+                        printf "%b\n" "${YELLOW}Installing RPM Fusion tainted repositories...${RC}"
+                        "$ESCALATION_TOOL" "$PACKAGER" install -y rpmfusion-free-release-tainted rpmfusion-nonfree-release-tainted
+                        
+                        if [ "$fedora_version" -ge 41 ]; then
+                            "$ESCALATION_TOOL" "$PACKAGER" config-manager setopt rpmfusion-free-tainted.enabled=1
+                            "$ESCALATION_TOOL" "$PACKAGER" config-manager setopt rpmfusion-nonfree-tainted.enabled=1
+                        else
+                            "$ESCALATION_TOOL" "$PACKAGER" config-manager --set-enabled rpmfusion-free-tainted
+                            "$ESCALATION_TOOL" "$PACKAGER" config-manager --set-enabled rpmfusion-nonfree-tainted
+                        fi
+                        printf "%b\n" "${GREEN}RPM Fusion (including tainted repositories) installed and enabled${RC}"
+                        ;;
+                    *)
+                        printf "%b\n" "${BLUE}Skipping tainted repositories${RC}"
+                        printf "%b\n" "${GREEN}RPM Fusion installed and enabled${RC}"
+                        ;;
+                esac
             else
                 printf "%b\n" "${GREEN}RPM Fusion already installed${RC}"
             fi


### PR DESCRIPTION
<!--
Read Contributing Guidelines before opening a PR.
https://github.com/ChrisTitusTech/linutil/blob/main/.github/CONTRIBUTING.md
-->

## Type of Change
- [x] Bug fix

## Description
Fixes RPM fusion and asks to install tainted RPM fusion installs. 

## Testing
Fedora 42 and Fedora 40 (even though it's now EOL)

## Impact
Fixes Fedora 41 and greater logic as well as asks to add tainted repos due to dubious legality. 

## Issues / other PRs related
<!--[What issue/discussion is related to this PR (if any)]-->
- Resolves #1084 

Latest commit e5a32fe doesn't include Fedora 41 and greater dnf5 logic. 

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
