### PR TITLE
add Game Launchers and Proton tool entries

### DIFF
--- a/core/tabs/gaming/game-launchers.sh
+++ b/core/tabs/gaming/game-launchers.sh
@@ -1,0 +1,282 @@
+#!/bin/sh -e
+
+SCRIPT_DIR=$(dirname -- "$0")
+SCRIPT_DIR=$(cd -- "$SCRIPT_DIR" && pwd)
+# shellcheck source=core/tabs/common-script.sh
+. "$SCRIPT_DIR/../common-script.sh"
+
+set_launcher() {
+    case "$1" in
+        steam)
+            LAUNCHER_NAME="Steam"
+            PKG_NAME="steam"
+            FLATPAK_ID="com.valvesoftware.Steam"
+            NIX_CONFIG='programs.steam.enable = true;'
+            ;;
+        lutris)
+            LAUNCHER_NAME="Lutris"
+            PKG_NAME="lutris"
+            FLATPAK_ID="net.lutris.Lutris"
+            NIX_CONFIG='environment.systemPackages = with pkgs; [ lutris ];'
+            ;;
+        retroarch)
+            LAUNCHER_NAME="RetroArch"
+            PKG_NAME="retroarch"
+            FLATPAK_ID="org.libretro.RetroArch"
+            NIX_CONFIG='environment.systemPackages = with pkgs; [ retroarch ];'
+            ;;
+        heroic)
+            LAUNCHER_NAME="Heroic"
+            PKG_NAME="heroic-games-launcher-bin"
+            FLATPAK_ID="com.heroicgameslauncher.hgl"
+            NIX_CONFIG='environment.systemPackages = with pkgs; [ heroic ];'
+            ;;
+        *)
+            printf "%b\n" "${RED}Unsupported launcher preset: $1${RC}"
+            exit 1
+            ;;
+    esac
+}
+
+print_nixos_guidance() {
+    printf "%b\n" "${YELLOW}NixOS is declarative. Linutil will not install or uninstall ${LAUNCHER_NAME} imperatively.${RC}"
+    printf "%b\n" "${CYAN}Add this to /etc/nixos/configuration.nix:${RC}"
+    printf "%s\n" "$NIX_CONFIG"
+    printf "%b\n" "${CYAN}Then apply it with:${RC} sudo nixos-rebuild switch"
+    printf "%b\n" "${CYAN}To uninstall, remove that option/package from configuration.nix and rebuild.${RC}"
+}
+
+is_flatpak_installed() {
+    command_exists flatpak && flatpak list --app --columns=application 2>/dev/null | grep -qx "$1"
+}
+
+install_flatpak_app() {
+    checkFlatpak
+    "$ESCALATION_TOOL" flatpak install --noninteractive flathub "$FLATPAK_ID"
+}
+
+uninstall_flatpak_app() {
+    if is_flatpak_installed "$FLATPAK_ID"; then
+        "$ESCALATION_TOOL" flatpak uninstall --noninteractive "$FLATPAK_ID"
+        return 0
+    fi
+    return 1
+}
+
+is_native_pkg_installed() {
+    pkg="$1"
+    case "$PACKAGER" in
+        pacman) "$PACKAGER" -Qq "$pkg" >/dev/null 2>&1 ;;
+        apt-get | nala) dpkg -s "$pkg" >/dev/null 2>&1 ;;
+        dnf | zypper) rpm -q "$pkg" >/dev/null 2>&1 ;;
+        eopkg) "$PACKAGER" info "$pkg" >/dev/null 2>&1 ;;
+        *) return 1 ;;
+    esac
+}
+
+get_pacman_pkg_name() {
+    pkg="$1"
+    "$PACKAGER" -Qq "$pkg" 2>/dev/null | sed -n '1p'
+}
+
+install_native_pkg() {
+    case "$PACKAGER" in
+        pacman) "$ESCALATION_TOOL" "$PACKAGER" -S --needed --noconfirm "$@" ;;
+        apt-get | nala) "$ESCALATION_TOOL" "$PACKAGER" install -y "$@" ;;
+        dnf) "$ESCALATION_TOOL" "$PACKAGER" install -y "$@" ;;
+        zypper) "$ESCALATION_TOOL" "$PACKAGER" -n install "$@" ;;
+        eopkg) "$ESCALATION_TOOL" "$PACKAGER" install -y "$@" ;;
+        *) return 1 ;;
+    esac
+}
+
+install_aur_pkg_direct() {
+    pkg="$1"
+
+    if ! command_exists git makepkg; then
+        install_native_pkg base-devel git
+    fi
+
+    temp_dir=$(mktemp -d)
+    if git clone "https://aur.archlinux.org/${pkg}.git" "$temp_dir/$pkg"; then
+        if (cd "$temp_dir/$pkg" && makepkg --noconfirm -si); then
+            rm -rf "$temp_dir"
+            return 0
+        fi
+    fi
+
+    rm -rf "$temp_dir"
+    return 1
+}
+
+uninstall_native_pkg() {
+    case "$PACKAGER" in
+        pacman) "$ESCALATION_TOOL" "$PACKAGER" -Rns --noconfirm "$@" ;;
+        apt-get | nala) "$ESCALATION_TOOL" "$PACKAGER" remove -y "$@" ;;
+        dnf) "$ESCALATION_TOOL" "$PACKAGER" remove -y "$@" ;;
+        zypper) "$ESCALATION_TOOL" "$PACKAGER" -n remove "$@" ;;
+        eopkg) "$ESCALATION_TOOL" "$PACKAGER" remove -y "$@" ;;
+        *) return 1 ;;
+    esac
+}
+
+install_arch_launcher() {
+    case "$LAUNCHER_NAME" in
+        Heroic)
+            install_aur_pkg_direct "$PKG_NAME"
+            ;;
+        RetroArch)
+            install_native_pkg retroarch retroarch-assets-xmb retroarch-assets-ozone retroarch-assets-glui libretro-core-info
+            ;;
+        *)
+            install_native_pkg "$PKG_NAME"
+            ;;
+    esac
+}
+
+install_launcher() {
+    if [ "$DTYPE" = "nixos" ]; then
+        print_nixos_guidance
+        return 0
+    fi
+
+    printf "%b\n" "${YELLOW}Installing ${LAUNCHER_NAME}...${RC}"
+    case "$PACKAGER" in
+        pacman)
+            install_arch_launcher
+            ;;
+        apt-get | nala | dnf | zypper | eopkg)
+            if [ "$LAUNCHER_NAME" = "Steam" ] || [ "$LAUNCHER_NAME" = "Heroic" ]; then
+                install_flatpak_app
+            elif [ "$PACKAGER" = "eopkg" ] && [ "$LAUNCHER_NAME" = "RetroArch" ]; then
+                install_flatpak_app
+            else
+                install_native_pkg "$PKG_NAME"
+            fi
+            ;;
+        *)
+            install_flatpak_app
+            ;;
+    esac
+    printf "%b\n" "${GREEN}${LAUNCHER_NAME} installation completed.${RC}"
+}
+
+uninstall_arch_launcher() {
+    installed_pkgs=""
+
+    case "$LAUNCHER_NAME" in
+        Heroic)
+            for pkg in heroic-games-launcher heroic-games-launcher-bin; do
+                installed_pkg=$(get_pacman_pkg_name "$pkg")
+                if [ -n "$installed_pkg" ] && ! printf '%s\n' "$installed_pkgs" | grep -qx "$installed_pkg"; then
+                    installed_pkgs="${installed_pkgs}${installed_pkgs:+
+}$installed_pkg"
+                fi
+            done
+            ;;
+        RetroArch)
+            for pkg in retroarch retroarch-assets-xmb retroarch-assets-ozone retroarch-assets-glui libretro-core-info; do
+                installed_pkg=$(get_pacman_pkg_name "$pkg")
+                if [ -n "$installed_pkg" ] && ! printf '%s\n' "$installed_pkgs" | grep -qx "$installed_pkg"; then
+                    installed_pkgs="${installed_pkgs}${installed_pkgs:+
+}$installed_pkg"
+                fi
+            done
+            ;;
+        *)
+            installed_pkg=$(get_pacman_pkg_name "$PKG_NAME")
+            if [ -n "$installed_pkg" ]; then
+                installed_pkgs="$installed_pkg"
+            fi
+            ;;
+    esac
+
+    if [ -n "$installed_pkgs" ]; then
+        # Remove related pacman packages in one transaction to satisfy dependencies.
+        # shellcheck disable=SC2086
+        uninstall_native_pkg $installed_pkgs
+        return 0
+    fi
+
+    if uninstall_flatpak_app; then
+        return 0
+    fi
+
+    return 1
+}
+
+uninstall_pkg_if_installed() {
+    pkg="$1"
+    if is_native_pkg_installed "$pkg"; then
+        uninstall_native_pkg "$pkg"
+        return 0
+    fi
+    return 1
+}
+
+uninstall_launcher() {
+    if [ "$DTYPE" = "nixos" ]; then
+        print_nixos_guidance
+        return 0
+    fi
+
+    printf "%b\n" "${YELLOW}Uninstalling ${LAUNCHER_NAME}...${RC}"
+    removed_any=false
+
+    case "$PACKAGER" in
+        pacman)
+            if uninstall_arch_launcher; then
+                removed_any=true
+            fi
+            ;;
+        apt-get | nala | dnf | zypper | eopkg)
+            if uninstall_pkg_if_installed "$PKG_NAME"; then
+                removed_any=true
+            fi
+            if uninstall_flatpak_app; then
+                removed_any=true
+            fi
+            ;;
+        *)
+            if uninstall_flatpak_app; then
+                removed_any=true
+            fi
+            ;;
+    esac
+
+    if [ "$removed_any" = true ]; then
+        printf "%b\n" "${GREEN}${LAUNCHER_NAME} uninstall completed.${RC}"
+    else
+        printf "%b\n" "${CYAN}${LAUNCHER_NAME} is not installed.${RC}"
+    fi
+}
+
+main() {
+    preset="${1:-${LAUNCHER_PRESET:-}}"
+    if [ -z "$preset" ]; then
+        printf "%b\n" "${RED}No launcher specified. Please run this script through Gaming > Game Launchers.${RC}"
+        exit 1
+    fi
+    set_launcher "$preset"
+    printf "%b\n" "${YELLOW}Choose action for ${LAUNCHER_NAME}:${RC}"
+    printf "%b\n" "1. ${YELLOW}Install${RC}"
+    printf "%b\n" "2. ${YELLOW}Uninstall${RC}"
+    printf "%b\n" "3. ${YELLOW}Abort${RC}"
+    printf "%b" "Enter your choice [1-3]: "
+    read -r action_choice
+
+    case "$action_choice" in
+        1) install_launcher ;;
+        2) uninstall_launcher ;;
+        3) printf "%b\n" "${CYAN}Aborted.${RC}" ; exit 0 ;;
+        *) printf "%b\n" "${RED}Invalid action choice.${RC}" ; exit 1 ;;
+    esac
+}
+
+checkDistro
+if [ "$DTYPE" = "nixos" ]; then
+    checkArch
+else
+    checkEnv
+fi
+main "$@"

