### PR TITLE
Fix "Gaming Dependency" conflicts without aborting install

### DIFF
--- a/core/tabs/system-setup/gaming-setup.sh
+++ b/core/tabs/system-setup/gaming-setup.sh
@@ -4,6 +4,73 @@
 
 . ../common-script.sh
 
+INSTALL_FAILURES=""
+INSTALL_CONFLICTS=""
+
+strip_ansi() {
+    esc=$(printf '\033')
+    sed "s/${esc}\\[[0-9;?]*[ -/]*[@-~]//g"
+}
+
+extract_conflicts() {
+    strip_ansi | sed -n '
+        / are in conflict/ {
+            s/^.*::[[:space:]]*//
+            s/[[:space:]]*Remove .*$//
+            s/\.$//
+            s/[[:space:]]*$//
+            p
+        }
+    '
+}
+
+record_step_failure() {
+    step_name="$1"
+    output_file="$2"
+    conflicts=$(extract_conflicts < "$output_file" | sort -u)
+
+    if [ -n "$conflicts" ]; then
+        INSTALL_CONFLICTS="${INSTALL_CONFLICTS}\n${conflicts}"
+    else
+        INSTALL_FAILURES="${INSTALL_FAILURES}\n- ${step_name}"
+    fi
+}
+
+run_install_step() {
+    step_name="$1"
+    shift
+    step_output=$(mktemp)
+
+    if "$@" > "$step_output" 2>&1; then
+        cat "$step_output"
+        printf "%b\n" "${GREEN}[OK]${RC} ${step_name}"
+    else
+        cat "$step_output"
+        printf "%b\n" "${YELLOW}[FAILED]${RC} ${step_name}"
+        record_step_failure "$step_name" "$step_output"
+    fi
+
+    rm -f "$step_output"
+}
+
+print_install_summary() {
+    printf "\n"
+
+    if [ -n "$INSTALL_CONFLICTS" ] || [ -n "$INSTALL_FAILURES" ]; then
+        printf "%b\n" "${YELLOW}Partially completed. Please resolve failed steps, then re-run install:${RC}"
+        if [ -n "$INSTALL_CONFLICTS" ]; then
+            printf "%b\n" "${YELLOW}Conflicts:${RC}"
+            printf "%b\n" "$INSTALL_CONFLICTS" | sed '/^$/d' | sort -u | sed 's/^/- /'
+        fi
+        if [ -n "$INSTALL_FAILURES" ]; then
+            printf "%b\n" "${YELLOW}Failures:${RC}"
+            printf "%b\n" "$INSTALL_FAILURES"
+        fi
+    else
+        printf "%b\n" "${GREEN}Completed.${RC}"
+    fi
+}
+
 installDepend() {
     DEPENDENCIES='wine dbus git'
     printf "%b\n" "${YELLOW}Installing dependencies...${RC}"
@@ -14,7 +81,7 @@ installDepend() {
                 if ! grep -q "^\s*\[lib32\]" /etc/pacman.conf; then
                     echo "[lib32]" | "$ESCALATION_TOOL" tee -a /etc/pacman.conf
                     echo "Include = /etc/pacman.d/mirrorlist" | "$ESCALATION_TOOL" tee -a /etc/pacman.conf
-                    "$ESCALATION_TOOL" "$PACKAGER" -Syu
+                    run_install_step "Refresh packages after enabling lib32" "$ESCALATION_TOOL" "$PACKAGER" -Syu
                 else
                     printf "%b\n" "${GREEN}lib32 is already enabled.${RC}"
                 fi
@@ -23,7 +90,7 @@ installDepend() {
                 if ! grep -q "^\s*\[multilib\]" /etc/pacman.conf; then
                     echo "[multilib]" | "$ESCALATION_TOOL" tee -a /etc/pacman.conf
                     echo "Include = /etc/pacman.d/mirrorlist" | "$ESCALATION_TOOL" tee -a /etc/pacman.conf
-                    "$ESCALATION_TOOL" "$PACKAGER" -Syu
+                    run_install_step "Refresh packages after enabling multilib" "$ESCALATION_TOOL" "$PACKAGER" -Syu
                 else
                     printf "%b\n" "${GREEN}Multilib is already enabled.${RC}"
                 fi
@@ -40,38 +107,46 @@ installDepend() {
                 gamescope mangohud lib32-mangohud gamemode lib32-gamemode"
 
             if "$PACKAGER" -Qq pipewire-jack >/dev/null 2>&1; then
-                "$ESCALATION_TOOL" "$PACKAGER" -S --needed --noconfirm lib32-pipewire-jack
+                run_install_step "Install lib32-pipewire-jack" "$ESCALATION_TOOL" "$PACKAGER" -S --needed --noconfirm lib32-pipewire-jack
             elif "$PACKAGER" -Qq jack2 >/dev/null 2>&1; then
-                "$ESCALATION_TOOL" "$PACKAGER" -S --needed --noconfirm lib32-jack2
+                run_install_step "Install lib32-jack2" "$ESCALATION_TOOL" "$PACKAGER" -S --needed --noconfirm lib32-jack2
             fi
 
-            $AUR_HELPER -S --needed --noconfirm $DEPENDENCIES $DISTRO_DEPS
+            run_install_step "Install main gaming dependencies (repo/AUR)" \
+                "$AUR_HELPER" -S --needed --noconfirm dbus git $DISTRO_DEPS
+            run_install_step "Install Wine" \
+                "$AUR_HELPER" -S --needed --noconfirm wine
             ;;
         apt-get | nala)
-            "$ESCALATION_TOOL" dpkg --add-architecture i386
-            "$ESCALATION_TOOL" "$PACKAGER" update
+            run_install_step "Enable i386 architecture" "$ESCALATION_TOOL" dpkg --add-architecture i386
+            run_install_step "Refresh package indexes" "$ESCALATION_TOOL" "$PACKAGER" update
             
-            "$ESCALATION_TOOL" "$PACKAGER" install -y $DEPENDENCIES
+            run_install_step "Install base dependencies" "$ESCALATION_TOOL" "$PACKAGER" install -y $DEPENDENCIES
             
             DISTRO_DEPS="libasound2-plugins:i386 libsdl2-2.0-0:i386 libdbus-1-3:i386 libsqlite3-0:i386 wine32:i386"
             apt-cache show software-properties-common >/dev/null 2>&1 && DISTRO_DEPS="$DISTRO_DEPS software-properties-common"
             
-            "$ESCALATION_TOOL" "$PACKAGER" install -y $DISTRO_DEPS
+            run_install_step "Install distro-specific dependencies" "$ESCALATION_TOOL" "$PACKAGER" install -y $DISTRO_DEPS
             ;;
         dnf)
             printf "%b\n" "${CYAN}Installing rpmfusion repos.${RC}"
-            "$ESCALATION_TOOL" "$PACKAGER" install https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-"$(rpm -E %fedora)".noarch.rpm https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-"$(rpm -E %fedora)".noarch.rpm -y
-            "$ESCALATION_TOOL" "$PACKAGER" config-manager setopt --repo fedora-cisco-openh264 enabled=1
+            run_install_step "Install RPM Fusion repositories" \
+                "$ESCALATION_TOOL" "$PACKAGER" install \
+                "https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm" \
+                "https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-$(rpm -E %fedora).noarch.rpm" -y
+            run_install_step "Enable fedora-cisco-openh264 repo" \
+                "$ESCALATION_TOOL" "$PACKAGER" config-manager setopt --repo fedora-cisco-openh264 enabled=1
     
-            "$ESCALATION_TOOL" "$PACKAGER" install -y $DEPENDENCIES
+            run_install_step "Install base dependencies" "$ESCALATION_TOOL" "$PACKAGER" install -y $DEPENDENCIES
             ;;
         zypper)
-            "$ESCALATION_TOOL" "$PACKAGER" -n install $DEPENDENCIES
+            run_install_step "Install base dependencies" "$ESCALATION_TOOL" "$PACKAGER" -n install $DEPENDENCIES
             ;;
         eopkg)
             DISTRO_DEPS="libgnutls libgtk-2 libgtk-3 pulseaudio alsa-lib alsa-plugins giflib libpng openal-soft libxcomposite libxinerama ncurses vulkan ocl-icd libva gst-plugins-base sdl2 v4l-utils sqlite3"
 
