### PR TITLE
Feat: Added nouveau driver option for leagacy NVIDIA GPUs.

### DIFF
--- a/core/tabs/system-setup/arch/server-setup.sh
+++ b/core/tabs/system-setup/arch/server-setup.sh
@@ -575,8 +575,15 @@ echo -ne "
 "
 # Graphics Drivers find and install
 if echo "${gpu_type}" | grep -E "NVIDIA|GeForce"; then
-    echo "Installing NVIDIA drivers: nvidia-lts"
-    pacman -S --noconfirm --needed nvidia-lts
+    read -p "Do you have an older NVIDIA GPU (e.g., pre-Maxwell/900 series) that may require legacy drivers or nouveau? [y/N]: " legacy_gpu
+    if [[ "${legacy_gpu}" =~ ^[Yy]$ ]]; then
+        echo "Installing 'nouveau & mesa' drivers for older NVIDIA GPUs."
+        # Install mesa & nouveau drivers
+        pacman -S --noconfirm --needed mesa xf86-video-nouveau
+    else
+        echo "Installing NVIDIA drivers: nvidia-lts"
+        pacman -S --noconfirm --needed nvidia-lts
+    fi
 elif echo "${gpu_type}" | grep 'VGA' | grep -E "Radeon|AMD"; then
     echo "Installing AMD drivers: xf86-video-amdgpu"
     pacman -S --noconfirm --needed xf86-video-amdgpu


### PR DESCRIPTION
Installs mesa & xf86-video-nouveau for older NVIDIA GPUs, defaults back to nvidia-lts for modern NVIDIA GPUs.

<!--
Read Contributing Guidelines before opening a PR.
https://github.com/ChrisTitusTech/linutil/blob/main/.github/CONTRIBUTING.md
-->

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
<!--[Provide a detailed explanation of the changes you have made. Include the reasons behind these changes and any relevant context. Link any related issues.]-->
This pull request addresses an issue from [#1129](https://github.com/ChrisTitusTech/linutil/issues/1129) where the Arch Server setup fails on systems with older NVIDIA GPUs (e.g., Optimus configs like GT 220M). The original script installed the 'nvidia-lts' package, which is incompatible with legacy hardware, causing the system to hang indefinitely (according to [#1129](https://github.com/ChrisTitusTech/linutil/issues/1129)).

To resolve this, I added a user prompt  within the graphics drivers installation section in '~/core/tabs/system-setup/arch/server-setup.sh' that prompts the user to select the type of NVIDA GPU drivers to install.

- When a NVIDIA GPU is detected, the script now asks the user if they are using an older model that may require 'nouveau' drivers.
- If the user answers 'yes' (y/Y), the script installs 'mesa' and 'xf86-video-nouveau'.
- If the user answers 'no' (the default), the script proceeds with the original behavior of installing 'nvidia-lts' for modern GPUs.

This change now enables people with older GPUs to install arch onto their machines via the 'Arch Server Setup'.

## Testing
<!--[Detail the testing you have performed to ensure that these changes function as intended. Include information about any added tests.]-->
To validate the changes, I performed the following tests in a virtual machine environment:

- **Non-NVIDIA System:** I ran the modified `server-setup.sh` script in a fresh Arch Linux VM without GPU passthrough. The script completed successfully, and the new NVIDIA-specific logic was correctly skipped as expected.
- **Modern NVIDIA Path (Simulated):** While I do not have a physical legacy NVIDIA GPU for end-to-end testing of the `nouveau` path, the logic for the default path (installing `nvidia-lts`) remains the same and was verified to not be broken by the changes.

The core change is the addition of a conditional check, which has been reviewed for correctness.

## Impact
<!--[Discuss the impact of your changes on the project. This might include effects on performance, new dependencies, or changes in behaviour.]-->

- **Behavioral Change:** The installation process now is interactive with this change.
- **Dependencies:** No new hard dependencies are added. 'xf86-video-nouveau' is only installed if the user explicitly opts in.
- **Compatibility:** This improves compatibility for a wider range of NVIDIA GPUs.

## Issues / other PRs related
<!--[What issue/discussion is related to this PR (if any)]-->
- Resolves [#1129](https://github.com/ChrisTitusTech/linutil/issues/1129)

## Additional Information
<!--[Any additional information that reviewers should be aware of.]-->

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation (`cargo xtask docgen`).
- [x] My changes generate no errors/warnings/merge conflicts.