--- a/core/tabs/gaming/heroic-launcher.sh
+++ b/core/tabs/gaming/heroic-launcher.sh
@@ -1,0 +1,5 @@
+#!/bin/sh -e
+
+SCRIPT_DIR=$(dirname -- "$0")
+SCRIPT_DIR=$(cd -- "$SCRIPT_DIR" && pwd)
+LAUNCHER_PRESET=heroic sh "$SCRIPT_DIR/game-launchers.sh" heroic

--- a/core/tabs/gaming/lutris-launcher.sh
+++ b/core/tabs/gaming/lutris-launcher.sh
@@ -1,0 +1,5 @@
+#!/bin/sh -e
+
+SCRIPT_DIR=$(dirname -- "$0")
+SCRIPT_DIR=$(cd -- "$SCRIPT_DIR" && pwd)
+LAUNCHER_PRESET=lutris sh "$SCRIPT_DIR/game-launchers.sh" lutris

--- a/core/tabs/gaming/proton-tools.sh
+++ b/core/tabs/gaming/proton-tools.sh
@@ -9,10 +9,12 @@ set_tool() {
     case "$1" in
         protonplus)
             TOOL_NAME="ProtonPlus"
+            NATIVE_PKG_NAMES="protonplus protonplus-bin"
             FLATPAK_ID="com.vysp3r.ProtonPlus"
             ;;
         protonup-qt)
             TOOL_NAME="ProtonUp-Qt"
+            NATIVE_PKG_NAMES="protonup-qt"
             FLATPAK_ID="net.davidotek.pupgui2"
             ;;
         *)
@@ -26,26 +28,111 @@ is_flatpak_installed() {
     command_exists flatpak && flatpak list --app --columns=application 2>/dev/null | grep -qx "$FLATPAK_ID"
 }
 
