### PR TITLE
fix: Add missing import to ollama installer

### DIFF
--- a/core/tabs/utils/ollama.sh
+++ b/core/tabs/utils/ollama.sh
@@ -1,6 +1,7 @@
 #!/bin/sh -e
 
 . ../common-script.sh
+. ../common-service-script.sh
 
 installollama() {
     clear


### PR DESCRIPTION
<!--
Read Contributing Guidelines before opening a PR.
https://github.com/ChrisTitusTech/linutil/blob/main/.github/CONTRIBUTING.md
-->

## Type of Change
- [ ] New feature
- [X] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Security patch
- [ ] UI/UX improvement

## Description
This PR fixes a missing `common-service-script.sh` source in `core/tabs/utils/ollama.sh`.

Without this, the script fails when attempting to call `startService` during the Ollama installation step, since that function is defined in `common-service-script.sh` and was never being sourced. The fix is a one-line addition at the top of the script:

```sh
. ../common-service-script.sh
```

## Issues / other PRs related
<!--[What issue/discussion is related to this PR (if any)]-->
- Resolves #1222

## Screenshots (if applicable)
