### PR TITLE
fix: harden SSH and Samba setup flows

### DIFF
--- a/core/tabs/utils/samba-ssh-setup.sh
+++ b/core/tabs/utils/samba-ssh-setup.sh
@@ -1,12 +1,17 @@
 #!/bin/sh -e
 
 # Load common script functions
-. ../common-script.sh  
+# shellcheck disable=SC1091
+# shellcheck source=../common-script.sh
+. ../common-script.sh
+# shellcheck disable=SC1091
+# shellcheck source=../common-service-script.sh
 . ../common-service-script.sh
 
 # Function to install packages based on the package manager
 install_package() {
     PACKAGE=$1
+    PACKAGER=${PACKAGER:-}
     if ! command_exists "$PACKAGE"; then
         case "$PACKAGER" in
             pacman)

--- a/core/tabs/utils/samba-ssh-setup.sh
+++ b/core/tabs/utils/samba-ssh-setup.sh
@@ -27,6 +27,161 @@ install_package() {
     fi
 }       
 
+validate_samba_config() {
+    if ! "$ESCALATION_TOOL" testparm -s >/dev/null; then
+        printf "%b\n" "${RED}Samba configuration validation failed. Review /etc/samba/smb.conf and try again.${RC}"
+        return 1
+    fi
+}
+
+get_samba_share_path() {
+    awk '
+        BEGIN { in_share = 0 }
+        /^\[Share\]/ { in_share = 1; next }
+        /^\[/ { in_share = 0 }
+        in_share && $1 == "path" {
+            sub(/^[[:space:]]*path[[:space:]]*=[[:space:]]*/, "")
+            print
+            exit
+        }
+    ' "$SAMBA_CONFIG"
+}
+
+allow_ufw_rule() {
+    if "$ESCALATION_TOOL" ufw allow "$1"; then
+        return 0
+    fi
+
+    if [ -n "$2" ]; then
+        "$ESCALATION_TOOL" ufw allow "$2"
+    else
+        return 1
+    fi
+}
+
+ufw_rule_exists() {
+    "$ESCALATION_TOOL" ufw status | grep -Fq "$1"
+}
+
+remove_ufw_rule() {
+    if ufw_rule_exists "$1"; then
+        printf "y\n" | "$ESCALATION_TOOL" ufw delete allow "$1" >/dev/null
+    fi
+}
+
+remove_local_ssh_host_entries() {
+    SSH_CONFIG="$HOME/.ssh/config"
+
+    if [ ! -f "$SSH_CONFIG" ]; then
+        printf "%b\n" "${YELLOW}No local SSH config found at $SSH_CONFIG.${RC}"
+        return 0
+    fi
+
+    printf "%b" "Enter the SSH host alias to remove (or 'all' to remove all host entries): "
+    read -r HOST_ALIAS
+
+    if [ "$HOST_ALIAS" = "all" ]; then
+        awk '
+            $1 == "Host" { skip = 1; next }
+            !skip { print }
+        ' "$SSH_CONFIG" > "$SSH_CONFIG.tmp" && mv "$SSH_CONFIG.tmp" "$SSH_CONFIG"
+        printf "%b\n" "${GREEN}Removed all local SSH host entries from $SSH_CONFIG.${RC}"
+        return 0
+    fi
+
+    if ! awk -v alias="$HOST_ALIAS" '$1 == "Host" { for (i = 2; i <= NF; i++) if ($i == alias) found = 1 } END { exit found ? 0 : 1 }' "$SSH_CONFIG"; then
+        printf "%b\n" "${YELLOW}Host $HOST_ALIAS not found in $SSH_CONFIG.${RC}"
+        return 0
+    fi
+
+    awk -v alias="$HOST_ALIAS" '
+        $1 == "Host" {
+            skip = 0
+            for (i = 2; i <= NF; i++) {
+                if ($i == alias) {
+                    skip = 1
+                }
+            }
+        }
+        !skip { print }
+    ' "$SSH_CONFIG" > "$SSH_CONFIG.tmp" && mv "$SSH_CONFIG.tmp" "$SSH_CONFIG"
+    printf "%b\n" "${GREEN}Removed local SSH host entry $HOST_ALIAS.${RC}"
+}
+
+remove_ssh_service_setup() {
+    case "$PACKAGER" in
+    apt-get|nala)
+        SSH_SERVICE="ssh"
+        ;;
+    *)
+        SSH_SERVICE="sshd"
+        ;;
+    esac
+
+    stopService "$SSH_SERVICE" || true
+    disableService "$SSH_SERVICE" || true
+    printf "%b\n" "${GREEN}SSH service setup removed. Package remains installed.${RC}"
+}
+
+remove_samba_setup() {
+    for service in smb nmb; do
+        stopService "$service" || true
+        disableService "$service" || true
+    done
+    printf "%b\n" "${GREEN}Samba service setup removed. Config files and packages were kept.${RC}"
+}
+
+remove_ssh_firewall_rules() {
+    if command_exists ufw; then
+        remove_ufw_rule OpenSSH
+        remove_ufw_rule ssh
+        remove_ufw_rule 22/tcp
+        printf "%b\n" "${GREEN}SSH firewall rules removed from UFW when present.${RC}"
+    else
+        printf "%b\n" "${YELLOW}UFW is not installed. Skipping SSH firewall rule removal.${RC}"
+    fi
+}
+
+remove_all_setup() {
+    remove_ssh_service_setup
+    remove_samba_setup
+    remove_ssh_firewall_rules
+    remove_local_ssh_host_entries
+}
+
+remove_setup_menu() {
+    printf "%b\n" "Remove Setup"
+    printf "%b\n" "1. Remove SSH service setup"
+    printf "%b\n" "2. Remove Samba service setup"
+    printf "%b\n" "3. Remove SSH firewall rules"
+    printf "%b\n" "4. Remove local SSH host entries"
+    printf "%b\n" "5. Remove all"
+    printf "%b" "Enter your choice (1-5): "
+    read -r REMOVE_CHOICE
+
+    case "$REMOVE_CHOICE" in
+        1)
+            remove_ssh_service_setup
+            ;;
+        2)
+            remove_samba_setup
+            ;;
+        3)
+            remove_ssh_firewall_rules
+            ;;
+        4)
+            remove_local_ssh_host_entries
+            ;;
+        5)
+            remove_all_setup
+            ;;
+        *)
+            printf "%b\n" "${RED}Invalid choice. Please enter a number between 1 and 5.${RC}"
+            return 1
+            ;;
+    esac
+}
+
 # Function to setup and configure SSH
 setup_ssh() {
     printf "%b\n" "${YELLOW}Setting up SSH...${RC}"
@@ -76,6 +231,7 @@ setup_samba() {
     install_package samba
 
     SAMBA_CONFIG="/etc/samba/smb.conf"
+    SHARED_DIR=
 
     if [ -f "$SAMBA_CONFIG" ]; then
         printf "%b\n" "${YELLOW}Samba configuration file already exists in $SAMBA_CONFIG.${RC}"
@@ -84,6 +240,7 @@ setup_samba() {
         if [ "$MODIFY_SAMBA" = "Y" ] || [ "$MODIFY_SAMBA" = "y" ]; then
             "$ESCALATION_TOOL" "$EDITOR" "$SAMBA_CONFIG"
         fi
+        SHARED_DIR=$(get_samba_share_path)
     else
         printf "%b\n" "${YELLOW}No existing Samba configuration found. Setting up a new one...${RC}"
 
@@ -92,35 +249,22 @@ setup_samba() {
         read -r SHARED_DIR
         SHARED_DIR=${SHARED_DIR:-/srv/samba/share}
 
-        # Create the shared directory if it doesn't exist
-        "$ESCALATION_TOOL" mkdir -p "$SHARED_DIR"
-        "$ESCALATION_TOOL" chmod -R 0777 "$SHARED_DIR"
-
         # Add a new Samba user
-        printf "%b" "Enter Samba username: "
-        read -r SAMBA_USER
-
-        # Loop until the passwords match
+        DEFAULT_SAMBA_USER=$(whoami)
         while true; do
-            printf "Enter Samba password: "
-            stty -echo
-            read -r SAMBA_PASSWORD
-            stty echo
-            printf "Confirm Samba password: "
-            stty -echo
-            read -r SAMBA_PASSWORD_CONFIRM
-            stty echo
-            printf "\n"
-            if [ "$SAMBA_PASSWORD" = "$SAMBA_PASSWORD_CONFIRM" ]; then
-                printf "%b\n" "${GREEN}Passwords match.${RC}"
+            printf "%b" "Enter Samba username (default: ${DEFAULT_SAMBA_USER}): "
+            read -r SAMBA_USER
+            SAMBA_USER=${SAMBA_USER:-$DEFAULT_SAMBA_USER}
+            if id "$SAMBA_USER" >/dev/null 2>&1; then
                 break
-            else
-                printf "%b\n" "${RED}Passwords do not match. Please try again.${RC}"
             fi
+            printf "%b\n" "${RED}User ${SAMBA_USER} does not exist on this system. Enter an existing local account.${RC}"
         done
 
-        # Add the user and set the password
-        "$ESCALATION_TOOL" smbpasswd -a "$SAMBA_USER"
+        # Create the shared directory if it doesn't exist and hand it to the Samba user.
+        "$ESCALATION_TOOL" mkdir -p "$SHARED_DIR"
+        "$ESCALATION_TOOL" chown "$SAMBA_USER":"$(id -gn "$SAMBA_USER")" "$SHARED_DIR"
+        "$ESCALATION_TOOL" chmod 0770 "$SHARED_DIR"
 
         # Configure Samba settings
         "$ESCALATION_TOOL" tee "$SAMBA_CONFIG" > /dev/null <<EOL
@@ -139,7 +283,14 @@ setup_samba() {
    read only = no
    valid users = $SAMBA_USER
 EOL
+
+        validate_samba_config || return 1
+
+        printf "%b\n" "${YELLOW}Set the Samba password for ${SAMBA_USER}.${RC}"
+        "$ESCALATION_TOOL" smbpasswd -a "$SAMBA_USER"
     fi
+
+    validate_samba_config || return 1
 
     for service in smb nmb; do
         startAndEnableService "$service"
@@ -147,7 +298,11 @@ EOL
 
     if isServiceActive smb && isServiceActive nmb; then
         printf "%b\n" "${GREEN}Samba is up and running.${RC}"
-        printf "%b\n" "${YELLOW}Samba share available at: $SHARED_DIR${RC}"
+        if [ -n "$SHARED_DIR" ]; then
+            printf "%b\n" "${YELLOW}Samba share available at: $SHARED_DIR${RC}"
+        else
+            printf "%b\n" "${YELLOW}Samba share path not found in $SAMBA_CONFIG.${RC}"
+        fi
     else
         printf "%b\n" "${RED}Failed to start Samba.${RC}"
     fi
@@ -158,8 +313,14 @@ configure_firewall() {
     printf "%b\n" "${BLUE}Configuring firewall...${RC}"
 
     if command_exists ufw; then
-        "$ESCALATION_TOOL" ufw allow OpenSSH
-        "$ESCALATION_TOOL" ufw allow Samba
+        allow_ufw_rule OpenSSH ssh || {
+            printf "%b\n" "${RED}Failed to allow SSH through UFW.${RC}"
+            return 1
+        }
+        allow_ufw_rule Samba 139,445/tcp || {
+            printf "%b\n" "${RED}Failed to allow Samba through UFW.${RC}"
+            return 1
+        }
         "$ESCALATION_TOOL" ufw enable
         printf "%b\n" "${GREEN}Firewall configured for SSH and Samba.${RC}"
     else
@@ -176,11 +337,12 @@ setup_ssh_samba(){
     printf "%b\n" "Select an option:"
     printf "%b\n" "1. Setup SSH"
     printf "%b\n" "2. Setup Samba"
-    printf "%b\n" "3. Configure Firewall"
-    printf "%b\n" "4. Setup All"
-    printf "%b\n" "5. Exit"
+    printf "%b\n" "3. Remove Setup"
+    printf "%b\n" "4. Configure Firewall"
+    printf "%b\n" "5. Setup All"
+    printf "%b\n" "6. Exit"
 
-    printf "%b" "Enter your choice (1-5): "
+    printf "%b" "Enter your choice (1-6): "
     read -r CHOICE
 
     case "$CHOICE" in
@@ -191,19 +353,22 @@ setup_ssh_samba(){
             setup_samba
             ;;
         3)
-            configure_firewall
+            remove_setup_menu
             ;;
         4)
+            configure_firewall
+            ;;
+        5)
             setup_ssh
             setup_samba
             configure_firewall
             ;;
-        5)
+        6)
             printf "%b\n" "${GREEN}Exiting.${RC}"
             exit 0
             ;;
         *)
-            printf "%b\n" "${RED}Invalid choice. Please enter a number between 1 and 5.${RC}"
+            printf "%b\n" "${RED}Invalid choice. Please enter a number between 1 and 6.${RC}"
             exit 1
             ;;
     esac

--- a/core/tabs/utils/ssh.sh
+++ b/core/tabs/utils/ssh.sh
@@ -1,5 +1,7 @@
 #!/bin/sh -e
 
+# shellcheck disable=SC1091
+# shellcheck source=../common-script.sh
 . ../common-script.sh
 
 ensure_ssh_config() {
@@ -178,6 +180,7 @@ run_remote_command() {
     read -r host_alias
     printf "%b" "Enter the command to run: " 
     read -r remote_command
+    # shellcheck disable=SC2029
     ssh "$host_alias" "$remote_command"
 }
 

--- a/core/tabs/utils/ssh.sh
+++ b/core/tabs/utils/ssh.sh
@@ -2,17 +2,104 @@
 
 . ../common-script.sh
 
-# Check if ~/.ssh/config exists, if not, create it
-if [ ! -f ~/.ssh/config ]; then
-    mkdir -p "$HOME/.ssh"
-    touch "$HOME/.ssh/config"
-    chmod 600 "$HOME/.ssh/config"
+ensure_ssh_config() {
+    if [ ! -f "$HOME/.ssh/config" ]; then
+        mkdir -p "$HOME/.ssh"
+        touch "$HOME/.ssh/config"
+        chmod 600 "$HOME/.ssh/config"
+    fi
+}
+
+host_exists() {
+    awk -v alias="$1" '$1 == "Host" { for (i = 2; i <= NF; i++) if ($i == alias) found = 1 } END { exit found ? 0 : 1 }' "$HOME/.ssh/config"
+}
+
+remove_host_block() {
+    tmp_config=$(mktemp)
+    awk -v alias="$1" '
+        $1 == "Host" {
+            skip = 0
+            for (i = 2; i <= NF; i++) {
+                if ($i == alias) {
+                    skip = 1
+                }
+            }
+        }
+        !skip { print }
+    ' "$HOME/.ssh/config" > "$tmp_config" && mv "$tmp_config" "$HOME/.ssh/config"
+}
+
+print_host_block() {
+    awk -v alias="$1" '
+        $1 == "Host" {
+            printing = 0
+            for (i = 2; i <= NF; i++) {
+                if ($i == alias) {
+                    printing = 1
+                    found = 1
+                }
+            }
+        }
+        printing { print }
+        END { exit found ? 0 : 1 }
+    ' "$HOME/.ssh/config"
+}
+
+run_remote_as_root() {
+    host_alias=$1
+    shift
+    ssh "$host_alias" sh -s -- "$@" <<'EOF'
+set -e
+
+if [ "$(id -u)" = "0" ]; then
+    remote_escalation=""
+elif command -v sudo >/dev/null 2>&1; then
+    remote_escalation="sudo"
+elif command -v doas >/dev/null 2>&1; then
+    remote_escalation="doas"
+else
+    printf "%s\n" "No supported escalation tool found on the remote host." >&2
+    exit 1
 fi
+
+run_privileged() {
+    if [ -n "$remote_escalation" ]; then
+        "$remote_escalation" "$@"
+    else
+        "$@"
+    fi
+}
+
+password_auth=$1
+pubkey_auth=$2
+
+run_privileged sed -i \
+    -e "s/^#\?PasswordAuthentication .*/PasswordAuthentication $password_auth/" \
+    -e "s/^#\?PubkeyAuthentication .*/PubkeyAuthentication $pubkey_auth/" \
+    /etc/ssh/sshd_config
+
+if ! grep -q '^PasswordAuthentication ' /etc/ssh/sshd_config; then
+    printf "%s\n" "PasswordAuthentication $password_auth" | run_privileged tee -a /etc/ssh/sshd_config >/dev/null
+fi
+
+if ! grep -q '^PubkeyAuthentication ' /etc/ssh/sshd_config; then
+    printf "%s\n" "PubkeyAuthentication $pubkey_auth" | run_privileged tee -a /etc/ssh/sshd_config >/dev/null
+fi
+
+if command -v systemctl >/dev/null 2>&1; then
+    run_privileged systemctl restart sshd || run_privileged systemctl restart ssh
+else
+    printf "%s\n" "Could not restart SSH automatically because systemctl is unavailable on the remote host." >&2
+fi
+EOF
+}
+
+ensure_ssh_config
 
 # Function to show available hosts from ~/.ssh/config
 show_available_hosts() {
     printf "%b\n" "Available Systems:"
-    grep -E "^Host " "$HOME/.ssh/config" | awk '{print $2}'
+    awk '$1 == "Host" { for (i = 2; i <= NF; i++) print $i }' "$HOME/.ssh/config"
     printf "%b\n" "-------------------"
 }
 
@@ -24,6 +111,10 @@ ask_for_host_details() {
     read -r host
     printf "%b" "Enter Remote User: "
     read -r  user
+    if host_exists "$host_alias"; then
+        printf "%b\n" "Host $host_alias already exists. Replacing existing entry."
+        remove_host_block "$host_alias"
+    fi
     {
         printf "%b\n" "Host $host_alias"
         printf "%b\n" "    HostName $host"
@@ -61,13 +152,7 @@ disable_password_auth() {
     printf "%b\n" "Enter the alias of the host: " 
     read -r host_alias
     printf "\n"
-    ssh "$host_alias" "
-        "$ESCALATION_TOOL" -S sed -i 's/^#PasswordAuthentication yes/PasswordAuthentication no/' /etc/ssh/sshd_config &&
-        "$ESCALATION_TOOL"  -S sed -i 's/^PasswordAuthentication yes/PasswordAuthentication no/' /etc/ssh/sshd_config &&
-        "$ESCALATION_TOOL"  -S sed -i 's/^#PubkeyAuthentication no/PubkeyAuthentication yes/' /etc/ssh/sshd_config &&
-        "$ESCALATION_TOOL"  -S sed -i 's/^PubkeyAuthentication no/PubkeyAuthentication yes/' /etc/ssh/sshd_config &&
-        "$ESCALATION_TOOL"  -S systemctl restart sshd
-    "
+    run_remote_as_root "$host_alias" no yes
     printf "%b\n" "PasswordAuthentication set to no and PubkeyAuthentication set to yes."
 }
 
@@ -76,13 +161,7 @@ enable_password_auth() {
     printf "%b\n" "Enter the alias of the host: "
     read -r host_alias
     printf "\n"
-    ssh "$host_alias" "
-        "$ESCALATION_TOOL"  -S sed -i 's/^#PasswordAuthentication no/PasswordAuthentication yes/' /etc/ssh/sshd_config &&
-        "$ESCALATION_TOOL"  -S sed -i 's/^PasswordAuthentication no/PasswordAuthentication yes/' /etc/ssh/sshd_config &&
-        "$ESCALATION_TOOL"  -S sed -i 's/^#PubkeyAuthentication yes/PubkeyAuthentication no/' /etc/ssh/sshd_config &&
-        "$ESCALATION_TOOL"  -S sed -i 's/^PubkeyAuthentication yes/PubkeyAuthentication no/' /etc/ssh/sshd_config &&
-        "$ESCALATION_TOOL"  -S systemctl restart sshd
-    "
+    run_remote_as_root "$host_alias" yes no
     printf "%b\n" "PasswordAuthentication set to yes and PubkeyAuthentication set to no."
 }
 
@@ -151,7 +230,11 @@ move_directory_to_remote() {
 remove_system() {
     printf "%b\n" "Enter the alias of the host to remove: "
     read -r host_alias
-    sed -i "/^Host $host_alias/,+3d" ~/.ssh/config
+    if ! host_exists "$host_alias"; then
+        printf "%b\n" "Host $host_alias not found."
+        return 1
+    fi
+    remove_host_block "$host_alias"
     printf "%b\n" "Removed $host_alias from SSH configuration."
 }
 
@@ -160,9 +243,12 @@ view_ssh_config() {
     printf "%b\n" "Enter the alias of the host to view (or press Enter to view all): "
     read -r  host_alias
     if [ -z "$host_alias" ]; then
-        cat ~/.ssh/config
+        cat "$HOME/.ssh/config"
     else
-        grep -A 3 "^Host $host_alias" ~/.ssh/config
+        if ! print_host_block "$host_alias"; then
+            printf "%b\n" "Host $host_alias not found."
+            return 1
+        fi
     fi
 }
 


### PR DESCRIPTION
<!--
Read Contributing Guidelines before opening a PR.
https://github.com/ChrisTitusTech/linutil/blob/main/.github/CONTRIBUTING.md
-->

## Type of Change
- [ ] New feature
- [X] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Security patch
- [X] UI/UX improvement

## Summary

- Harden the SSH Samba and SSH Commands utilities so setup and teardown behave reliably across normal user flows and distro differences.

## Issues addressed
1. SSH Samba accepted arbitrary Samba usernames even though `smbpasswd -a` only works for an existing local Unix account, which caused setup failure for valid-looking but nonexistent usernames.
2. SSH Samba asked for a Samba password twice, reported success, then ignored those values and invoked interactive `smbpasswd -a` anyway.
3. SSH Samba did not validate smb.conf with `testparm` before enabling services.
4. SSH Samba handled existing configs poorly by not recovering the configured share path from `smb.conf` for its success output.
5. Firewall setup relied on UFW profile names like OpenSSH and Samba, which are not portable across systems.
6. SSH Commands assumed remote privilege escalation via `sudo -S`, even though the shared escalation path also allows `doas`.
7. SSH Commands edited `~/.ssh/config` using fixed line ranges, which was inconsistent with the host blocks it actually writes.
8. SSH Samba had no built-in way to safely remove previously applied service, firewall, or local SSH setup.

## Issues / other PRs related
<!--[What issue/discussion is related to this PR (if any)]-->

## Screenshots (if applicable)