+is_native_pkg_installed() {
+    pkg="$1"
+    case "$PACKAGER" in
+        pacman) "$PACKAGER" -Qq "$pkg" >/dev/null 2>&1 ;;
+        apt-get | nala) dpkg -s "$pkg" >/dev/null 2>&1 ;;
+        dnf | zypper) rpm -q "$pkg" >/dev/null 2>&1 ;;
+        apk) "$PACKAGER" info -e "$pkg" >/dev/null 2>&1 ;;
+        xbps-install) xbps-query "$pkg" >/dev/null 2>&1 ;;
+        eopkg) "$PACKAGER" info "$pkg" >/dev/null 2>&1 ;;
+        *) return 1 ;;
+    esac
+}
+
+install_native_pkg() {
+    pkg="$1"
+    case "$PACKAGER" in
+        pacman) "$AUR_HELPER" -S --needed --noconfirm "$pkg" ;;
+        apt-get | nala) "$ESCALATION_TOOL" "$PACKAGER" install -y "$pkg" ;;
+        dnf) "$ESCALATION_TOOL" "$PACKAGER" install -y "$pkg" ;;
+        zypper) "$ESCALATION_TOOL" "$PACKAGER" -n install "$pkg" ;;
+        apk) "$ESCALATION_TOOL" "$PACKAGER" add "$pkg" ;;
+        xbps-install) "$ESCALATION_TOOL" "$PACKAGER" -Sy "$pkg" ;;
+        eopkg) "$ESCALATION_TOOL" "$PACKAGER" install -y "$pkg" ;;
+        *) return 1 ;;
+    esac
+}
+
+install_native_tool() {
+    for pkg in $NATIVE_PKG_NAMES; do
+        if is_native_pkg_installed "$pkg"; then
+            printf "%b\n" "${GREEN}${TOOL_NAME} is already installed as ${pkg}.${RC}"
+            return 0
+        fi
+
+        printf "%b\n" "${YELLOW}Trying native package ${pkg} for ${TOOL_NAME}...${RC}"
+        if install_native_pkg "$pkg"; then
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+uninstall_native_pkg() {
+    pkg="$1"
+    case "$PACKAGER" in
+        pacman) "$ESCALATION_TOOL" "$PACKAGER" -Rns --noconfirm "$pkg" ;;
+        apt-get | nala) "$ESCALATION_TOOL" "$PACKAGER" remove -y "$pkg" ;;
+        dnf) "$ESCALATION_TOOL" "$PACKAGER" remove -y "$pkg" ;;
+        zypper) "$ESCALATION_TOOL" "$PACKAGER" -n remove "$pkg" ;;
+        apk) "$ESCALATION_TOOL" "$PACKAGER" del "$pkg" ;;
+        xbps-install) "$ESCALATION_TOOL" xbps-remove -R "$pkg" ;;
+        eopkg) "$ESCALATION_TOOL" "$PACKAGER" remove -y "$pkg" ;;
+        *) return 1 ;;
+    esac
+}
+
+uninstall_native_tool() {
+    removed_any=false
+
+    for pkg in $NATIVE_PKG_NAMES; do
+        if is_native_pkg_installed "$pkg"; then
+            uninstall_native_pkg "$pkg"
+            removed_any=true
+        fi
+    done
+
+    [ "$removed_any" = true ]
+}
+
 install_tool() {
     if is_flatpak_installed; then
         printf "%b\n" "${GREEN}${TOOL_NAME} is already installed.${RC}"
         return 0
     fi
 
+    if install_native_tool; then
+        printf "%b\n" "${GREEN}${TOOL_NAME} installation completed.${RC}"
+        return 0
+    fi
+
     checkFlatpak
-    printf "%b\n" "${YELLOW}Installing ${TOOL_NAME} with Flatpak...${RC}"
+    printf "%b\n" "${YELLOW}Native package unavailable. Installing ${TOOL_NAME} with Flatpak...${RC}"
     "$ESCALATION_TOOL" flatpak install --noninteractive flathub "$FLATPAK_ID"
     printf "%b\n" "${GREEN}${TOOL_NAME} installation completed.${RC}"
 }
 
 uninstall_tool() {
-    if ! is_flatpak_installed; then
-        printf "%b\n" "${CYAN}${TOOL_NAME} is not installed via Flatpak.${RC}"
+    removed_any=false
+
+    if uninstall_native_tool; then
+        removed_any=true
+    fi
+
+    if is_flatpak_installed; then
+        printf "%b\n" "${YELLOW}Uninstalling ${TOOL_NAME} with Flatpak...${RC}"
+        "$ESCALATION_TOOL" flatpak uninstall --noninteractive "$FLATPAK_ID"
+        removed_any=true
+    fi
+
+    if [ "$removed_any" = false ]; then
+        printf "%b\n" "${CYAN}${TOOL_NAME} is not installed.${RC}"
         return 0
     fi
 
-    printf "%b\n" "${YELLOW}Uninstalling ${TOOL_NAME} with Flatpak...${RC}"
-    "$ESCALATION_TOOL" flatpak uninstall --noninteractive "$FLATPAK_ID"
     printf "%b\n" "${GREEN}${TOOL_NAME} uninstall completed.${RC}"
 }
 

--- a/core/tabs/gaming/proton-tools.sh
+++ b/core/tabs/gaming/proton-tools.sh
@@ -1,0 +1,77 @@
+#!/bin/sh -e
+
+SCRIPT_DIR=$(dirname -- "$0")
+SCRIPT_DIR=$(cd -- "$SCRIPT_DIR" && pwd)
+# shellcheck source=core/tabs/common-script.sh
+. "$SCRIPT_DIR/../common-script.sh"
+
+set_tool() {
+    case "$1" in
+        protonplus)
+            TOOL_NAME="ProtonPlus"
+            FLATPAK_ID="com.vysp3r.ProtonPlus"
+            ;;
+        protonup-qt)
+            TOOL_NAME="ProtonUp-Qt"
+            FLATPAK_ID="net.davidotek.pupgui2"
+            ;;
+        *)
+            printf "%b\n" "${RED}Unsupported Proton tool preset: $1${RC}"
+            exit 1
+            ;;
+    esac
+}
+
+is_flatpak_installed() {
+    command_exists flatpak && flatpak list --app --columns=application 2>/dev/null | grep -qx "$FLATPAK_ID"
+}
+
+install_tool() {
+    if is_flatpak_installed; then
+        printf "%b\n" "${GREEN}${TOOL_NAME} is already installed.${RC}"
+        return 0
+    fi
+
+    checkFlatpak
+    printf "%b\n" "${YELLOW}Installing ${TOOL_NAME} with Flatpak...${RC}"
+    "$ESCALATION_TOOL" flatpak install --noninteractive flathub "$FLATPAK_ID"
+    printf "%b\n" "${GREEN}${TOOL_NAME} installation completed.${RC}"
+}
+
+uninstall_tool() {
+    if ! is_flatpak_installed; then
+        printf "%b\n" "${CYAN}${TOOL_NAME} is not installed via Flatpak.${RC}"
+        return 0
+    fi
+
+    printf "%b\n" "${YELLOW}Uninstalling ${TOOL_NAME} with Flatpak...${RC}"
+    "$ESCALATION_TOOL" flatpak uninstall --noninteractive "$FLATPAK_ID"
+    printf "%b\n" "${GREEN}${TOOL_NAME} uninstall completed.${RC}"
+}
+
+main() {
+    preset="${1:-${PROTON_TOOL_PRESET:-}}"
+    if [ -z "$preset" ]; then
+        printf "%b\n" "${RED}No Proton tool specified. Please run this script through Gaming > Tools and Setups.${RC}"
+        exit 1
+    fi
+
+    set_tool "$preset"
+    printf "%b\n" "${YELLOW}Choose action for ${TOOL_NAME}:${RC}"
+    printf "%b\n" "1. ${YELLOW}Install${RC}"
+    printf "%b\n" "2. ${YELLOW}Uninstall${RC}"
+    printf "%b\n" "3. ${YELLOW}Abort${RC}"
+    printf "%b" "Enter your choice [1-3]: "
+    read -r action_choice
+
+    case "$action_choice" in
+        1) install_tool ;;
+        2) uninstall_tool ;;
+        3) printf "%b\n" "${CYAN}Aborted.${RC}" ; exit 0 ;;
+        *) printf "%b\n" "${RED}Invalid action choice.${RC}" ; exit 1 ;;
+    esac
+}
+
+checkDistro
+checkEnv
+main "$@"

--- a/core/tabs/gaming/protonplus.sh
+++ b/core/tabs/gaming/protonplus.sh
@@ -1,0 +1,5 @@
+#!/bin/sh -e
+
+SCRIPT_DIR=$(dirname -- "$0")
+SCRIPT_DIR=$(cd -- "$SCRIPT_DIR" && pwd)
+PROTON_TOOL_PRESET=protonplus sh "$SCRIPT_DIR/proton-tools.sh" protonplus

--- a/core/tabs/gaming/protonup-qt.sh
+++ b/core/tabs/gaming/protonup-qt.sh
@@ -1,0 +1,5 @@
+#!/bin/sh -e
+
+SCRIPT_DIR=$(dirname -- "$0")
+SCRIPT_DIR=$(cd -- "$SCRIPT_DIR" && pwd)
+PROTON_TOOL_PRESET=protonup-qt sh "$SCRIPT_DIR/proton-tools.sh" protonup-qt

--- a/core/tabs/gaming/retroarch-launcher.sh
+++ b/core/tabs/gaming/retroarch-launcher.sh
@@ -1,0 +1,5 @@
+#!/bin/sh -e
+
+SCRIPT_DIR=$(dirname -- "$0")
+SCRIPT_DIR=$(cd -- "$SCRIPT_DIR" && pwd)
+LAUNCHER_PRESET=retroarch sh "$SCRIPT_DIR/game-launchers.sh" retroarch

