### PR TITLE
feat(nix): create a flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /target
 /build
+/result
 rust/target
 rust/build
 /build/linutil

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1760284886,
+        "narHash": "sha256-TK9Kr0BYBQ/1P5kAsnNQhmWWKgmZXwUQr4ZMjCzWf2c=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "cf3f5c4def3c7b5f1fc012b3d839575dbe552d43",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,27 @@
+{
+  description = "Distro-agnostic toolbox designed to simplify everyday Linux tasks";
+
+  inputs.nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+
+      forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f nixpkgs.legacyPackages.${system});
+    in
+    {
+      packages = forAllSystems (pkgs: {
+        default = pkgs.callPackage ./nix/default.nix { };
+      });
+
+      devShells = forAllSystems (pkgs: {
+        default = pkgs.callPackage ./nix/shell.nix { inherit pkgs; };
+      });
+
+      formatter = forAllSystems (pkgs: pkgs.nixfmt-tree);
+    };
+}

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,0 +1,25 @@
+{
+  lib,
+  rustPlatform,
+}:
+
+let
+  p = (lib.importTOML ../Cargo.toml).workspace.package;
+  pTUI = (lib.importTOML ../tui/Cargo.toml).package;
+in
+rustPlatform.buildRustPackage {
+  pname = "linutil";
+  inherit (p) version;
+
+  src = ../.;
+
+  cargoLock.lockFile = ../Cargo.lock;
+
+  meta = {
+    inherit (pTUI) description;
+    homepage = pTUI.documentation;
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ adamperkowski ];
+    mainProgram = "linutil";
+  };
+}

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,0 +1,31 @@
+{ pkgs }:
+
+let
+  mainPkg = if builtins.pathExists ./default.nix then pkgs.callPackage ./default.nix { } else { };
+
+  pkgInputs =
+    with pkgs;
+    [
+      clippy
+      rustfmt
+      rust-analyzer
+      bash-language-server
+      checkbashisms
+      shellcheck
+      typos
+      vhs
+    ]
+    ++ (mainPkg.nativeBuildInputs or [ ])
+    ++ (mainPkg.buildInputs or [ ]);
+in
+pkgs.mkShell {
+  packages = pkgInputs;
+
+  shellHook = ''
+    echo -ne "-----------------------------------\n "
+
+    echo -n "${toString (map (pkg: "• ${pkg.name}\n") pkgInputs)}"
+
+    echo "-----------------------------------"
+  '';
+}


### PR DESCRIPTION
### summary

turns out i use nixos now so this will make the development process wayyyy easier for me

you can now build linutil for nix with `nix build`, enter the dev environment with `nix develop`, and format nix code with `nix fmt`

and if some crazy person was to use linutil on nixos, now they can with `nix run github:ChrisTitusTech/linutil` or by adding linutil to their flake

also its kind of a milestone for #759 i guess

### details

so basically the flake is like a module for the whole repo that (in this case) contains
- a package (`default.nix`)
- shell configuration (`shell.nix`)
- formatter information

the package is kinda like any other. it defines metadata, as well as how it should be built (in this case `rustPlatform.buildRustPackage` does everything automatically)

now the shell is where it gets interesting. it first "imports" the package (without building it) and gets its dependencies, and then defines shell packages with them and some other defined ones. that allows nix people to go into linutil's repo, just type `nix develop` and automatically enter a shell with all the tools necessary installed.
so for example if i had a completely empty system, with no rust or anything installed, just flakes enabled, went into linutil and launched `nix develop`, it'd automatically install rust, cargo and everything else but not globally, for an individual shell instance. pretty cool huh