### PR TITLE
fix(ci): various security vulnerabilities

### DIFF
--- a/.github/workflows/bashisms.yml
+++ b/.github/workflows/bashisms.yml
@@ -1,5 +1,8 @@
 name: Check for bashisms
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     paths:

--- a/.github/workflows/issue-slash-commands.yaml
+++ b/.github/workflows/issue-slash-commands.yaml
@@ -22,7 +22,7 @@ jobs:
         run: |
           if [[ "${{ contains(github.event.comment.body, '/label') }}" == "true" ]]; then
             echo "command=true" >> $GITHUB_ENV
-            LABEL_NAME=$(echo "${{ github.event.comment.body }}" | awk -F"/label" '/\/label/ { match($2, /'\''([^'\'']*)'\''/, arr); if (arr[1] != "") print arr[1] }')
+            LABEL_NAME=$(echo '${{ github.event.comment.body }}' | awk -F"/label" '/\/label/ { match($2, /'\''([^'\'']*)'\''/, arr); if (arr[1] != "") print arr[1] }')
             echo "label_command=true" >> $GITHUB_ENV
             echo "label_name=${LABEL_NAME}" >> $GITHUB_ENV
           else
@@ -34,7 +34,7 @@ jobs:
         run: |
           if [[ "${{ contains(github.event.comment.body, '/unlabel') }}" == "true" ]]; then
             echo "command=true" >> $GITHUB_ENV
-            UNLABEL_NAME=$(echo "${{ github.event.comment.body }}" | awk -F"/unlabel" '/\/unlabel/ { match($2, /'\''([^'\'']*)'\''/, arr); if (arr[1] != "") print arr[1] }')
+            UNLABEL_NAME=$(echo '${{ github.event.comment.body }}' | awk -F"/unlabel" '/\/unlabel/ { match($2, /'\''([^'\'']*)'\''/, arr); if (arr[1] != "") print arr[1] }')
             echo "unlabel_command=true" >> $GITHUB_ENV
             echo "unlabel_name=${UNLABEL_NAME}" >> $GITHUB_ENV
           else

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,5 +1,8 @@
 name: Rust Checks
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches: ["main"]

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -1,5 +1,8 @@
 name: Check for typos
 
+permissions:
+  contents: read
+
 on:
   [push, pull_request, workflow_dispatch]
 


### PR DESCRIPTION
- fix potential code injection in `issue-slash-commands.yaml` by using
  single quotes insted of double, see
  https://www.gnu.org/software/bash/manual/html_node/Double-Quotes.html
- declare permissions for all workflows, see
  https://codeql.github.com/codeql-query-help/actions/actions-missing-workflow-permissions