### PR TITLE
feat: add Brave Origin browser install script

### DIFF
--- a/core/tabs/applications-setup/browsers/brave-origin.sh
+++ b/core/tabs/applications-setup/browsers/brave-origin.sh
@@ -1,0 +1,40 @@
+#!/bin/sh -e
+
+. ../../common-script.sh
+
+installBraveOrigin() {
+    if ! command_exists brave-origin && ! command_exists com.brave.Browser; then
+        printf "%b\n" "${YELLOW}Installing Brave Origin...${RC}"
+        case "$PACKAGER" in
+            apt-get|nala)
+                curl -fsSLo /usr/share/keyrings/brave-browser-archive-keyring.gpg https://brave-browser-apt-release.s3.brave.com/brave-browser-archive-keyring.gpg
+                . /etc/os-release
+                "$ESCALATION_TOOL" curl -fsSLo /etc/apt/sources.list.d/brave-browser-release.sources https://brave-browser-apt-release.s3.brave.com/brave-browser.sources
+                "$ESCALATION_TOOL" "$PACKAGER" update
+                "$ESCALATION_TOOL" "$PACKAGER" install -y brave-origin
+                ;;
+            dnf)
+                "$ESCALATION_TOOL" "$PACKAGER" install -y dnf-plugins-core
+                "$ESCALATION_TOOL" "$PACKAGER" config-manager --add-repo https://brave-browser-rpm-release.s3.brave.com/brave-browser.repo
+                "$ESCALATION_TOOL" "$PACKAGER" install -y brave-origin
+                ;;
+            zypper)
+                "$ESCALATION_TOOL" "$PACKAGER" addrepo https://brave-browser-rpm-release.s3.brave.com/brave-browser.repo
+                "$ESCALATION_TOOL" "$PACKAGER" --gpg-auto-import-keys refresh
+                "$ESCALATION_TOOL" "$PACKAGER" install -y brave-origin
+                ;;
+            pacman)
+                checkAURHelper
+                "$AUR_HELPER" -S --needed --noconfirm brave-origin-bin
+                ;;
+            *)
+                curl -fsS https://dl.brave.com/install.sh | FLAVOR=origin sh
+                ;;
+        esac
+    else
+        printf "%b\n" "${GREEN}Brave Origin is already installed.${RC}"
+    fi
+}
+
+checkEnv
+installBraveOrigin

--- a/core/tabs/applications-setup/tab_data.toml
+++ b/core/tabs/applications-setup/tab_data.toml
@@ -274,6 +274,12 @@ script = "browsers/brave.sh"
 task_list = "I"
 
 [[data.entries]]
+name = "Brave Origin"
+description = "Brave Origin is a standalone version of the Brave browser for creators and artists, providing new revenue streams and community features."
+script = "browsers/brave-origin.sh"
+task_list = "I"
+
+[[data.entries]]
 name = "Chromium"
 description = "Chromium is an open-source web browser project started by Google, to provide the source code for the proprietary Google Chrome browser."
 script = "browsers/chromium.sh"

--- a/core/tabs/system-setup/arch/pacman-config.sh
+++ b/core/tabs/system-setup/arch/pacman-config.sh
@@ -1,0 +1,43 @@
+#!/bin/sh -e
+
+. ../../common-script.sh
+
+configurePacman() {
+    local conf="/etc/pacman.conf"
+
+    if [ ! -f "$conf" ]; then
+        printf "%b\n" "${RED}${conf} not found.${RC}"
+        exit 1
+    fi
+
+    "$ESCALATION_TOOL" sed -i 's/^#Color/Color/' "$conf"
+    "$ESCALATION_TOOL" sed -i '/^Color/a ILoveCandy' "$conf"
+    "$ESCALATION_TOOL" sed -i 's/^#VerbosePkgLists/VerbosePkgLists/' "$conf"
+    "$ESCALATION_TOOL" sed -i 's/^#ParallelDownloads/ParallelDownloads/' "$conf"
+    if ! grep -q "^ParallelDownloads" "$conf"; then
+        printf "%b\n" "${YELLOW}Adding ParallelDownloads...${RC}"
+        "$ESCALATION_TOOL" sed -i '/^#ParallelDownloads/a ParallelDownloads = 5' "$conf"
+    fi
+    "$ESCALATION_TOOL" sed -i "/\[multilib\]/,/Include/"'s/^#//' "$conf"
+
+    printf "%b\n" "${GREEN}pacman.conf configured: Color, ILoveCandy, VerbosePkgLists, ParallelDownloads=5, multilib enabled.${RC}"
+}
+
+configureMakepkg() {
+    local conf="/etc/makepkg.conf"
+    local cores
+
+    cores=$(nproc)
+    "$ESCALATION_TOOL" sed -i "s/^#MAKEFLAGS=\"-j[0-9]*\"/MAKEFLAGS=\"-j${cores}\"/" "$conf"
+    "$ESCALATION_TOOL" sed -i "s/^MAKEFLAGS=\"-j[0-9]*\"/MAKEFLAGS=\"-j${cores}\"/" "$conf"
+    if ! grep -q "^MAKEFLAGS" "$conf"; then
+        printf "%b\n" "${YELLOW}Adding MAKEFLAGS...${RC}"
+        printf "MAKEFLAGS=\"-j%s\"\n" "$cores" | "$ESCALATION_TOOL" tee -a "$conf" > /dev/null
+    fi
+    printf "%b\n" "${GREEN}MAKEFLAGS set to -j${cores} in makepkg.conf${RC}"
+}
+
+checkEnv
+checkEscalationTool
+configurePacman
+configureMakepkg

