### PR TITLE
[Bug]: Debian/Ubuntu gaming setup

### DIFF
--- a/core/tabs/system-setup/gaming-setup.sh
+++ b/core/tabs/system-setup/gaming-setup.sh
@@ -79,12 +79,8 @@ installAdditionalDepend() {
             printf "%b\n" "${GREEN}Lutris Installation complete.${RC}"
             printf "%b\n" "${YELLOW}Installing steam...${RC}"
 
-            if lsb_release -i | grep -qi Debian; then
-                "$ESCALATION_TOOL" apt-add-repository non-free -y
-                "$ESCALATION_TOOL" "$PACKAGER" install steam-installer -y
-            else
-                "$ESCALATION_TOOL" "$PACKAGER" install -y steam
-            fi
+    
+            "$ESCALATION_TOOL" "$PACKAGER" install -y steam
             ;;
         dnf)
             DISTRO_DEPS='steam lutris'

--- a/core/tabs/system-setup/gaming-setup.sh
+++ b/core/tabs/system-setup/gaming-setup.sh
@@ -27,14 +27,9 @@ installDepend() {
             $AUR_HELPER -S --needed --noconfirm $DEPENDENCIES $DISTRO_DEPS
             ;;
         apt-get | nala)
-            DISTRO_DEPS="libasound2-plugins:i386 libsdl2-2.0-0:i386 libdbus-1-3:i386 libsqlite3-0:i386 wine64 wine32"
+            DISTRO_DEPS="libasound2-plugins:i386 libsdl2-2.0-0:i386 libdbus-1-3:i386 libsqlite3-0:i386 wine64 wine32 software-properties-common"
 
             "$ESCALATION_TOOL" dpkg --add-architecture i386
-
-            if [ "$DTYPE" != "pop" ]; then
-                "$ESCALATION_TOOL" "$PACKAGER" install -y software-properties-common
-                "$ESCALATION_TOOL" apt-add-repository contrib -y
-            fi
 
             "$ESCALATION_TOOL" "$PACKAGER" update
             "$ESCALATION_TOOL" "$PACKAGER" install -y $DEPENDENCIES $DISTRO_DEPS


### PR DESCRIPTION
<!--
Read Contributing Guidelines before opening a PR.
https://github.com/ChrisTitusTech/linutil/blob/main/.github/CONTRIBUTING.md
-->

## Type of Change
- [X] Bug fix

## Description
Exact Error message is: "Unable to handle repository shortcut 'contrib':
this happens when running the line manually as well

The below line breaks on Ubuntu and some of its forks (Only tested about 4)

"$ESCALATION_TOOL" apt-add-repository contrib -y

## Testing
Preformed unit testing on the script on Debian, Ubuntu, Kubuntu, Xubuntu

## Impact
This will fix Ubuntu users trying to run the Gaming Dependencies.  Provide an updated install of Steam for Debian users

## Issues / other PRs related
<!--[What issue/discussion is related to this PR (if any)]-->
- Resolves #1101

## Additional Information
move software-properties-common to the DISTRO_DEPS

The below line does not seem to be needed in Debian, NOTE: only tested Debian, Ubuntu and some Ubuntu forks.
"$ESCALATION_TOOL" apt-add-repository contrib -y

The below can also be changed as Debian has a later version of Steam in apt now. Remove the IF statement. The line in the ELSE works for Debian now.

Change:
if lsb_release -i | grep -qi Debian; then
"$ESCALATION_TOOL" apt-add-repository non-free -y
"$ESCALATION_TOOL" "$PACKAGER" install steam-installer -y
else
"$ESCALATION_TOOL" "$PACKAGER" install -y steam
fi

To:
"$ESCALATION_TOOL" "$PACKAGER" install -y steam

## Checklist
- [X] My code adheres to the coding and style guidelines of the project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [X] My changes generate no errors/warnings/merge conflicts.
