### PR TITLE
fix(mybash-setup): update zoxide install URL to use refs/heads format

### DIFF
--- a/core/tabs/applications-setup/mybash-setup.sh
+++ b/core/tabs/applications-setup/mybash-setup.sh
@@ -86,7 +86,7 @@ installZoxide() {
         return
     fi
 
-    if ! curl -sSL https://raw.githubusercontent.com/ajeetdsouza/zoxide/main/install.sh | sh; then
+    if ! curl -sSL https://raw.githubusercontent.com/ajeetdsouza/zoxide/refs/heads/main/install.sh | sh; then
         printf "%b\n" "${RED}Something went wrong during zoxide install!${RC}"
         exit 1
     fi


### PR DESCRIPTION
## Problem

The zoxide install script URL in `mybash-setup.sh` uses the legacy `raw.githubusercontent.com` shorthand format which is no longer reliably resolving, causing the zoxide installation to fail.

**Old URL:** `https://raw.githubusercontent.com/ajeetdsouza/zoxide/main/install.sh`

## Root Cause

GitHub has updated its CDN to use explicit `refs/heads/` prefix for branch references. The old shorthand format (without `refs/heads/`) can intermittently return 404 errors depending on CDN region and caching behavior.

## Fix

Updated the URL to the current GitHub raw format:

`https://raw.githubusercontent.com/ajeetdsouza/zoxide/refs/heads/main/install.sh`

This is a one-line change with no functional impact — both URLs serve the same content, but the new format is the current standard and resolves reliably.