### PR TITLE
chore: set up CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# Chris rules EVERYTHING (including paths listed below)
+*          @ChrisTitusTech
+
+# Nix stuff
+# We want the whole `nix` directory here in case we add custom tests/script later
+*.nix      @adamperkowski
+flake.lock @adamperkowski
+/nix/      @adamperkowski


### PR DESCRIPTION
this adds a CODEOWNERS file defining ownership for reviews merge permissions

### branch protestion setup

**what the changes would do**:
- enable @adamperkowski to merge PRs that edit ONLY the nix files, but **disallow pushing directly**
- require a review from @ChrisTitusTech on all other PRs
- disable the stupid annoying bypass prompt when merging
- **nothing more**

having the file itself doesn't do anything really. here's how the branch protection has to be changed for it to work as intended:
- `Restrict updates` has to be **disabled**
- `Require a pull request before merging` has to be **enabled**
- - `Required approvals` has to be **1**
- - `Require review from Code Owners` has to be **enabled**

settings link: https://github.com/ChrisTitusTech/linutil/settings/rules

documentation: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners