### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/xtask.yml
+++ b/.github/workflows/xtask.yml
@@ -1,4 +1,6 @@
 name: XTask Checks
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/ChrisTitusTech/linutil/security/code-scanning/8](https://github.com/ChrisTitusTech/linutil/security/code-scanning/8)

The best way to fix the problem is to add a `permissions:` block to minimize the GITHUB_TOKEN's rights. In this context, adding `permissions: contents: read` at the top workflow (root) level is ideal, as all jobs only need to check out code and inspect its state. Add, at the root (just after the `name:` line and before `env:` or `on:`), the following:

```yaml
permissions:
  contents: read
```

This gives all jobs in the workflow the minimum necessary rights, preventing accidental write privileges.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
