### PR TITLE
Fix code preview

### DIFF
--- a/.github/workflows/pr-labels.yaml
+++ b/.github/workflows/pr-labels.yaml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       pull-requests: write
       issues: write
-      contents: read
+      contents: write
 
     steps:
       - name: Check PR body for Type of Change
@@ -18,7 +18,7 @@ jobs:
         with:
           script: |
             const prBody = context.payload.pull_request.body || '';
-            const labelsToAdd = [];
+            const labelsToAdd = ['initial review required'];
 
             // Check for Type of Change checkboxes
             if (/\[x\]\s*New feature/i.test(prBody)) {

--- a/core/tabs/gaming/tab_data.toml
+++ b/core/tabs/gaming/tab_data.toml
@@ -143,4 +143,3 @@ name = "Fallout 76 INI and Mods"
 description = "This script will add a Custom Fallout 76 INI file that improves performance and stability. It also includes some quality of life improvements."
 script = "fallout-76/fallout76settings.sh"
 task_list = "FM"
-

--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -70,6 +70,9 @@ fn run(terminal: &mut Terminal<CrosstermBackend<Stdout>>, state: &mut AppState) 
                 .compare_exchange(true, false, Ordering::AcqRel, Ordering::Acquire)
                 .is_ok()
             {
+                if state.take_force_clear() {
+                    terminal.clear()?;
+                }
                 terminal.draw(|frame| state.draw(frame)).unwrap();
             }
             continue;
@@ -93,6 +96,9 @@ fn run(terminal: &mut Terminal<CrosstermBackend<Stdout>>, state: &mut AppState) 
                 }
             }
             _ => {}
+        }
+        if state.take_force_clear() {
+            terminal.clear()?;
         }
         terminal.draw(|frame| state.draw(frame)).unwrap();
     }

--- a/tui/src/root.rs
+++ b/tui/src/root.rs
@@ -8,7 +8,7 @@ This means you have full system access and commands can potentially damage your 
 Please proceed with caution and make sure you understand what each script does before executing it.";
 
 #[cfg(unix)]
