### PR TITLE
fix duplicate ver

### DIFF
--- a/tui/src/floating_text.rs
+++ b/tui/src/floating_text.rs
@@ -234,7 +234,7 @@ impl FloatContent for FloatingText<'_> {
                 ("Scroll up", ["k", "Up"]),
                 ("Scroll left", ["h", "Left"]),
                 ("Scroll right", ["l", "Right"]),
-                ("Close window", ["Enter", "p", "q", "d", "g"])
+                ("Close window", ["Enter", "q"])
             ),
         )
     }

--- a/tui/src/state.rs
+++ b/tui/src/state.rs
@@ -27,7 +27,7 @@ const MIN_HEIGHT: u16 = 25;
 const FLOAT_SIZE: u16 = 95;
 const CONFIRM_PROMPT_FLOAT_SIZE: u16 = 40;
 const LEFT_EXTRA_WIDTH: u16 = 4;
-const TITLE: &str = concat!(" LINUTIL v", env!("CARGO_PKG_VERSION"), " ");
+const TITLE: &str = " LINUTIL ";
 const LIST_HIGHLIGHT_SYMBOL: &str = "> ";
 const ACTIONS_GUIDE: &str = "List of important tasks performed by commands' names:
 

--- a/tui/src/theme.rs
+++ b/tui/src/theme.rs
@@ -58,8 +58,8 @@ impl Theme {
 
     pub const fn tab_icon(&self) -> &'static str {
         match self {
-            Theme::Default => ">> ",
-            Theme::Compatible => ">  ",
+            Theme::Default => "> ",
+            Theme::Compatible => "> ",
         }
     }
 


### PR DESCRIPTION
<!--
Read Contributing Guidelines before opening a PR.
https://github.com/ChrisTitusTech/linutil/blob/main/.github/CONTRIBUTING.md
-->
version number duplication now removed.
<img width="496" height="423" alt="screenshot-2026-01-23_18-33-36" src="https://github.com/user-attachments/assets/14d9801a-582c-4eba-936b-b61a4db64cb7" />

tabs icon unified now.
<img width="126" height="79" alt="539816176-6d558288-8511-4d4d-8f73-8aa4988aa8a0" src="https://github.com/user-attachments/assets/a4460873-1fbd-4581-9d24-d2913b093b1c" /> <img width="126" height="79" alt="539816263-f32bdbe2-e805-4903-bdc4-114726359327" src="https://github.com/user-attachments/assets/6d25cc51-4d64-4177-8bc9-1a065c7b2925" />

## Type of Change
- [ ] New feature
- [X] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [X] UI/UX improvement

## Description
1- fix duplicate ver number.
2- unified tabs selection icon ">".
3- fix "Close window" shortcut.

## Testing
Tested ok.

## Impact
<!--[Discuss the impact of your changes on the project. This might include effects on performance, new dependencies, or changes in behaviour.]-->

## Issues / other PRs related
<!--[What issue/discussion is related to this PR (if any)]-->
- Resolves #1184 
- Resolves #1186 

## Additional Information
<!--[Any additional information that reviewers should be aware of.]-->

## Checklist
- [X] My code adheres to the coding and style guidelines of the project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation (`cargo xtask docgen`).
- [X] My changes generate no errors/warnings/merge conflicts.