--- a/core/tabs/gaming/steam-launcher.sh
+++ b/core/tabs/gaming/steam-launcher.sh
@@ -1,0 +1,5 @@
+#!/bin/sh -e
+
+SCRIPT_DIR=$(dirname -- "$0")
+SCRIPT_DIR=$(cd -- "$SCRIPT_DIR" && pwd)
+LAUNCHER_PRESET=steam sh "$SCRIPT_DIR/game-launchers.sh" steam

--- a/core/tabs/gaming/tab_data.toml
+++ b/core/tabs/gaming/tab_data.toml
@@ -153,13 +153,13 @@ task_list = "I"
 
 [[data.entries]]
 name = "ProtonPlus"
-description = "Manage ProtonPlus installation with Flatpak."
+description = "Manage ProtonPlus installation with native packages first and Flatpak fallback."
 script = "protonplus.sh"
 task_list = "FI"
 
 [[data.entries]]
 name = "ProtonUp-Qt"
-description = "Manage ProtonUp-Qt installation with Flatpak."
+description = "Manage ProtonUp-Qt installation with native packages first and Flatpak fallback."
 script = "protonup-qt.sh"
 task_list = "FI"
 

--- a/core/tabs/gaming/tab_data.toml
+++ b/core/tabs/gaming/tab_data.toml
@@ -152,6 +152,18 @@ script = "../system-setup/gaming-setup.sh"
 task_list = "I"
 
 [[data.entries]]
+name = "ProtonPlus"
+description = "Manage ProtonPlus installation with Flatpak."
+script = "protonplus.sh"
+task_list = "FI"
+
+[[data.entries]]
+name = "ProtonUp-Qt"
+description = "Manage ProtonUp-Qt installation with Flatpak."
+script = "protonup-qt.sh"
+task_list = "FI"
+
+[[data.entries]]
 name = "General GPU Drivers"
 description = "Auto-detects your GPU and installs a recommended driver stack for your distro, with NixOS guidance."
 script = "../system-setup/gpu-driver.sh"

--- a/core/tabs/gaming/tab_data.toml
+++ b/core/tabs/gaming/tab_data.toml
@@ -109,15 +109,6 @@ script = "emulators/sega/kronos.sh"
 task_list = "FM"
 
 [[data.entries]]
-name = "Multi-System Emulators"
-
-[[data.entries.entries]]
-name = "RetroArch Game Emulator"
-description = "Frontend for emulators, game engines and media players. NO Games or Bios' are included"
-script = "emulators/retroarch.sh"
-task_list = "FM"
-
-[[data.entries]]
 name = "Xbox Emulators"
 
 [[data.entries.entries]]
@@ -182,6 +173,34 @@ task_list = "I SS"
 matches = true
 data = { environment = "XDG_SESSION_TYPE" }
 values = ["wayland", "Wayland"]
+
+[[data]]
+name = "Game Launchers"
+
+[[data.entries]]
+name = "Steam"
+description = "Manage Steam launcher installation with Install, Uninstall, or Abort actions."
+script = "steam-launcher.sh"
+task_list = "FI"
+
+[[data.entries]]
+name = "Lutris"
+description = "Manage Lutris launcher installation with Install, Uninstall, or Abort actions."
+script = "lutris-launcher.sh"
+task_list = "FI"
+
+[[data.entries]]
+name = "RetroArch"
+description = "Manage RetroArch launcher installation with Install, Uninstall, or Abort actions."
+script = "retroarch-launcher.sh"
+task_list = "FI"
+
+[[data.entries]]
+name = "Heroic"
+description = "Manage Heroic launcher installation with Install, Uninstall, or Abort actions."
+script = "heroic-launcher.sh"
+task_list = "FI"
+
 [[data]]
 name = "Arc Raiders Titus Mods"
 description = "Applies optimized game configuration files from ChrisTitusTech/arc-raiders. Sets Engine.ini to read-only to prevent the game from overwriting the settings, disables motion blur, and enables VRR optimizations."

--- a/core/tabs/gaming/tab_data.toml
+++ b/core/tabs/gaming/tab_data.toml
@@ -147,7 +147,7 @@ task_list = "FI"
 
 [[data.entries]]
 name = "Gaming Dependencies"
-description = "This script is designed to handle the installation of gaming dependencies across different Linux distributions."
+description = "Installs gaming runtime dependencies across distributions. Steam and Lutris are managed separately from Game Launchers."
 script = "../system-setup/gaming-setup.sh"
 task_list = "I"
 

--- a/core/tabs/system-setup/gaming-setup.sh
+++ b/core/tabs/system-setup/gaming-setup.sh
@@ -94,7 +94,7 @@ installDepend() {
                 if ! grep -q "^\s*\[lib32\]" /etc/pacman.conf; then
                     echo "[lib32]" | "$ESCALATION_TOOL" tee -a /etc/pacman.conf
                     echo "Include = /etc/pacman.d/mirrorlist" | "$ESCALATION_TOOL" tee -a /etc/pacman.conf
-                    run_install_step "Refresh packages after enabling lib32" "$ESCALATION_TOOL" "$PACKAGER" -Syu
+                    run_install_step "Refresh packages after enabling lib32" "$ESCALATION_TOOL" "$PACKAGER" -Sy --noconfirm
                 else
                     printf "%b\n" "${GREEN}lib32 is already enabled.${RC}"
                 fi
@@ -103,7 +103,7 @@ installDepend() {
                 if ! grep -q "^\s*\[multilib\]" /etc/pacman.conf; then
                     echo "[multilib]" | "$ESCALATION_TOOL" tee -a /etc/pacman.conf
                     echo "Include = /etc/pacman.d/mirrorlist" | "$ESCALATION_TOOL" tee -a /etc/pacman.conf
-                    run_install_step "Refresh packages after enabling multilib" "$ESCALATION_TOOL" "$PACKAGER" -Syu
+                    run_install_step "Refresh packages after enabling multilib" "$ESCALATION_TOOL" "$PACKAGER" -Sy --noconfirm
                 else
                     printf "%b\n" "${GREEN}Multilib is already enabled.${RC}"
                 fi

--- a/core/tabs/system-setup/gaming-setup.sh
+++ b/core/tabs/system-setup/gaming-setup.sh
@@ -156,38 +156,11 @@ installDepend() {
 installAdditionalDepend() {
     case "$PACKAGER" in
         pacman)
-            DISTRO_DEPS='steam lutris goverlay'
-            run_install_step "Install additional gaming apps" \
+            DISTRO_DEPS='goverlay'
+            run_install_step "Install additional gaming utilities" \
                 "$ESCALATION_TOOL" "$PACKAGER" -S --needed --noconfirm $DISTRO_DEPS
             ;;
-        apt-get | nala)
-            printf "%b\n" "${YELLOW}Installing Lutris...${RC}"
-            lutris_url=$(curl -s https://api.github.com/repos/lutris/lutris/releases/latest | grep "browser_download_url.*\.deb" | cut -d '"' -f 4)
-            
-            if [ -n "$lutris_url" ]; then
-                printf "%b\n" "${YELLOW}Downloading latest Lutris from GitHub...${RC}"
-                run_install_step "Download latest Lutris package" curl -sSLo lutris.deb "$lutris_url"
-                run_install_step "Install downloaded Lutris package" "$ESCALATION_TOOL" "$PACKAGER" install -y ./lutris.deb
-                rm lutris.deb
-                run_install_step "Refresh package indexes" "$ESCALATION_TOOL" "$PACKAGER" update
-                run_install_step "Install Lutris from repositories" "$ESCALATION_TOOL" "$PACKAGER" install -y lutris
-            fi
-
-            printf "%b\n" "${GREEN}Lutris Installation complete.${RC}"
-            printf "%b\n" "${YELLOW}Installing steam...${RC}"
-            run_install_step "Install Steam" "$ESCALATION_TOOL" "$PACKAGER" install -y steam
-            ;;
-        dnf)
-            DISTRO_DEPS='steam lutris'
-            run_install_step "Install additional gaming apps" "$ESCALATION_TOOL" "$PACKAGER" install -y $DISTRO_DEPS
-            ;;
-        zypper)
-            DISTRO_DEPS='lutris'
-            run_install_step "Install additional gaming apps" "$ESCALATION_TOOL" "$PACKAGER" -n install $DISTRO_DEPS
-            ;;
-        eopkg)
-            DISTRO_DEPS='steam lutris'
-            run_install_step "Install additional gaming apps" "$ESCALATION_TOOL" "$PACKAGER" install -y $DISTRO_DEPS
+        apt-get | nala | dnf | zypper | eopkg)
             ;;
         *)
             printf "%b\n" "${RED}Unsupported package manager ${PACKAGER}${RC}"

