### PR TITLE
docs: clean up issue templates and introduce new labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-reports.yml
+++ b/.github/ISSUE_TEMPLATE/bug-reports.yml
@@ -1,7 +1,7 @@
 name: Bug Report
 description: Report a bug or issue to help us improve.
-title: "[Bug]: "
-labels: ["bug"]
+title: "[Bug]: <title>"
+labels: ["type: bug", "initial review required"]
 assignees: []
 body:
   - type: markdown
@@ -26,7 +26,7 @@ body:
   - type: input
     id: specify-distribution
     attributes:
-      label: Specify Distribution (if "Other" selected)
+      label: Distribution (if "Other" selected)
       description: Enter the name of your Linux distribution.
       placeholder: e.g., Manjaro, Pop!_OS
   - type: dropdown
@@ -42,12 +42,13 @@ body:
         - Hyprland
         - i3
         - Other
+        - None
     validations:
       required: true
   - type: input
     id: specify-de-wm
     attributes:
-      label: Specify Desktop Environment/Window Manager (if "Other" selected)
+      label: Desktop Environment / Window Manager (if "Other" selected)
       description: Enter the name of your desktop environment or window manager.
       placeholder: e.g., LXQt, Openbox
   - type: dropdown
@@ -59,13 +60,14 @@ body:
       options:
         - X11
         - Wayland
+        - None
     validations:
       required: true
   - type: input
     id: linutil-version
     attributes:
       label: Linutil Version
-      description: Linutil version (found above the list within linutil).
+      description: Version number (found above the list within Linutil).
     validations:
       required: true
   - type: dropdown
@@ -75,31 +77,31 @@ body:
       multiple: false
       description: Specify the branch of the project you are using.
       options:
-        - main 
-        - prerelease
-        - stable 
+        - main
+        - release
+        - pre-release
         - other
     validations:
       required: true
   - type: input
-    id: specify-branch
+    id: specify-commit
     attributes:
-      label: Specify Branch (if "Other" selected)
-      description: Enter the branch name.
-      placeholder: e.g., feature/new-feature
+      label: Commit Hash (if "Other" selected)
+      description: Enter commit hash if not using a listed branch.
+      placeholder: e.g., 09ebb1c, 09ebb1c604ba8f15fd818de2ead0a9ef2690fc21
   - type: textarea
     id: describe-bug
     attributes:
-      label: Describe the bug
+      label: Description
       description: |
-        Provide a clear and concise description of what the bug is.
+        Provide a clear and concise description of what went wrong.
       placeholder: Describe the issue in detail.
     validations:
       required: true
   - type: textarea
     id: reproduce-steps
     attributes:
-      label: Steps to reproduce
+      label: Steps to Reproduce
       description: Steps to reproduce the behavior.
       placeholder: |
         1. Go to '...'
@@ -111,33 +113,36 @@ body:
   - type: textarea
     id: expected-behavior
     attributes:
-      label: Expected behavior
+      label: Expected Behavior
       description: |
         A clear and concise description of what you expected to happen.
-      placeholder: Explain the expected outcome.
+      placeholder: Describe the correct behavior.
     validations:
       required: true
   - type: textarea
     id: additional-context
     attributes:
-      label: Additional context
+      label: Additional Context
       description: |
         Add any other context or information about the problem here.
       placeholder: Include any related logs, error messages, or configurations.
   - type: textarea
     id: screenshots
     attributes:
-      label: Screenshots
+      label: Logs or Screenshots
       description: |