-pub fn check_root_status(bypass_root: bool) -> Option<FloatingText<'static>> {
+pub fn check_root_status(bypass_root: bool) -> Option<FloatingText> {
     if bypass_root {
         return None;
     }

--- a/tui/src/state.rs
+++ b/tui/src/state.rs
@@ -18,17 +18,18 @@ use ratatui::{
     layout::Flex,
     prelude::*,
     symbols::border,
-    widgets::{Block, List, ListState, Padding, Paragraph},
+    widgets::{Block, Clear, List, ListState, Padding, Paragraph},
 };
 use std::rc::Rc;
+use unicode_width::UnicodeWidthStr;
 
 const MIN_WIDTH: u16 = 100;
 const MIN_HEIGHT: u16 = 25;
 const FLOAT_SIZE: u16 = 95;
+const PREVIEW_FLOAT_SIZE: u16 = 100;
 const CONFIRM_PROMPT_FLOAT_SIZE: u16 = 40;
 const LEFT_EXTRA_WIDTH: u16 = 4;
 const TITLE: &str = " LINUTIL ";
-const LIST_HIGHLIGHT_SYMBOL: &str = "> ";
 const ACTIONS_GUIDE: &str = "List of important tasks performed by commands' names:
 
 D  - disk modifications (ex. partitioning) (privileged)
@@ -71,6 +72,7 @@ pub struct AppState {
     size_bypass: bool,
     skip_confirmation: bool,
     mouse_enabled: bool,
+    force_clear: bool,
     system_info: Option<SystemInfo>,
     logo: Option<Logo>,
 }
@@ -118,7 +120,7 @@ impl AppState {
 
         let longest_tab_display_len = tabs
             .iter()
-            .map(|tab| tab.name.len() + args.theme.tab_icon().len())
+            .map(|tab| tab.name.width() + args.theme.tab_icon().width())
             .max()
             .unwrap_or(22) as u16;
 
@@ -140,6 +142,7 @@ impl AppState {
             size_bypass: args.size_bypass,
             skip_confirmation: args.skip_confirmation,
             mouse_enabled: args.mouse,
+            force_clear: false,
             system_info: SystemInfo::gather(),
             logo: Logo::load(),
         };
@@ -167,6 +170,12 @@ impl AppState {
             self.selected_commands = config_values.auto_execute_commands;
             self.handle_initial_auto_execute();
         }
+    }
+
+    pub fn take_force_clear(&mut self) -> bool {
+        let should_clear = self.force_clear;
+        self.force_clear = false;
+        should_clear
     }
 
     fn handle_initial_auto_execute(&mut self) {
@@ -277,6 +286,8 @@ impl AppState {
 
     pub fn draw(&mut self, frame: &mut Frame) {
         let area = frame.area();
+        // Clear the full frame so closed floating windows don't leave stale text behind.
+        frame.render_widget(Clear, area);
         self.drawable = !self.is_terminal_drawable(area);
         if !self.drawable {
             let warning = Paragraph::new(format!(
@@ -447,7 +458,7 @@ impl AppState {
             .title_bottom(bottom_title)
             .padding(Padding::horizontal(1));
         let list_inner_width = list_block.inner(chunks[1]).width as usize;
-        let list_content_width = list_inner_width.saturating_sub(LIST_HIGHLIGHT_SYMBOL.len());
+        let list_content_width = list_inner_width.saturating_sub(self.theme.tab_icon().width());
 
         let mut items: Vec<Line> = Vec::with_capacity(self.filter.item_list().len());
 
@@ -486,7 +497,8 @@ impl AppState {
                         format!("{}  {} {}", self.theme.cmd_icon(), node.name, indicator);
                     let right_content = format!("{} ", node.task_list);
                     let center_space = " ".repeat(
-                        list_content_width.saturating_sub(left_content.len() + right_content.len()),
+                        list_content_width
+                            .saturating_sub(left_content.width() + right_content.width()),
                     );
                     Line::styled(
                         format!("{left_content}{center_space}{right_content}"),
@@ -507,10 +519,13 @@ impl AppState {
             list_dim_style
         };
         let list_highlight_symbol = if list_focus {
-            LIST_HIGHLIGHT_SYMBOL
+            self.theme.tab_icon()
         } else {
             "  "
         };
+
+        // Clear list area so stale content from floating windows isn't left behind.
+        frame.render_widget(Clear, chunks[1]);
 
         // Create the list widget with items
         let list = List::new(items)
@@ -621,6 +636,7 @@ impl AppState {
             Focus::FloatingWindow(command) => {
                 if command.handle_key_event(key) {
                     self.focus = Focus::List;
+                    self.force_clear = true;
                 }
             }
 
@@ -857,8 +873,8 @@ impl AppState {
     fn enable_preview(&mut self) {
         if let Some(list_node) = self.get_selected_node() {
             let preview_title = format!("[Preview] - {}", list_node.name.as_str());
-            let preview = FloatingText::from_command(&list_node.command, &preview_title, false);
-            self.spawn_float(preview, FLOAT_SIZE, FLOAT_SIZE);
+            let preview = FloatingText::from_command(&list_node.command, &preview_title, true);
+            self.spawn_float(preview, PREVIEW_FLOAT_SIZE, PREVIEW_FLOAT_SIZE);
         }
     }
 

--- a/tui/src/theme.rs
+++ b/tui/src/theme.rs
@@ -1,5 +1,11 @@
 use clap::ValueEnum;
 use ratatui::style::Color;
+use std::sync::OnceLock;
+
+const ASCII_TAB_ICON: &str = "> ";
+const FANCY_TAB_ICON: &str = "❯ ";
+const ASCII_MULTI_SELECT_ICON: &str = "*";
+const FANCY_MULTI_SELECT_ICON: &str = "✔";
 
 // Add the Theme name here for a new theme
 // This is more secure than the previous list
@@ -44,30 +50,38 @@ impl Theme {
 
     pub const fn dir_icon(&self) -> &'static str {
         match self {
-            Theme::Default => "[D]",
-            Theme::Compatible => "[D]",
+            Theme::Default => "[~]",
+            Theme::Compatible => "[~]",
         }
     }
 
     pub const fn cmd_icon(&self) -> &'static str {
         match self {
-            Theme::Default => "[*]",
-            Theme::Compatible => "[*]",
+            Theme::Default => "[$]",
+            Theme::Compatible => "[$]",
         }
     }
 
-    pub const fn tab_icon(&self) -> &'static str {
-        match self {
-            Theme::Default => "> ",
-            Theme::Compatible => "> ",
-        }
+    pub fn tab_icon(&self) -> &'static str {
+        static TAB_ICON: OnceLock<&'static str> = OnceLock::new();
+        TAB_ICON.get_or_init(|| {
+            if should_use_ascii_glyphs() {
+                ASCII_TAB_ICON
+            } else {
+                FANCY_TAB_ICON
+            }
+        })
     }
 
-    pub const fn multi_select_icon(&self) -> &'static str {
-        match self {
-            Theme::Default => "*",
-            Theme::Compatible => "*",
-        }
+    pub fn multi_select_icon(&self) -> &'static str {
+        static MULTI_SELECT_ICON: OnceLock<&'static str> = OnceLock::new();
+        MULTI_SELECT_ICON.get_or_init(|| {
+            if should_use_ascii_glyphs() {
+                ASCII_MULTI_SELECT_ICON
+            } else {
+                FANCY_MULTI_SELECT_ICON
+            }
+        })
     }
 
     pub const fn success_color(&self) -> Color {
@@ -104,6 +118,29 @@ impl Theme {
             Theme::Compatible => Color::DarkGray,
         }
     }
+}
+
+fn should_use_ascii_glyphs() -> bool {
+    is_linux_console_term() || !locale_supports_utf8()
+}
+
+fn is_linux_console_term() -> bool {
+    matches!(
+        std::env::var("TERM").ok().as_deref(),
+        Some("linux") | Some("dumb")
+    )
+}
+
+fn locale_supports_utf8() -> bool {
+    ["LC_ALL", "LC_CTYPE", "LANG"]
+        .into_iter()
+        .filter_map(|key| std::env::var(key).ok())
+        .find(|value| !value.is_empty())
+        .map(|value| {
+            let normalized = value.to_ascii_lowercase();
+            normalized.contains("utf-8") || normalized.contains("utf8")
+        })
+        .unwrap_or(false)
 }
 
 impl Theme {


### PR DESCRIPTION
<!--
Read Contributing Guidelines before opening a PR.
https://github.com/ChrisTitusTech/linutil/blob/main/.github/CONTRIBUTING.md
-->

## Type of Change
- [ ] New feature
- [X] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [X] UI/UX improvement

## Description
1- Fix code preview with some lines extending outside middle box.
2- Expand middle box when selecting code preview (remove paddings)
3- Minor UI enhancements to tabs icon and multi-selection mode with fallback to ASCII when in TTY.

## Issues / other PRs related
<!--[What issue/discussion is related to this PR (if any)]-->


## Screenshots (if applicable)
<img width="1914" height="1046" alt="543263290-90cc56a2-c543-4eec-a5bd-43e9c70b7595" src="https://github.com/user-attachments/assets/2c9f629a-9856-4f3a-9036-58db6cb01ed3" />
<img width="1912" height="1045" alt="543263327-0aca6b09-cc70-404d-9154-01889e13343b" src="https://github.com/user-attachments/assets/2cf12d2e-c0b0-46e7-9502-989c07c3d213" />
<img width="1309" height="661" alt="543864477-ee615b24-69af-47c5-be86-280ca84c4b94" src="https://github.com/user-attachments/assets/79264733-9c90-4bad-bdf3-462cb17cd522" />
