### PR TITLE
Use temporary directory for AUR helper installation

### DIFF
--- a/core/tabs/common-script.sh
+++ b/core/tabs/common-script.sh
@@ -57,35 +57,38 @@ checkArch() {
 }
 
 checkAURHelper() {
-    if [ "$PACKAGER" = "pacman" ] && [ -z "$AUR_HELPER_CHECKED" ]; then
-        AUR_HELPERS="yay paru"
-        for helper in ${AUR_HELPERS}; do
-            if command_exists "${helper}"; then
-                AUR_HELPER=${helper}
-                printf "${CYAN}Using ${helper} as AUR helper${RC}\n"
+    ## Check & Install AUR helper
+    if [ "$PACKAGER" = "pacman" ]; then
+        if [ -z "$AUR_HELPER_CHECKED" ]; then
+            AUR_HELPERS="yay paru"
+            for helper in ${AUR_HELPERS}; do
+                if command_exists "${helper}"; then
+                    AUR_HELPER=${helper}
+                    printf "%b\n" "${CYAN}Using ${helper} as AUR helper${RC}"
+                    AUR_HELPER_CHECKED=true
+                    return 0
+                fi
+            done
+
+            printf "%b\n" "${YELLOW}Installing yay as AUR helper...${RC}"
+            "$ESCALATION_TOOL" "$PACKAGER" -S --needed --noconfirm base-devel git
+            TMP_BUILD_DIR=$(mktemp -d)
+            trap 'rm -rf "$TMP_BUILD_DIR"' 0
+            git clone https://aur.archlinux.org/yay-bin.git "$TMP_BUILD_DIR/yay-bin"
+            (
+                cd "$TMP_BUILD_DIR/yay-bin"
+                makepkg --noconfirm -si
+            )
+            rm -rf "$TMP_BUILD_DIR"
+            trap - 0
+
+            if command_exists yay; then
+                AUR_HELPER="yay"
                 AUR_HELPER_CHECKED=true
-                return 0
+            else
+                printf "%b\n" "${RED}Failed to install AUR helper.${RC}"
+                exit 1
             fi
-        done
-
-        printf "${YELLOW}Installing yay as AUR helper...${RC}\n"
-        "$ESCALATION_TOOL" "$PACKAGER" -S --needed --noconfirm base-devel git
-        
-        TMP_BUILD_DIR=$(mktemp -d)
-        cd "$TMP_BUILD_DIR"
-        git clone https://aur.archlinux.org/yay-bin.git
-        cd yay-bin && makepkg --noconfirm -si
-
-        
-        cd - >/dev/null
-        rm -rf "$TMP_BUILD_DIR"
-
-        if command_exists yay; then
-            AUR_HELPER="yay"
-            AUR_HELPER_CHECKED=true
-        else
-            printf "${RED}Failed to install AUR helper.${RC}\n"
-            exit 1
         fi
     fi
 }

--- a/core/tabs/common-script.sh
+++ b/core/tabs/common-script.sh
@@ -57,31 +57,35 @@ checkArch() {
 }
 
 checkAURHelper() {
-    ## Check & Install AUR helper
-    if [ "$PACKAGER" = "pacman" ]; then
-        if [ -z "$AUR_HELPER_CHECKED" ]; then
-            AUR_HELPERS="yay paru"
-            for helper in ${AUR_HELPERS}; do
-                if command_exists "${helper}"; then
-                    AUR_HELPER=${helper}
-                    printf "%b\n" "${CYAN}Using ${helper} as AUR helper${RC}"
-                    AUR_HELPER_CHECKED=true
-                    return 0
-                fi
-            done
-
-            printf "%b\n" "${YELLOW}Installing yay as AUR helper...${RC}"
-            "$ESCALATION_TOOL" "$PACKAGER" -S --needed --noconfirm base-devel git
-            cd /opt && "$ESCALATION_TOOL" git clone https://aur.archlinux.org/yay-bin.git && "$ESCALATION_TOOL" chown -R "$USER":"$USER" ./yay-bin
-            cd yay-bin && makepkg --noconfirm -si
-
-            if command_exists yay; then
-                AUR_HELPER="yay"
+    if [ "$PACKAGER" = "pacman" ] && [ -z "$AUR_HELPER_CHECKED" ]; then
+        AUR_HELPERS="yay paru"
+        for helper in ${AUR_HELPERS}; do
+            if command_exists "${helper}"; then
+                AUR_HELPER=${helper}
+                printf "${CYAN}Using ${helper} as AUR helper${RC}\n"
                 AUR_HELPER_CHECKED=true
-            else
-                printf "%b\n" "${RED}Failed to install AUR helper.${RC}"
-                exit 1
+                return 0
             fi
+        done
+
+        printf "${YELLOW}Installing yay as AUR helper...${RC}\n"
+        "$ESCALATION_TOOL" "$PACKAGER" -S --needed --noconfirm base-devel git
+        
+        TMP_BUILD_DIR=$(mktemp -d)
+        cd "$TMP_BUILD_DIR"
+        git clone https://aur.archlinux.org/yay-bin.git
+        cd yay-bin && makepkg --noconfirm -si
+
+        
+        cd - >/dev/null
+        rm -rf "$TMP_BUILD_DIR"
+
+        if command_exists yay; then
+            AUR_HELPER="yay"
+            AUR_HELPER_CHECKED=true
+        else
+            printf "${RED}Failed to install AUR helper.${RC}\n"
+            exit 1
         fi
     fi
 }

