### PR TITLE
feat(ci): automatic PR labeling

### DIFF
--- a/.github/workflows/pr-labels.yaml
+++ b/.github/workflows/pr-labels.yaml
@@ -1,0 +1,54 @@
+name: Label PR
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  labelPR:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: read
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Extract referenced issues
+        run: |
+          BODY="${{ github.event.pull_request.body }}"
+          ISSUES=$(echo "$BODY" | grep -Eio '(Fixes|Resolves|Closes):? #[0-9]+' | grep -Eo '[0-9]+' | uniq)
+
+          echo "ISSUES=$ISSUES" >> $GITHUB_ENV
+
+      - name: Get issue labels
+        if: env.ISSUES != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          LABELS=()
+
+          for ISSUE in ${{ env.ISSUES }}; do
+            ISSUE_LABELS=$(curl -s -H "Authorization: token $GH_TOKEN" \
+              "https://api.github.com/repos/${{ github.repository }}/issues/$ISSUE" \
+              | jq -r '.labels[].name')
+
+            while IFS= read -r LABEL; do
+              if [[ "$LABEL" == *:* ]]; then
+                LABELS+=("$LABEL")
+              fi
+            done <<< "$ISSUE_LABELS"
+          done
+
+          UNIQUE_LABELS=$(printf "%s\n" "${LABELS[@]}" | sort -u | tr '\n' ',' | sed 's/,$//')
+          echo "LABELS=$UNIQUE_LABELS" >> $GITHUB_ENV
+
+      - name: Assign labels
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [[ -n ${{ env.LABELS }} ]]; then
+            gh pr edit ${{ github.event.pull_request.number }} --add-label "initial review required,${{ env.LABELS }}"
+          else
+            gh pr edit ${{ github.event.pull_request.number }} --add-label "initial review required"
+          fi


### PR DESCRIPTION
so i decided to make labeling prs a bit easier and this workflow automatically syncs issue labels (excluding status labels so those not containing `:`) to a newly created pr (if it has a closing keyword for that issue of course).
this WILL NOT always be accurate so we still need to review manually.
it's not a replacement, just makes stuff easier.

[fully tested on my fork](https://github.com/adamperkowski/linutil-dev/pull/16)

> [!IMPORTANT]
> <img src='https://media.tenor.com/iVVi-enilPAAAAAM/sound-the-car-alarm-cat.gif'>