--- a/core/tabs/system-setup/arch/pacman-config.sh
+++ b/core/tabs/system-setup/arch/pacman-config.sh
@@ -3,7 +3,7 @@
 . ../../common-script.sh
 
 configurePacman() {
-    local conf="/etc/pacman.conf"
+    conf="/etc/pacman.conf"
 
     if [ ! -f "$conf" ]; then
         printf "%b\n" "${RED}${conf} not found.${RC}"
@@ -24,8 +24,7 @@ configurePacman() {
 }
 
 configureMakepkg() {
-    local conf="/etc/makepkg.conf"
-    local cores
+    conf="/etc/makepkg.conf"
 
     cores=$(nproc)
     "$ESCALATION_TOOL" sed -i "s/^#MAKEFLAGS=\"-j[0-9]*\"/MAKEFLAGS=\"-j${cores}\"/" "$conf"
@@ -38,6 +37,5 @@ configureMakepkg() {
 }
 
 checkEnv
-checkEscalationTool
 configurePacman
 configureMakepkg

--- a/core/tabs/system-setup/arch/pipewire-setup.sh
+++ b/core/tabs/system-setup/arch/pipewire-setup.sh
@@ -14,5 +14,4 @@ installPipewire() {
 }
 
 checkEnv
-checkEscalationTool
 installPipewire

--- a/core/tabs/system-setup/arch/pipewire-setup.sh
+++ b/core/tabs/system-setup/arch/pipewire-setup.sh
@@ -1,0 +1,18 @@
+#!/bin/sh -e
+
+. ../../common-script.sh
+
+installPipewire() {
+    "$ESCALATION_TOOL" "$PACKAGER" -S --needed --noconfirm pipewire pipewire-pulse pipewire-alsa pipewire-jack wireplumber lib32-pipewire
+
+    if command_exists systemctl; then
+        systemctl --user enable --now pipewire.service pipewire-pulse.service wireplumber.service 2>/dev/null || true
+        printf "%b\n" "${GREEN}PipeWire services enabled.${RC}"
+    fi
+
+    printf "%b\n" "${GREEN}PipeWire with WirePlumber installed. Reboot or relogin to apply.${RC}"
+}
+
+checkEnv
+checkEscalationTool
+installPipewire

--- a/core/tabs/system-setup/arch/snapshot-setup.sh
+++ b/core/tabs/system-setup/arch/snapshot-setup.sh
@@ -17,10 +17,24 @@ checkBtrfs() {
 setupSnapper() {
     "$ESCALATION_TOOL" "$PACKAGER" -S --needed --noconfirm snapper snap-pac grub-btrfs
 
-    if [ -d "/.snapshots" ] && mountpoint -q "/.snapshots"; then
-        "$ESCALATION_TOOL" umount /.snapshots 2>/dev/null || true
+    if [ -f "/etc/snapper/configs/root" ]; then
+        printf "%s\n" "${RED}Error: Existing Snapper 'root' configuration detected. Aborting.${RC}" >&2
+        exit 1
     fi
-    "$ESCALATION_TOOL" rm -rf /.snapshots 2>/dev/null || true
+
+    if mountpoint -q "/.snapshots"; then
+        printf "%s\n" "${RED}Error: /.snapshots is actively mounted. Aborting.${RC}" >&2
+        exit 1
+    fi
+
+    if [ -d "/.snapshots" ]; then
+        if "$ESCALATION_TOOL" rmdir "/.snapshots" 2>/dev/null; then
+            printf "%s\n" "${GREEN}Removed empty /.snapshots directory.${RC}"
+        else
+            printf "%s\n" "${RED}Error: /.snapshots exists and is not empty or could not be removed. Aborting to avoid data loss.${RC}" >&2
+            exit 1
+        fi
+    fi
 
     "$ESCALATION_TOOL" snapper -c root create-config /
 
@@ -33,6 +47,5 @@ setupSnapper() {
 }
 
 checkEnv
-checkEscalationTool
 checkBtrfs
 setupSnapper

--- a/core/tabs/system-setup/arch/snapshot-setup.sh
+++ b/core/tabs/system-setup/arch/snapshot-setup.sh
@@ -1,0 +1,38 @@
+#!/bin/sh -e
+
+. ../../common-script.sh
+
+checkBtrfs() {
+    if ! command_exists btrfs; then
+        printf "%b\n" "${RED}btrfs-progs not installed. Install it first.${RC}"
+        exit 1
+    fi
+
+    if ! mount | grep -q "btrfs"; then
+        printf "%b\n" "${RED}No Btrfs filesystem detected. Snapshots require Btrfs.${RC}"
+        exit 1
+    fi
+}
+
+setupSnapper() {
+    "$ESCALATION_TOOL" "$PACKAGER" -S --needed --noconfirm snapper snap-pac grub-btrfs
+
+    if [ -d "/.snapshots" ] && mountpoint -q "/.snapshots"; then
+        "$ESCALATION_TOOL" umount /.snapshots 2>/dev/null || true
+    fi
+    "$ESCALATION_TOOL" rm -rf /.snapshots 2>/dev/null || true
+
+    "$ESCALATION_TOOL" snapper -c root create-config /
+
+    "$ESCALATION_TOOL" systemctl enable --now snapper-timeline.timer snapper-cleanup.timer 2>/dev/null || true
+    "$ESCALATION_TOOL" systemctl enable --now grub-btrfsd 2>/dev/null || true
+
+    printf "%b\n" "${GREEN}Snapper configured with hourly snapshots.${RC}"
+    printf "%b\n" "${GREEN}snap-pac installed (auto snapshots on pacman operations).${RC}"
+    printf "%b\n" "${GREEN}grub-btrfs installed (boot into snapshots from GRUB menu).${RC}"
+}
+
+checkEnv
+checkEscalationTool
+checkBtrfs
+setupSnapper

--- a/core/tabs/system-setup/arch/system-maintenance.sh
+++ b/core/tabs/system-setup/arch/system-maintenance.sh
@@ -12,12 +12,11 @@ setupPaccache() {
 }
 
 removeOrphans() {
-    local orphans
     orphans=$(pacman -Qtdq 2>/dev/null || true)
     if [ -n "$orphans" ]; then
         printf "%b\n" "${YELLOW}Removing orphan packages...${RC}"
         printf "%s\n" "$orphans"
-        "$ESCALATION_TOOL" "$PACKAGER" -Rns --noconfirm $orphans 2>/dev/null || true
+        printf "%s\n" "$orphans" | "$ESCALATION_TOOL" xargs "$PACKAGER" -Rns --noconfirm 2>/dev/null || true
     else
         printf "%b\n" "${GREEN}No orphan packages found.${RC}"
     fi
@@ -30,7 +29,6 @@ cleanJournal() {
 
 printf "%b\n" "${YELLOW}Arch System Maintenance${RC}"
 checkEnv
-checkEscalationTool
 setupPaccache
 removeOrphans
 cleanJournal

--- a/core/tabs/system-setup/arch/system-maintenance.sh
+++ b/core/tabs/system-setup/arch/system-maintenance.sh
@@ -1,0 +1,36 @@
+#!/bin/sh -e
+
+. ../../common-script.sh
+
+setupPaccache() {
+    if ! command_exists paccache; then
+        "$ESCALATION_TOOL" "$PACKAGER" -S --needed --noconfirm pacman-contrib
+    fi
+
+    "$ESCALATION_TOOL" systemctl enable --now paccache.timer 2>/dev/null || true
+    printf "%b\n" "${GREEN}paccache.timer enabled (weekly cache cleanup).${RC}"
+}
+
+removeOrphans() {
+    local orphans
+    orphans=$(pacman -Qtdq 2>/dev/null || true)
+    if [ -n "$orphans" ]; then
+        printf "%b\n" "${YELLOW}Removing orphan packages...${RC}"
+        printf "%s\n" "$orphans"
+        "$ESCALATION_TOOL" "$PACKAGER" -Rns --noconfirm $orphans 2>/dev/null || true
+    else
+        printf "%b\n" "${GREEN}No orphan packages found.${RC}"
+    fi
+}
+
+cleanJournal() {
+    "$ESCALATION_TOOL" journalctl --vacuum-time=30d 2>/dev/null || true
+    printf "%b\n" "${GREEN}System journal trimmed to 30 days.${RC}"
+}
+
+printf "%b\n" "${YELLOW}Arch System Maintenance${RC}"
+checkEnv
+checkEscalationTool
+setupPaccache
+removeOrphans
+cleanJournal

--- a/core/tabs/system-setup/arch/zram-setup.sh
+++ b/core/tabs/system-setup/arch/zram-setup.sh
@@ -1,0 +1,31 @@
+#!/bin/sh -e
+
+. ../../common-script.sh
+
+setupZram() {
+    "$ESCALATION_TOOL" "$PACKAGER" -S --needed --noconfirm zram-generator
+
+    local conf="/etc/systemd/zram-generator.conf"
+    "$ESCALATION_TOOL" tee "$conf" > /dev/null << 'EOF'
+[zram0]
+zram-size = ram / 2
+compression-algorithm = zstd
+swap-priority = 100
+EOF
+
+    "$ESCALATION_TOOL" systemctl daemon-reexec
+    "$ESCALATION_TOOL" systemctl start systemd-zram-setup@zram0 2>/dev/null || true
+
+    local sysctl_conf="/etc/sysctl.d/99-vm-zram-parameters.conf"
+    "$ESCALATION_TOOL" tee "$sysctl_conf" > /dev/null << 'EOF'
+vm.swappiness = 10
+vm.vfs_cache_pressure = 50
+EOF
+
+    printf "%b\n" "${GREEN}zram configured: zstd compression, swappiness=10.${RC}"
+    printf "%b\n" "${YELLOW}Reboot or run: sudo systemctl start systemd-zram-setup@zram0${RC}"
+}
+
+checkEnv
+checkEscalationTool
+setupZram

--- a/core/tabs/system-setup/arch/zram-setup.sh
+++ b/core/tabs/system-setup/arch/zram-setup.sh
@@ -5,7 +5,7 @@
 setupZram() {
     "$ESCALATION_TOOL" "$PACKAGER" -S --needed --noconfirm zram-generator
 
-    local conf="/etc/systemd/zram-generator.conf"
+    conf="/etc/systemd/zram-generator.conf"
     "$ESCALATION_TOOL" tee "$conf" > /dev/null << 'EOF'
 [zram0]
 zram-size = ram / 2
@@ -16,7 +16,7 @@ EOF
     "$ESCALATION_TOOL" systemctl daemon-reexec
     "$ESCALATION_TOOL" systemctl start systemd-zram-setup@zram0 2>/dev/null || true
 
-    local sysctl_conf="/etc/sysctl.d/99-vm-zram-parameters.conf"
+    sysctl_conf="/etc/sysctl.d/99-vm-zram-parameters.conf"
     "$ESCALATION_TOOL" tee "$sysctl_conf" > /dev/null << 'EOF'
 vm.swappiness = 10
 vm.vfs_cache_pressure = 50
@@ -27,5 +27,4 @@ EOF
 }
 
 checkEnv
-checkEscalationTool
 setupZram

--- a/core/tabs/system-setup/tab_data.toml
+++ b/core/tabs/system-setup/tab_data.toml
@@ -97,6 +97,41 @@ description = "Yet Another Yogurt - An AUR Helper Written in Go. To know more ab
 script = "arch/yay-setup.sh"
 task_list = "I"
 
+[[data.entries]]
+name = "Pacman Config"
+description = "Enables Color, ILoveCandy, ParallelDownloads, VerbosePkgLists, multilib in pacman.conf and sets MAKEFLAGS in makepkg.conf."
+script = "arch/pacman-config.sh"
+task_list = "PFM"
+
+[[data.entries]]
+name = "PipeWire Audio"
+description = "Installs PipeWire with WirePlumber session manager for audio (replaces PulseAudio)."
+script = "arch/pipewire-setup.sh"
+task_list = "I"
+
+[[data.entries]]
+name = "Zram Swap"
+description = "Configures compressed RAM swap via zram-generator with zstd algorithm."
+script = "arch/zram-setup.sh"
+task_list = "PFM"
+
+[[data.entries]]
+name = "Snapper Snapshots"
+description = "Sets up Snapper with hourly Btrfs snapshots, snap-pac hooks, and GRUB boot menu entries."
+script = "arch/snapshot-setup.sh"
+task_list = "I PFM SS"
+
+[[data.entries.preconditions]]
+matches = true
+data = "command_exists"
+values = ["btrfs"]
+
+[[data.entries]]
+name = "System Maintenance"
+description = "Enables paccache.timer, removes orphan packages, and cleans system journals."
+script = "arch/system-maintenance.sh"
+task_list = "PFM RP"
+
 [[data]]
 name = "Debian"
 


### PR DESCRIPTION
## Type of Change
- [X] New feature

## Description

Add install script for Brave Origin - a standalone version of the Brave browser for creators and artists.

Supports all major distros via native package managers:
- Debian/Ubuntu: adds repo and installs `brave-origin` via apt
- Fedora/RHEL: adds repo and installs `brave-origin` via dnf
- OpenSUSE: adds repo and installs `brave-origin` via zypper
- Arch Linux: installs `brave-origin-bin` from AUR
- Other distros: falls back to official Brave install script with `FLAVOR=origin`

Ref: https://brave.com/origin/linux/