-            "$ESCALATION_TOOL" "$PACKAGER" install -y $DEPENDENCIES $DISTRO_DEPS
+            run_install_step "Install base and distro-specific dependencies" \
+                "$ESCALATION_TOOL" "$PACKAGER" install -y $DEPENDENCIES $DISTRO_DEPS
             ;;
         *)
             printf "%b\n" "${RED}Unsupported package manager ${PACKAGER}${RC}"
@@ -84,7 +159,8 @@ installAdditionalDepend() {
     case "$PACKAGER" in
         pacman)
             DISTRO_DEPS='steam lutris goverlay'
-            "$ESCALATION_TOOL" "$PACKAGER" -S --needed --noconfirm $DISTRO_DEPS
+            run_install_step "Install additional gaming apps" \
+                "$ESCALATION_TOOL" "$PACKAGER" -S --needed --noconfirm $DISTRO_DEPS
             ;;
         apt-get | nala)
             printf "%b\n" "${YELLOW}Installing Lutris...${RC}"
@@ -92,28 +168,28 @@ installAdditionalDepend() {
             
             if [ -n "$lutris_url" ]; then
                 printf "%b\n" "${YELLOW}Downloading latest Lutris from GitHub...${RC}"
-                curl -sSLo lutris.deb "$lutris_url"
-                "$ESCALATION_TOOL" "$PACKAGER" install -y ./lutris.deb
+                run_install_step "Download latest Lutris package" curl -sSLo lutris.deb "$lutris_url"
+                run_install_step "Install downloaded Lutris package" "$ESCALATION_TOOL" "$PACKAGER" install -y ./lutris.deb
                 rm lutris.deb
-                "$ESCALATION_TOOL" "$PACKAGER" update
-                "$ESCALATION_TOOL" "$PACKAGER" install -y lutris
+                run_install_step "Refresh package indexes" "$ESCALATION_TOOL" "$PACKAGER" update
+                run_install_step "Install Lutris from repositories" "$ESCALATION_TOOL" "$PACKAGER" install -y lutris
             fi
 
             printf "%b\n" "${GREEN}Lutris Installation complete.${RC}"
             printf "%b\n" "${YELLOW}Installing steam...${RC}"
-            "$ESCALATION_TOOL" "$PACKAGER" install -y steam
+            run_install_step "Install Steam" "$ESCALATION_TOOL" "$PACKAGER" install -y steam
             ;;
         dnf)
             DISTRO_DEPS='steam lutris'