--- a/core/tabs/system-setup/gaming-setup.sh
+++ b/core/tabs/system-setup/gaming-setup.sh
@@ -40,12 +40,25 @@ run_install_step() {
     step_name="$1"
     shift
     step_output=$(mktemp)
+    step_dir=$(mktemp -d)
+    step_pipe="$step_dir/output.pipe"
+    mkfifo "$step_pipe"
 
-    if "$@" > "$step_output" 2>&1; then
-        cat "$step_output"
+    printf "%b\n" "${CYAN}[RUNNING]${RC} ${step_name}"
+    tee "$step_output" < "$step_pipe" &
+    tee_pid=$!
+
+    set +e
+    "$@" > "$step_pipe" 2>&1
+    step_status=$?
+    wait "$tee_pid"
+    set -e
+
+    rm -rf "$step_dir"
+
+    if [ "$step_status" -eq 0 ]; then
         printf "%b\n" "${GREEN}[OK]${RC} ${step_name}"
     else
-        cat "$step_output"
         printf "%b\n" "${YELLOW}[FAILED]${RC} ${step_name}"
         record_step_failure "$step_name" "$step_output"
     fi

--- a/core/tabs/system-setup/gaming-setup.sh
+++ b/core/tabs/system-setup/gaming-setup.sh
@@ -40,80 +40,38 @@ installDepend() {
                 gamescope mangohud lib32-mangohud gamemode lib32-gamemode"
 
             if "$PACKAGER" -Qq pipewire-jack >/dev/null 2>&1; then
-                "$ESCALATION_TOOL" "$PACKAGER" -S --needed --noconfirm lib32-pipewire-jack
+                "$ESCALATION_TOOL" "$PACKAGER" -S --needed lib32-pipewire-jack
             elif "$PACKAGER" -Qq jack2 >/dev/null 2>&1; then
-                "$ESCALATION_TOOL" "$PACKAGER" -S --needed --noconfirm lib32-jack2
+                "$ESCALATION_TOOL" "$PACKAGER" -S --needed lib32-jack2
             fi
 
-            $AUR_HELPER -S --needed --noconfirm $DEPENDENCIES $DISTRO_DEPS
+            $AUR_HELPER -S --needed $DEPENDENCIES $DISTRO_DEPS
             ;;
         apt-get | nala)
             "$ESCALATION_TOOL" dpkg --add-architecture i386
             "$ESCALATION_TOOL" "$PACKAGER" update
             
-            "$ESCALATION_TOOL" "$PACKAGER" install -y $DEPENDENCIES
+            "$ESCALATION_TOOL" "$PACKAGER" install $DEPENDENCIES
             
             DISTRO_DEPS="libasound2-plugins:i386 libsdl2-2.0-0:i386 libdbus-1-3:i386 libsqlite3-0:i386 wine32:i386"
             apt-cache show software-properties-common >/dev/null 2>&1 && DISTRO_DEPS="$DISTRO_DEPS software-properties-common"
             
-            "$ESCALATION_TOOL" "$PACKAGER" install -y $DISTRO_DEPS
+            "$ESCALATION_TOOL" "$PACKAGER" install $DISTRO_DEPS
             ;;
         dnf)
             printf "%b\n" "${CYAN}Installing rpmfusion repos.${RC}"
-            "$ESCALATION_TOOL" "$PACKAGER" install https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-"$(rpm -E %fedora)".noarch.rpm https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-"$(rpm -E %fedora)".noarch.rpm -y
+            "$ESCALATION_TOOL" "$PACKAGER" install https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-"$(rpm -E %fedora)".noarch.rpm https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-"$(rpm -E %fedora)".noarch.rpm
             "$ESCALATION_TOOL" "$PACKAGER" config-manager setopt --repo fedora-cisco-openh264 enabled=1
     
-            "$ESCALATION_TOOL" "$PACKAGER" install -y $DEPENDENCIES
+            "$ESCALATION_TOOL" "$PACKAGER" install $DEPENDENCIES
             ;;
         zypper)
-            "$ESCALATION_TOOL" "$PACKAGER" -n install $DEPENDENCIES
+            "$ESCALATION_TOOL" "$PACKAGER" install $DEPENDENCIES
             ;;
         eopkg)
             DISTRO_DEPS="libgnutls libgtk-2 libgtk-3 pulseaudio alsa-lib alsa-plugins giflib libpng openal-soft libxcomposite libxinerama ncurses vulkan ocl-icd libva gst-plugins-base sdl2 v4l-utils sqlite3"
 
-            "$ESCALATION_TOOL" "$PACKAGER" install -y $DEPENDENCIES $DISTRO_DEPS
-            ;;
-        *)
-            printf "%b\n" "${RED}Unsupported package manager ${PACKAGER}${RC}"
-            exit 1
-            ;;
-    esac
-}
-
-installAdditionalDepend() {
-    case "$PACKAGER" in
-        pacman)
-            DISTRO_DEPS='steam lutris goverlay'
-            "$ESCALATION_TOOL" "$PACKAGER" -S --needed --noconfirm $DISTRO_DEPS
-            ;;
-        apt-get | nala)
-            printf "%b\n" "${YELLOW}Installing Lutris...${RC}"
-            lutris_url=$(curl -s https://api.github.com/repos/lutris/lutris/releases/latest | grep "browser_download_url.*\.deb" | cut -d '"' -f 4)
-            
-            if [ -n "$lutris_url" ]; then
-                printf "%b\n" "${YELLOW}Downloading latest Lutris from GitHub...${RC}"
-                curl -sSLo lutris.deb "$lutris_url"
-                "$ESCALATION_TOOL" "$PACKAGER" install -y ./lutris.deb
-                rm lutris.deb
-                "$ESCALATION_TOOL" "$PACKAGER" update
-                "$ESCALATION_TOOL" "$PACKAGER" install -y lutris
-            fi
-
-            printf "%b\n" "${GREEN}Lutris Installation complete.${RC}"
-            printf "%b\n" "${YELLOW}Installing steam...${RC}"
-            "$ESCALATION_TOOL" "$PACKAGER" install -y steam
-            ;;
-        dnf)
-            DISTRO_DEPS='steam lutris'
-            "$ESCALATION_TOOL" "$PACKAGER" install -y $DISTRO_DEPS
-            ;;
-        zypper)
-            DISTRO_DEPS='lutris'
-            "$ESCALATION_TOOL" "$PACKAGER" -n install $DISTRO_DEPS
-            ;;
-        eopkg)
-            DISTRO_DEPS='steam lutris'
-            "$ESCALATION_TOOL" "$PACKAGER" install -y $DISTRO_DEPS
+            "$ESCALATION_TOOL" "$PACKAGER" install $DEPENDENCIES $DISTRO_DEPS
             ;;
         *)
             printf "%b\n" "${RED}Unsupported package manager ${PACKAGER}${RC}"
