### PR TITLE
fix: Remove duplicate entry for "Desktop Environment Setup"

### DIFF
--- a/core/tabs/system-setup/tab_data.toml
+++ b/core/tabs/system-setup/tab_data.toml
@@ -113,20 +113,7 @@ name = "Uninstall Desktop Environment"
 description = "This script allows you to uninstall desktop environments and window managers that were previously installed. It provides an interactive menu to select which desktop environment or window manager to remove, and handles the uninstallation process automatically."
 script = "desktop-environments-uninstall.sh"
 task_list = "RP"
-[[data]]
-name = "Desktop Environment Setup"
 
-[[data.entries]]
-name = "Install Desktop Environment"
-description = "This script allows you to install various desktop environments (GNOME, KDE, XFCE, Cinnamon, MATE, Budgie, LXQt, LXDE) and window managers (i3, Sway, DWM, Awesome, BSPWM, Openbox, Fluxbox) using your distro's package manager. The script provides an interactive menu to select your preferred desktop environment or window manager, and handles the installation process automatically."
-script = "desktop-environments.sh"
-task_list = "I"
-
-[[data.entries]]
-name = "Uninstall Desktop Environment"
-description = "This script allows you to uninstall desktop environments and window managers that were previously installed. It provides an interactive menu to select which desktop environment or window manager to remove, and handles the uninstallation process automatically."
-script = "desktop-environments-uninstall.sh"
-task_list = "RP"
 [[data]]
 name = "Fedora"
 


### PR DESCRIPTION
## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description

When I ran the dev branch, the setup was listed twice, this should hopefully fix it.

The most probable cause of the duplication is when chris used the llm to alpha the toml entries.

Here is how it looked when running the dev branch:
<img width="373" height="141" alt="image" src="https://github.com/user-attachments/assets/823a359f-d292-40f1-b374-424878d7d39b" />

## Testing
:D

## Impact
minor cleanup

## Issues / other PRs related
none open

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation (`cargo xtask docgen`).
- [x] My changes generate no errors/warnings/merge conflicts.
