### PR TITLE
Fix Arch gaming dependency install on PipeWire JACK systems

### DIFF
--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -79,8 +79,8 @@ mod tests {
         let config = Config::read_config(&config_path, &tab_list);
 
         assert_eq!(config.auto_execute_commands.len(), 1);
-        assert_eq!(config.skip_confirmation, true);
-        assert_eq!(config.size_bypass, false);
+        assert!(config.skip_confirmation);
+        assert!(!config.size_bypass);
 
         drop(temp_dir);
     }

--- a/core/tabs/system-setup/gaming-setup.sh
+++ b/core/tabs/system-setup/gaming-setup.sh
@@ -39,6 +39,12 @@ installDepend() {
                 libxslt lib32-libxslt cups samba lib32-mesa vulkan-radeon lib32-vulkan-radeon \
                 gamescope mangohud lib32-mangohud gamemode lib32-gamemode"
 
+            if "$PACKAGER" -Qq pipewire-jack >/dev/null 2>&1; then
+                "$ESCALATION_TOOL" "$PACKAGER" -S --needed --noconfirm lib32-pipewire-jack
+            elif "$PACKAGER" -Qq jack2 >/dev/null 2>&1; then
+                "$ESCALATION_TOOL" "$PACKAGER" -S --needed --noconfirm lib32-jack2
+            fi
+
             $AUR_HELPER -S --needed --noconfirm $DEPENDENCIES $DISTRO_DEPS
             ;;
         apt-get | nala)

--- a/tui/src/filter.rs
+++ b/tui/src/filter.rs
@@ -91,13 +91,9 @@ impl Filter {
         } else {
             self.items.iter().find_map(|item| {
                 let mut item_chars = item.node.name.chars();
-                let mut search_chars = self.search_input.iter();
-                loop {
+                let search_chars = self.search_input.iter();
+                for search_char in search_chars {
                     // Take the next character from search input first, since we don't want to remove an extra character from the item
-                    let Some(search_char) = search_chars.next() else {
-                        break;
-                    };
-
                     // If the item is shorter than the search input, or a character doesn't match, skip this item
                     let item_char = item_chars.next()?;
                     if !item_char.eq_ignore_ascii_case(search_char) {

--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -87,10 +87,8 @@ fn run(terminal: &mut Terminal<CrosstermBackend<Stdout>>, state: &mut AppState) 
                     return Ok(());
                 }
             }
-            Event::Mouse(mouse_event) => {
-                if !state.handle_mouse(&mouse_event) {
-                    return Ok(());
-                }
+            Event::Mouse(mouse_event) if !state.handle_mouse(&mouse_event) => {
+                return Ok(());
             }
             _ => {}
         }

--- a/tui/src/state.rs
+++ b/tui/src/state.rs
@@ -617,13 +617,14 @@ impl AppState {
             return true;
         }
 
-        match &mut self.focus {
-            Focus::FloatingWindow(command) => {
-                if command.handle_key_event(key) {
-                    self.focus = Focus::List;
-                }
+        if let Focus::FloatingWindow(command) = &mut self.focus {
+            if command.handle_key_event(key) {
+                self.focus = Focus::List;
             }
+            return true;
+        }
 
+        match &mut self.focus {
             Focus::ConfirmationPrompt(confirm) => {
                 confirm.content.handle_key_event(key);
                 match confirm.content.status {


### PR DESCRIPTION
<!--
Read Contributing Guidelines before opening a PR.
https://github.com/ChrisTitusTech/linutil/blob/main/.github/CONTRIBUTING.md
-->

## Type of Change
- [ ] New feature
- [X] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Security patch
- [ ] UI/UX improvement

## Description
This fixes the "Gaming Dependencies" installer failing on Arch-based systems where `pipewire-jack` is already installed. Previously, the Arch dependency transaction could let `lib32-jack` resolve to `lib32-jack2`, which then pulled `jack2` and conflicted with the existing `pipewire-jack` package. That caused yay/pacman to abort with an unresolved package conflict.

## Changes
  - Detect the installed JACK provider on `pacman` systems before the main dependency transaction.
  - If `pipewire-jack` is installed, pre-install `lib32-pipewire-jack`.
  - If `jack2` is installed, pre-install `lib32-jack2`.
  - Leave other package managers unchanged.

## Additional fix/changes
- Fixed existing `cargo clippy` failures.

#### Changes:
- Boolean test assertions now use `assert!`.
- Iterator loop cleaned up.
- Collapsed mouse event match.
- Refactored floating-window key handling in a borrow-safe way.

## Testing
- Ran `shellcheck - typos - clippy` successfully.
- Ran "Gaming Dependencies" successfully.