@@ -126,4 +84,3 @@ checkEnv
 checkAURHelper
 checkEscalationTool
 installDepend
-installAdditionalDepend

--- a/docs/content/userguide/_index.md
+++ b/docs/content/userguide/_index.md
@@ -77,7 +77,7 @@ Tools for monitor management, printer setup, Bluetooth, WiFi, service management
 
 ### Gaming
 
-Install gaming dependencies, emulators, and game-specific optimizations.
+Install gaming dependencies, game launchers, emulators, and game-specific optimizations.
 
 **[Read the Features Guide →](features/)**
 

--- a/docs/content/userguide/_index.md
+++ b/docs/content/userguide/_index.md
@@ -13,7 +13,7 @@ Linutil is a distro-agnostic toolbox designed to simplify everyday Linux tasks. 
 - **System Setup**: Configure your distro with optimized settings and tools
 - **Security**: Apply firewall baselines and harden your system
 - **Utilities**: Manage monitors, printers, Bluetooth, WiFi, and more
-- **Gaming**: Set up gaming dependencies and emulators
+- **Gaming**: Set up gaming dependencies, game launchers, emulators, and game-specific optimizations
 
 ## Who Should Use Linutil?
 
@@ -77,7 +77,7 @@ Tools for monitor management, printer setup, Bluetooth, WiFi, service management
 
 ### Gaming
 
-Install gaming dependencies, game launchers, emulators, and game-specific optimizations.
+Install gaming dependencies, manage game launchers, add emulators, and apply game-specific optimizations.
 
 **[Read the Features Guide →](features/)**
 

--- a/docs/content/userguide/features/_index.md
+++ b/docs/content/userguide/features/_index.md
@@ -32,6 +32,19 @@ An alternative to UFW, FirewallD is the default firewall manager on Fedora and R
 
 Installs the libraries and tools needed to run games on Linux across different distributions (Steam, Wine, DXVK, Vulkan drivers, etc.).
 
+### Game Launchers
+
+The Gaming tab includes a **Game Launchers** section for managing common launchers with an interactive Install, Uninstall, or Abort prompt.
+
+| Launcher | Behavior |
+|----------|----------|
+| Steam | Uses native packages on Arch-based systems; uses Flatpak on several other distros where native availability is less consistent |
+| Lutris | Uses the native package manager on supported distros |
+| RetroArch | Uses native packages where available, with Flatpak fallback for selected distros |
+| Heroic | Uses Flatpak on non-Arch systems; on Arch-based systems builds `heroic-games-launcher-bin` directly from AUR |
+
+On NixOS, these entries print declarative configuration guidance instead of modifying the system imperatively.
+
 ### Emulators
 
 | Emulator | Console |

--- a/docs/content/userguide/features/_index.md
+++ b/docs/content/userguide/features/_index.md
@@ -34,7 +34,7 @@ Installs the libraries and tools needed to run games on Linux across different d
 
 ### Proton Compatibility Tools
 
-The Gaming tab includes **ProtonPlus** and **ProtonUp-Qt** under **Tools and Setups**. Both entries use an interactive Install, Uninstall, or Abort prompt and prefer Flathub Flatpak packages:
+The Gaming tab includes **ProtonPlus** and **ProtonUp-Qt** under **Tools and Setups**. Both entries use an interactive Install, Uninstall, or Abort prompt, try native packages first, and fall back to Flathub Flatpak packages:
 
 | Tool | Flatpak ID |
 |------|------------|

--- a/docs/content/userguide/features/_index.md
+++ b/docs/content/userguide/features/_index.md
@@ -30,7 +30,7 @@ An alternative to UFW, FirewallD is the default firewall manager on Fedora and R
 
 ### Gaming Dependencies
 
-Installs the libraries and tools needed to run games on Linux across different distributions (Steam, Wine, DXVK, Vulkan drivers, etc.).
+Installs the libraries and tools needed to run games on Linux across different distributions, such as Wine, Vulkan support, MangoHud, GameMode, and related runtime dependencies. Steam and Lutris are managed separately from the **Game Launchers** section.
 
 ### Proton Compatibility Tools
 

--- a/docs/content/userguide/features/_index.md
+++ b/docs/content/userguide/features/_index.md
@@ -32,6 +32,15 @@ An alternative to UFW, FirewallD is the default firewall manager on Fedora and R
 
 Installs the libraries and tools needed to run games on Linux across different distributions (Steam, Wine, DXVK, Vulkan drivers, etc.).
 
+### Proton Compatibility Tools
+
+The Gaming tab includes **ProtonPlus** and **ProtonUp-Qt** under **Tools and Setups**. Both entries use an interactive Install, Uninstall, or Abort prompt and prefer Flathub Flatpak packages:
+
+| Tool | Flatpak ID |
+|------|------------|
+| ProtonPlus | `com.vysp3r.ProtonPlus` |
+| ProtonUp-Qt | `net.davidotek.pupgui2` |
+
 ### Game Launchers
 
 The Gaming tab includes a **Game Launchers** section for managing common launchers with an interactive Install, Uninstall, or Abort prompt.

--- a/docs/content/userguide/tweaks/_index.md
+++ b/docs/content/userguide/tweaks/_index.md
@@ -47,7 +47,7 @@ The **System Setup** section contains distro-specific and general configuration 
 | Hyprland (JaKooLit) | Install JaKooLit's Hyprland configuration |
 | Full System Cleanup | Remove unused packages, clear cache, empty trash |
 | Full System Update | Update all packages to the latest available |
-| Gaming Dependencies | Install gaming dependencies across distros |
+| Gaming Dependencies | Install gaming runtime dependencies across distros |
 | Global Theme | Install and configure a global desktop theme |
 | Remove Snaps | Remove Snap and prevent it from reinstalling |
 | Build Prerequisites | Install software build dependencies |
@@ -83,7 +83,7 @@ These scripts work across all distributions:
 |--------|-------------|
 | Full System Update | Update all packages using your distro's package manager |
 | Full System Cleanup | Clear package caches, temp files, and trash |
-| Gaming Dependencies | Install dependencies needed for gaming on Linux |
+| Gaming Dependencies | Install runtime dependencies needed for gaming on Linux |
 | Build Prerequisites | Install common software build dependencies |
 
 > [!TIP]

--- a/docs/content/userguide/walkthrough.md
+++ b/docs/content/userguide/walkthrough.md
@@ -140,6 +140,17 @@ https://github.com/AdnanHodzic/auto-cpufreq
 - **General GPU Drivers**: Auto-detects your GPU and installs a recommended driver stack for your distro, with NixOS guidance.
 - **Nvidia Drivers & Hardware Acceleration**: Opens the Arch-specific NVIDIA installer (kept under System Setup / Arch).
 - **Waydroid**: Waydroid is an emulator that allows you to run Android apps and games on Linux.
