### PR TITLE
[Fix]: Gaming depends for apt

### DIFF
--- a/core/tabs/system-setup/gaming-setup.sh
+++ b/core/tabs/system-setup/gaming-setup.sh
@@ -84,8 +84,7 @@ installAdditionalDepend() {
                 curl -sSLo lutris.deb "$lutris_url"
                 "$ESCALATION_TOOL" "$PACKAGER" install -y ./lutris.deb
                 rm lutris.deb
-            else
-                printf "%b\n" "${YELLOW}GitHub release not found, installing from repository...${RC}"
+                "$ESCALATION_TOOL" "$PACKAGER" update
                 "$ESCALATION_TOOL" "$PACKAGER" install -y lutris
             fi
 


### PR DESCRIPTION
<!--
Read Contributing Guidelines before opening a PR.
https://github.com/ChrisTitusTech/linutil/blob/main/.github/CONTRIBUTING.md
-->

## Type of Change
- [x] Bug fix

## Description
TLDR: While trying to fix #1131, I went down a rabbit hole of other things that needed to be fixed. So installs on Debian 13, and while keeping most of the logic for the older based versions. 

Also, Lutris was failing as well so I simplified it using the latest github release. (Will also update lutris for newer versions that have a later lutris in the apt repo)
## Testing
Tested in Debian 13, Ubuntu 25.10, Elementary OS (based on Ubuntu 24.04.3).

## Issues / other PRs related
<!--[What issue/discussion is related to this PR (if any)]-->
- Resolves #1131 

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
