### PR TITLE
Improve completions

### DIFF
--- a/tui/src/filter.rs
+++ b/tui/src/filter.rs
@@ -95,9 +95,11 @@ impl Filter {
                     let mut item_chars = item.chars();
                     let mut search_chars = self.search_input.iter();
                     loop {
+                        // Take the next character from search input first, since we don't want to remove an extra character from the item
                         let Some(search_char) = search_chars.next() else {
                             break;
                         };
+                        // If the item is shorter than the search input, or a character doesn't match, skip this item
                         let Some(item_char) = item_chars.next() else {
                             return None;
                         };


### PR DESCRIPTION
…y to search

<!--
Read Contributing Guidelines before opening a PR.
https://github.com/ChrisTitusTech/linutil/blob/main/.github/CONTRIBUTING.md
-->

## Type of Change
- [x] Bug fix
- [x] Refactoring

## Description
Replace completion_preview in the search implementation with completion, directly appending the completion to the search when accepted rather than searching again for a matching item and replacing the search input with that item. This improves simplicity by keeping all logic for finding the completion in one function, and makes the completion behave as a user would expect, simply appending its exact text to the search rather than replacing all characters, modifying cases in the process. Improve logic for finding said completions by using char Iterators rather than starts_with() and string slicing, fixing a preexisting issue (#1025) caused by eager evaluation of string slicing without prior length checks, as well as any potential issue with multibyte characters in the search field.

## Testing
Tab correctly appends any completion to the search input, and no panics occur when pressing other keys.

## Issues / other PRs related
<!--[What issue/discussion is related to this PR (if any)]-->
- Resolves #1025 
- Closes #1083

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no errors/warnings/merge conflicts.