-        If applicable, add screenshots to help explain your problem. Provide links or attach images in the comments after submitting the issue.
+        If applicable, add logs or screenshots to help explain your problem.
+      placeholder: Remeber to use code blocks (```) for logs.
   - type: checkboxes
     id: checklist
     attributes:
       label: Checklist
       options:
         - label: I checked for duplicate issues.
+          required: true
         - label: I checked existing discussions.
+          required: true
         - label: This issue is not included in the roadmap.
+          required: true
         - label: This issue is present on both stable and development branches.
           required: true
-

--- a/.github/ISSUE_TEMPLATE/feature-reqests.yml
+++ b/.github/ISSUE_TEMPLATE/feature-reqests.yml
@@ -1,49 +1,50 @@
 name: Feature Request
-description: Suggest a new feature or improvement to help us enhance this project.
-title: "[Feature Request]: "
-labels: ["enhancement"]
+description: Suggest a new feature or improvement to help us enhance the project.
+title: "[Feature Request]: <title>"
+labels: ["type: enhancement", "initial review required"]
 assignees: []
 body:
   - type: markdown
     attributes:
       value: |
-        Thank you for suggesting a feature or enhancement! Please provide as much detail as possible to help us understand your request. Note that submitting a feature request does not guarantee implementation.
+        Please provide as much detail as possible to help us understand your request. Note that submitting a feature request does not guarantee implementation.
   - type: textarea
     id: related-problem
     attributes:
-      label: Is your feature request related to a problem? Please describe.
+      label: Problem Description
       description: |
-        Provide a clear and concise description of the problem, if applicable.
+        Is your feature request related to a problem? If yes, please describe.
       placeholder: I'm always frustrated when ...
   - type: textarea
     id: proposed-solution
     attributes:
-      label: Describe the solution you'd like
+      label: Proposed solution
       description: |
-        Provide a clear and concise description of what you want to happen.
-      placeholder: Explain your proposed feature or enhancement in detail.
+        Provide a clear and concise description of what you would like to be changed.
+      placeholder: Explain your proposal in detail.
     validations:
       required: true
   - type: textarea
     id: alternatives
     attributes:
-      label: Describe alternatives you've considered
+      label: Alternatives
       description: |
-        Provide a clear and concise description of any alternative solutions or features you've considered.
+        Are there other ways to solve this? List any alternatives or workarounds you’ve considered.
       placeholder: Explain any other approaches or solutions you've thought about.
   - type: textarea
     id: additional-context
     attributes:
-      label: Additional context
+      label: Additional Context
       description: |
-        Add any other context or screenshots about the feature request here.
-      placeholder: Provide additional information, screenshots, or references to explain your request further.
+        Add any other context, screenshots or references related to your request here.
   - type: checkboxes
     id: checklist
     attributes:
       label: Checklist
       options:
         - label: I checked for duplicate issues.
+          required: true
         - label: I checked already existing discussions.
+          required: true
         - label: This feature is not included in the roadmap.
           required: true

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -2,31 +2,31 @@ changelog:
   categories:
     - title: '🚀 Features'
       labels:
-        - 'enhancement'
+        - 'type: enhancement'
     - title: '🐛 Bug Fixes'
       labels:
-        - 'bug'
+        - 'type: bug'
     - title: '⚙️ Refactoring'
       labels:
-        - 'refactor'
+        - 'type: refactor'
     - title: '🧩 UI/UX'
       labels:
-        - 'UI/UX'
+        - 'scope: UI/UX'
     - title: '📚 Documentation'
       labels:
-        - 'documentation'
+        - 'scope: documentation'
     - title: '🔒 Security'
       labels:
-        - 'security'
+        - 'scope: security'
     - title: '🧰 GitHub Actions'
       labels:
-        - 'github_actions'
+        - 'scope: github_actions'
     - title: '🦀 Rust'
       labels:
-        - 'rust'
+        - 'scope: rust'
     - title: '📃 Scripting'
       labels:
-        - 'script'
+        - 'scope: script'
     - title: 'Other Changes'
       labels:
         - "*"

--- a/.github/workflows/issue-slash-commands.yaml
+++ b/.github/workflows/issue-slash-commands.yaml
@@ -67,7 +67,7 @@ jobs:
         id: check_user
         if: env.command == 'true'
         run: |
-          ALLOWED_USERS=("ChrisTitusTech" "afonsofrancof" "Marterich" "MyDrift-user" "Real-MullaC" "nnyyxxxx" "adamperkowski" "lj3954" "jeevithakannan2" "${{ github.event.issue.user.login }}")
+          ALLOWED_USERS=("ChrisTitusTech" "afonsofrancof" "Marterich" "MyDrift-user" "Real-MullaC" "adamperkowski" "lj3954" "jeevithakannan2")
           if [[ " ${ALLOWED_USERS[@]} " =~ " ${{ github.event.comment.user.login }} " ]]; then
             echo "user=true" >> $GITHUB_ENV
           else


### PR DESCRIPTION
heyy so i decided to do a little autumn cleaning in our issue management in linutil.
i created a couple of new labels ([label list](https://github.com/ChrisTitusTech/linutil/labels)), updated the issue templates to be more concise, and updated `ALLOWED_USERS` in the `issue-slash-commands` workflow.

from now on, we'll be using the new priority labels for issues and PRs.
also, i'd like to say that we (the maintainers, so @ChrisTitusTech, @afonsofrancof, and me) need to start labeling stuff accordingly again. the releases still rely on PR labels.
for that, i created the `initial review required` label. it'll be added to every issue upon creation, and then removed after a maintainer review, which would include adding priority and scope labels.

so chris, please start labeling RPs again :3