--- a/core/tabs/system-setup/arch/paru-setup.sh
+++ b/core/tabs/system-setup/arch/paru-setup.sh
@@ -11,12 +11,14 @@ installDepend() {
                 printf "%b\n" "${YELLOW}Installing paru as AUR helper...${RC}"
                 "$ESCALATION_TOOL" "$PACKAGER" -S --needed --noconfirm base-devel git
                 TMP_BUILD_DIR=$(mktemp -d)
-                cd "$TMP_BUILD_DIR"
-                git clone https://aur.archlinux.org/paru-bin.git
-                cd paru-bin && makepkg --noconfirm -si
-
-                cd - >/dev/null
+                trap 'rm -rf "$TMP_BUILD_DIR"' 0
+                git clone https://aur.archlinux.org/paru-bin.git "$TMP_BUILD_DIR/paru-bin"
+                (
+                    cd "$TMP_BUILD_DIR/paru-bin"
+                    makepkg --noconfirm -si
+                )
                 rm -rf "$TMP_BUILD_DIR"
+                trap - 0
                 printf "%b\n" "${GREEN}Paru installed${RC}"
             else
                 printf "%b\n" "${GREEN}Paru already installed${RC}"

--- a/core/tabs/system-setup/arch/paru-setup.sh
+++ b/core/tabs/system-setup/arch/paru-setup.sh
@@ -10,8 +10,13 @@ installDepend() {
             if ! command_exists paru; then
                 printf "%b\n" "${YELLOW}Installing paru as AUR helper...${RC}"
                 "$ESCALATION_TOOL" "$PACKAGER" -S --needed --noconfirm base-devel git
-                cd /opt && "$ESCALATION_TOOL" git clone https://aur.archlinux.org/paru-bin.git && "$ESCALATION_TOOL" chown -R "$USER": ./paru-bin
+                TMP_BUILD_DIR=$(mktemp -d)
+                cd "$TMP_BUILD_DIR"
+                git clone https://aur.archlinux.org/paru-bin.git
                 cd paru-bin && makepkg --noconfirm -si
+
+                cd - >/dev/null
+                rm -rf "$TMP_BUILD_DIR"
                 printf "%b\n" "${GREEN}Paru installed${RC}"
             else
                 printf "%b\n" "${GREEN}Paru already installed${RC}"

--- a/core/tabs/system-setup/arch/yay-setup.sh
+++ b/core/tabs/system-setup/arch/yay-setup.sh
@@ -10,8 +10,14 @@ installDepend() {
             if ! command_exists yay; then
                 printf "%b\n" "${YELLOW}Installing yay as AUR helper...${RC}"
                 "$ESCALATION_TOOL" "$PACKAGER" -S --needed --noconfirm base-devel git
-                cd /opt && "$ESCALATION_TOOL" git clone https://aur.archlinux.org/yay-bin.git && "$ESCALATION_TOOL" chown -R "$USER": ./yay-bin
+
+                TMP_BUILD_DIR=$(mktemp -d)
+                cd "$TMP_BUILD_DIR"
+                git clone https://aur.archlinux.org/yay-bin.git
                 cd yay-bin && makepkg --noconfirm -si
+
+                cd - >/dev/null
+                rm -rf "$TMP_BUILD_DIR"
                 printf "%b\n" "${GREEN}Yay installed${RC}"
             else
                 printf "%b\n" "${GREEN}Aur helper already installed${RC}"

--- a/core/tabs/system-setup/arch/yay-setup.sh
+++ b/core/tabs/system-setup/arch/yay-setup.sh
@@ -10,14 +10,15 @@ installDepend() {
             if ! command_exists yay; then
                 printf "%b\n" "${YELLOW}Installing yay as AUR helper...${RC}"
                 "$ESCALATION_TOOL" "$PACKAGER" -S --needed --noconfirm base-devel git
-
                 TMP_BUILD_DIR=$(mktemp -d)
-                cd "$TMP_BUILD_DIR"
-                git clone https://aur.archlinux.org/yay-bin.git
-                cd yay-bin && makepkg --noconfirm -si
-
-                cd - >/dev/null
+                trap 'rm -rf "$TMP_BUILD_DIR"' 0
+                git clone https://aur.archlinux.org/yay-bin.git "$TMP_BUILD_DIR/yay-bin"
+                (
+                    cd "$TMP_BUILD_DIR/yay-bin"
+                    makepkg --noconfirm -si
+                )
                 rm -rf "$TMP_BUILD_DIR"
+                trap - 0
                 printf "%b\n" "${GREEN}Yay installed${RC}"
             else
                 printf "%b\n" "${GREEN}Aur helper already installed${RC}"


### PR DESCRIPTION
Previously, the script cloned the AUR helper into /opt and stayed in that directory for the remainder of the execution. This PR switches to using mktemp, which prevents system pollution and ensures the script maintains its correct working directory.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Security patch
- [ ] UI/UX improvement

## Description
Standardizes the installation process for AUR helpers (`yay` and `paru`) by using temporary build directories instead of cloning into `/opt`. This removes the need for manual `chown` operations and ensures the system remains clean after installation.
