### PR TITLE
fix(system-update): use `extra` package for `rate-mirrors` instead of aur

### DIFF
--- a/core/tabs/system-setup/system-update.sh
+++ b/core/tabs/system-setup/system-update.sh
@@ -5,7 +5,7 @@
 fastUpdate() {
     case "$PACKAGER" in
         pacman)
-            "$AUR_HELPER" -S --needed --noconfirm rate-mirrors-bin
+            "$AUR_HELPER" -S --needed --noconfirm rate-mirrors
 
             printf "%b\n" "${YELLOW}Generating a new list of mirrors using rate-mirrors. This process may take a few seconds...${RC}"
 


### PR DESCRIPTION
## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Security patch
- [ ] UI/UX improvement

## Description
Since it already contains in extra repo, no need to use aur package, which improve update time for first time user

## Issues / other PRs related
<!--[What issue/discussion is related to this PR (if any)]-->

- Resolves #