-            "$ESCALATION_TOOL" "$PACKAGER" install -y $DISTRO_DEPS
+            run_install_step "Install additional gaming apps" "$ESCALATION_TOOL" "$PACKAGER" install -y $DISTRO_DEPS
             ;;
         zypper)
             DISTRO_DEPS='lutris'
-            "$ESCALATION_TOOL" "$PACKAGER" -n install $DISTRO_DEPS
+            run_install_step "Install additional gaming apps" "$ESCALATION_TOOL" "$PACKAGER" -n install $DISTRO_DEPS
             ;;
         eopkg)
             DISTRO_DEPS='steam lutris'
-            "$ESCALATION_TOOL" "$PACKAGER" install -y $DISTRO_DEPS
+            run_install_step "Install additional gaming apps" "$ESCALATION_TOOL" "$PACKAGER" install -y $DISTRO_DEPS
             ;;
         *)
             printf "%b\n" "${RED}Unsupported package manager ${PACKAGER}${RC}"
@@ -127,3 +203,4 @@ checkAURHelper
 checkEscalationTool
 installDepend
 installAdditionalDepend
+print_install_summary


### PR DESCRIPTION
<!--
Read Contributing Guidelines before opening a PR.
https://github.com/ChrisTitusTech/linutil/blob/main/.github/CONTRIBUTING.md
-->

## Type of Change
- [X] Bug fix

## Description
Fix the `Gaming Dependencies` installer so package conflicts or failed install steps no longer stop the entire flow.

## Changes
 - Wraps install commands in a non-fatal step runner.
 - Continues remaining install steps after a failed package transaction.
 - Tracks failed steps and package conflicts separately.
 - Extracts concrete package conflict messages from package manager output.
 - Shows a clear final status:
   - `Completed.` when all steps succeed.
   - `Partially completed. Please resolve failed steps, then re-run install:` when some steps fail or a conflict is detected, showing the user which step failed or which conflict was found.
 - Splits Wine installation from the main pacman dependency group so a `wine` / `wine-staging` conflict does not block other gaming dependencies.

## Example
Instead of ending with only `[FAILED] Install Wine`,  the installer now summarizes the detected conflict:
`Partially completed. Please resolve failed steps, then re-run install:`
`Conflicts:`
`- wine-11.8-1 and wine-staging-11.8-1 are in conflict`

## Screenshots (if applicable)
<img width="1330" height="382" alt="screenshot-2026-05-16_06-09-45" src="https://github.com/user-attachments/assets/982b5145-3abd-481a-8634-fecc791cd27a" />