+
+### Game Launchers
+
+- **Steam**: Manage Steam launcher installation with Install, Uninstall, or Abort actions.
+- **Lutris**: Manage Lutris launcher installation with Install, Uninstall, or Abort actions.
+- **RetroArch**: Manage RetroArch installation with Install, Uninstall, or Abort actions.
+- **Heroic**: Manage Heroic Games Launcher installation with Install, Uninstall, or Abort actions.
+
+On NixOS, launcher entries print declarative configuration guidance instead of applying imperative package changes.
+
+On Arch-based systems, Heroic is built directly from the AUR `heroic-games-launcher-bin` package.
 - **Arc Raiders Titus Mods**: Applies optimized game configuration files from ChrisTitusTech/arc-raiders. Sets Engine.ini to read-only to prevent the game from overwriting the settings, disables motion blur, and enables VRR optimizations.
 - **Diablo II Resurrected Loot Filter**: Installs a loot filter for Diablo II Resurrected from ChrisTitusTech/d2r-loot-filter. Highlights high runes and other valuable items. Works on Battle.net and single player. After install, add launch option: -mod lootfilter -txt
 - **Fallout 76 INI and Mods**: Installs a custom Fallout76Custom.ini and mods from ChrisTitusTech/fallout76-configs via Steam. Improves performance and stability with quality of life tweaks.

--- a/docs/content/userguide/walkthrough.md
+++ b/docs/content/userguide/walkthrough.md
@@ -127,8 +127,8 @@ https://github.com/AdnanHodzic/auto-cpufreq
 - **Auto Mount Drive**: This utility is designed to help with automating the process of mounting a drive on to your system.
 - **Bottles**: Bottles allows Windows software, like applications and games, to run on Linux. Bottles also provides tools to categorize, organize and optimize your applications.
 - **Gaming Dependencies**: Installs gaming runtime dependencies across distributions. Steam and Lutris are managed separately from Game Launchers.
-- **ProtonPlus**: Manage ProtonPlus installation with Flatpak.
-- **ProtonUp-Qt**: Manage ProtonUp-Qt installation with Flatpak.
+- **ProtonPlus**: Manage ProtonPlus installation with native packages first and Flatpak fallback.
+- **ProtonUp-Qt**: Manage ProtonUp-Qt installation with native packages first and Flatpak fallback.
 - **General GPU Drivers**: Auto-detects your GPU and installs a recommended driver stack for your distro, with NixOS guidance.
 - **Nvidia Drivers & Hardware Acceleration**: Opens the Arch-specific NVIDIA installer (kept under System Setup / Arch).
 - **Waydroid**: Waydroid is an emulator that allows you to run Android apps and games on Linux.

--- a/docs/content/userguide/walkthrough.md
+++ b/docs/content/userguide/walkthrough.md
@@ -126,7 +126,7 @@ https://github.com/ChrisTitusTech/neovim
 https://github.com/AdnanHodzic/auto-cpufreq
 - **Auto Mount Drive**: This utility is designed to help with automating the process of mounting a drive on to your system.
 - **Bottles**: Bottles allows Windows software, like applications and games, to run on Linux. Bottles also provides tools to categorize, organize and optimize your applications.
-- **Gaming Dependencies**: This script is designed to handle the installation of gaming dependencies across different Linux distributions.
+- **Gaming Dependencies**: Installs gaming runtime dependencies across distributions. Steam and Lutris are managed separately from Game Launchers.
 - **ProtonPlus**: Manage ProtonPlus installation with Flatpak.
 - **ProtonUp-Qt**: Manage ProtonUp-Qt installation with Flatpak.
 - **General GPU Drivers**: Auto-detects your GPU and installs a recommended driver stack for your distro, with NixOS guidance.
@@ -235,6 +235,7 @@ https://github.com/ChrisTitusTech/dwm-titus
 - **Bluetooth Manager**: This utility is designed to manage bluetooth in your system
 - **Numlock on Startup**: This utility is designed to enable Num Lock at boot, rather than within desktop environments like KDE or GNOME
 - **Ollama**: This utility is designed to manage ollama in your system
+- **Ranalama**: This utility is designed to manage ramalama in your system
 - **Service Manager**: This utility is designed to manage services in your system
 - **US Locale Setup**: This fixes US UTF-8 Locale and Folder listings
 - **WiFi Manager**: This utility is designed to manage wifi in your system

--- a/docs/content/userguide/walkthrough.md
+++ b/docs/content/userguide/walkthrough.md
@@ -74,12 +74,6 @@ https://github.com/ChrisTitusTech/neovim
 - **Android Debloater**: Universal Android Debloater (UAD) is a tool designed to help users remove bloatware and unnecessary pre-installed applications from Android devices, enhancing performance and user experience.
 - **Bash Prompt**: The .bashrc file is a script that runs every time a new terminal session is started in Unix-like operating systems. It is used to configure the shell session, set up aliases, define functions, and more, making the terminal easier to use and more powerful. This command configures the key sections and functionalities defined in the .bashrc file from CTT's mybash repository. https://github.com/ChrisTitusTech/mybash
 - **Docker**: Docker is an open platform that uses OS-level virtualization to deliver software in packages called containers.
-- **DWM-Titus**: DWM is a dynamic window manager for X.
-It manages windows in tiled, monocle and floating layouts.
-All of the layouts can be applied dynamically, optimising the environment for the application in use and the task performed.
-This command installs and configures DWM and a desktop manager.
-The list of patches applied can be found in CTT's DWM repository
-https://github.com/ChrisTitusTech/dwm-titus
 - **Fastfetch**: Fastfetch is a neofetch-like tool for fetching system information and displaying it prettily. It is written mainly in C, with performance and customizability in mind. This command installs fastfetch and configures from CTT's mybash repository. https://github.com/ChrisTitusTech/mybash
 - **Flatpak / Flathub**: Flatpak is a universal application sandbox for Linux that uses isolated packages from Flathub to prevent conflicts and system alterations, while alleviating dependency concerns. This command installs Flatpak and adds the Flathub repository
 - **Ghostty**: Ghostty is a terminal emulator that has embedded web technologies, allowing for a highly customizable and visually appealing terminal experience.
@@ -121,10 +115,6 @@ https://github.com/ChrisTitusTech/dwm-titus
 - **Flycast**: A Dreamcase emulator. NO Games are included
 - **Kronos**: A Sega Saturn emulator. NO Games are included
 
-### Multi-System Emulators
-
-- **RetroArch Game Emulator**: Frontend for emulators, game engines and media players. NO Games or Bios' are included
-
 ### Xbox Emulators
 
 - **XEMU**: An Original Xbox emulator. NO Games or Bios' are included
@@ -137,6 +127,8 @@ https://github.com/AdnanHodzic/auto-cpufreq
 - **Auto Mount Drive**: This utility is designed to help with automating the process of mounting a drive on to your system.
 - **Bottles**: Bottles allows Windows software, like applications and games, to run on Linux. Bottles also provides tools to categorize, organize and optimize your applications.
 - **Gaming Dependencies**: This script is designed to handle the installation of gaming dependencies across different Linux distributions.
+- **ProtonPlus**: Manage ProtonPlus installation with Flatpak.
+- **ProtonUp-Qt**: Manage ProtonUp-Qt installation with Flatpak.
 - **General GPU Drivers**: Auto-detects your GPU and installs a recommended driver stack for your distro, with NixOS guidance.
 - **Nvidia Drivers & Hardware Acceleration**: Opens the Arch-specific NVIDIA installer (kept under System Setup / Arch).
 - **Waydroid**: Waydroid is an emulator that allows you to run Android apps and games on Linux.
@@ -145,15 +137,12 @@ https://github.com/AdnanHodzic/auto-cpufreq
 
 - **Steam**: Manage Steam launcher installation with Install, Uninstall, or Abort actions.
 - **Lutris**: Manage Lutris launcher installation with Install, Uninstall, or Abort actions.
-- **RetroArch**: Manage RetroArch installation with Install, Uninstall, or Abort actions.
-- **Heroic**: Manage Heroic Games Launcher installation with Install, Uninstall, or Abort actions.
-
-On NixOS, launcher entries print declarative configuration guidance instead of applying imperative package changes.
-
-On Arch-based systems, Heroic is built directly from the AUR `heroic-games-launcher-bin` package.
+- **RetroArch**: Manage RetroArch launcher installation with Install, Uninstall, or Abort actions.
+- **Heroic**: Manage Heroic launcher installation with Install, Uninstall, or Abort actions.
 - **Arc Raiders Titus Mods**: Applies optimized game configuration files from ChrisTitusTech/arc-raiders. Sets Engine.ini to read-only to prevent the game from overwriting the settings, disables motion blur, and enables VRR optimizations.
 - **Diablo II Resurrected Loot Filter**: Installs a loot filter for Diablo II Resurrected from ChrisTitusTech/d2r-loot-filter. Highlights high runes and other valuable items. Works on Battle.net and single player. After install, add launch option: -mod lootfilter -txt
 - **Fallout 76 INI and Mods**: Installs a custom Fallout76Custom.ini and mods from ChrisTitusTech/fallout76-configs via Steam. Improves performance and stability with quality of life tweaks.
+- **Starfield Titus INI and Mods**: Installs custom Starfield mods from ChrisTitusTech/starfield-config via steam.
 
 ## Security
 
@@ -170,9 +159,16 @@ On Arch-based systems, Heroic is built directly from the AUR `heroic-games-launc
 ### Arch
 
 - **Arch Server Setup**: This command installs a minimal arch server setup under 5 minutes.
+- **DWM-Titus**: DWM is a dynamic window manager for X.
+It manages windows in tiled, monocle and floating layouts.
+All of the layouts can be applied dynamically, optimising the environment for the application in use and the task performed.
+This command installs and configures DWM and a desktop manager.
+The list of patches applied can be found in CTT's DWM repository
+https://github.com/ChrisTitusTech/dwm-titus
 - **Hyprland JaKooLit**: Install JaKooLit's Hyprland configuration
 - **Install Chaotic-AUR Repository**: Chaotic-AUR provides prebuilt binaries for popular AUR packages, saving compilation time. To know more visit: https://aur.chaotic.cx/
 - **Linux Neptune for SteamDeck**: Valve's fork of Linux Kernel for the SteamDeck
+- **Install CachyOS Repository and Kernel**: To deliver a performance-optimized distribution, CachyOS recompiles Arch Linux packages specifically for the x86-64-v3, x86-64-v4, and Zen4+ architectures.
 - **Nvidia Drivers & Hardware Acceleration**: This script installs and configures nvidia drivers with Hardware Acceleration.
 - **Omarchy Rice by DHH**: Simplified Hyprland configuration by DHH the ruby on rails dude.
 - **Paru AUR Helper**: Paru is your standard pacman wrapping AUR helper with lots of features and minimal interaction. To know more about AUR helpers visit: https://wiki.archlinux.org/title/AUR_helpers
@@ -205,6 +201,7 @@ On Arch-based systems, Heroic is built directly from the AUR `heroic-games-launc
 - **Build Prerequisites**: This script is designed to handle the installation of various software dependencies across different Linux distributions
 - **Full System Cleanup**: This script is designed to remove unnecessary packages, clean old cache files, remove temporary files, and to empty the trash.
 - **Full System Update**: This command updates your system to the latest packages available for your distro
+- **Full System Update (Topgrade)**: This command uses topgrade to update your system packages, configs, and more from various sources
 - **Global Theme**: This script is designed to handle the installation and configuration of global theming
 - **Remove Snaps**: This script is designed to remove snap
 - **TTY Fonts**: This Script will set the default TTY font to Terminus size 32 Bold

--- a/tui/src/state.rs
+++ b/tui/src/state.rs
@@ -210,6 +210,8 @@ impl AppState {
                     || path.ends_with("/gaming/lutris-launcher.sh")
                     || path.ends_with("/gaming/retroarch-launcher.sh")
                     || path.ends_with("/gaming/heroic-launcher.sh")
+                    || path.ends_with("/gaming/protonplus.sh")
+                    || path.ends_with("/gaming/protonup-qt.sh")
             }
             _ => false,
         }

--- a/tui/src/state.rs
+++ b/tui/src/state.rs
@@ -176,7 +176,7 @@ impl AppState {
     }
 
     fn spawn_confirmprompt(&mut self) {
-        if self.skip_confirmation {
+        if self.skip_confirmation || self.should_skip_confirmation_for_selection() {
             self.handle_confirm_command();
         } else {
             let cmd_names: Vec<_> = self
@@ -191,6 +191,27 @@ impl AppState {
                 CONFIRM_PROMPT_FLOAT_SIZE,
                 CONFIRM_PROMPT_FLOAT_SIZE,
             ));
+        }
+    }
+
+    fn should_skip_confirmation_for_selection(&self) -> bool {
+        !self.selected_commands.is_empty()
+            && self
+                .selected_commands
+                .iter()
+                .all(|node| self.should_skip_confirmation_for_command(&node.command))
+    }
+
+    fn should_skip_confirmation_for_command(&self, command: &Command) -> bool {
+        match command {
+            Command::LocalFile { file, .. } => {
+                let path = file.to_string_lossy();
+                path.ends_with("/gaming/steam-launcher.sh")
+                    || path.ends_with("/gaming/lutris-launcher.sh")
+                    || path.ends_with("/gaming/retroarch-launcher.sh")
+                    || path.ends_with("/gaming/heroic-launcher.sh")
+            }
+            _ => false,
         }
     }
 


### PR DESCRIPTION
<!--
Read Contributing Guidelines before opening a PR.
https://github.com/ChrisTitusTech/linutil/blob/main/.github/CONTRIBUTING.md
-->

## Type of Change
- [X] New feature
- [X] Documentation update
- [X] Bug fix

## Summary

Adds dedicated Gaming tab entries for managing game launchers and Proton compatibility tools.

  New **Game Launchers** entries:
  - Steam
  - Lutris
  - RetroArch
  - Heroic

  New **Tools and Setups** entries:
  - ProtonPlus
  - ProtonUp-Qt

## Changes
- Added per-launcher wrapper scripts for Steam, Lutris, RetroArch, and Heroic.
- Refactored shared launcher handling into `game-launchers.sh`.
- Added ProtonPlus and ProtonUp-Qt entries under Gaming > Tools and Setups.
- Removed Steam and Lutris installation from Gaming Dependencies now that they have dedicated launcher entries.
- Improved install/uninstall behavior across supported package managers.
- Added NixOS handling that prints declarative configuration guidance instead of applying imperative package changes.
- Uses Flatpak where native launcher availability is less consistent.
- On Arch-based systems, installs Heroic by building `heroic-games-launcher-bin` directly from AUR.
- Updated user guide docs and regenerated the walkthrough.

## Testing
- `shellcheck`, `typos`, and `cargo clippy` all passed.

## Note
Arch/AUR native install for ProtonUp-Qt may print `python-steam` test-suite `AttributeError` noise related to protobuf. In testing, the AUR package still built and installed successfully. This is upstream dependency output, not a Linutil script failure.

## Issues
- Fixes issue #1312 

## Screenshots
<img width="1089" height="627" alt="screenshot-2026-06-05_20-05-31" src="https://github.com/user-attachments/assets/3dc4ea1f-d363-40c5-b164-fc7f8e0cf6e8" />
<img width="1090" height="628" alt="screenshot-2026-06-05_20-05-44" src="https://github.com/user-attachments/assets/097ec0b9-3ad2-4683-8aed-8425e88bb140" />

