### PR TITLE
Add SSD TRIM (fstrim.timer) setup script

### DIFF
--- a/core/tabs/system-setup/fstrim-setup.sh
+++ b/core/tabs/system-setup/fstrim-setup.sh
@@ -1,0 +1,52 @@
+#!/bin/sh -e
+
+. ../common-script.sh
+
+installFstrim() {
+    # fstrim ships with util-linux
+    if ! command_exists fstrim; then
+        printf "%b\n" "${YELLOW}Installing fstrim (util-linux)...${RC}"
+        case "$PACKAGER" in
+            pacman)
+                "$ESCALATION_TOOL" "$PACKAGER" -S --needed --noconfirm util-linux
+                ;;
+            apk)
+                "$ESCALATION_TOOL" "$PACKAGER" add util-linux
+                ;;
+            xbps-install)
+                "$ESCALATION_TOOL" "$PACKAGER" -Sy util-linux
+                ;;
+            *)
+                "$ESCALATION_TOOL" "$PACKAGER" install -y util-linux
+                ;;
+        esac
+    else
+        printf "%b\n" "${GREEN}fstrim is already installed${RC}"
+    fi
+}
+
+enableFstrimTimer() {
+    if ! systemctl cat fstrim.timer >/dev/null 2>&1; then
+        printf "%b\n" "${RED}fstrim.timer is not available on this system; cannot enable periodic TRIM.${RC}"
+        exit 1
+    fi
+    printf "%b\n" "${YELLOW}Enabling weekly fstrim.timer...${RC}"
+    "$ESCALATION_TOOL" systemctl enable --now fstrim.timer
+}
+
+runInitialTrim() {
+    printf "%b\n" "${YELLOW}Running an initial trim on all supported mounted filesystems...${RC}"
+    "$ESCALATION_TOOL" fstrim -av || printf "%b\n" "${YELLOW}Some filesystems do not support trim and were skipped.${RC}"
+}
+
+checkEnv
+checkEscalationTool
+installFstrim
+enableFstrimTimer
+runInitialTrim
+
+if systemctl is-active --quiet fstrim.timer; then
+    printf "%b\n" "${GREEN}Periodic SSD TRIM is active (weekly via fstrim.timer).${RC}"
+else
+    printf "%b\n" "${RED}fstrim.timer could not be activated. Check 'systemctl status fstrim.timer'.${RC}"
+fi

--- a/core/tabs/system-setup/tab_data.toml
+++ b/core/tabs/system-setup/tab_data.toml
@@ -216,7 +216,8 @@ task_list = "I"
 name = "Enable SSD TRIM"
 description = "Enable weekly SSD TRIM through systemd's fstrim.timer and run an initial trim. This is the recommended alternative to mounting with the continuous discard option. For more information visit: https://wiki.archlinux.org/title/Solid_state_drive#TRIM"
 script = "fstrim-setup.sh"
-task_list = "I SS"
+task_list = "D I SS"
+multi_select = false
 
 [[data.preconditions]]
 matches = true

--- a/core/tabs/system-setup/tab_data.toml
+++ b/core/tabs/system-setup/tab_data.toml
@@ -213,6 +213,17 @@ script = "compile-setup.sh"
 task_list = "I"
 
 [[data]]
+name = "Enable SSD TRIM"
+description = "Enable weekly SSD TRIM through systemd's fstrim.timer and run an initial trim. This is the recommended alternative to mounting with the continuous discard option. For more information visit: https://wiki.archlinux.org/title/Solid_state_drive#TRIM"
+script = "fstrim-setup.sh"
+task_list = "I SS"
+
+[[data.preconditions]]
+matches = true
+data = "command_exists"
+values = [ "systemctl" ]
+
+[[data]]
 name = "Full System Cleanup"
 description = "This script is designed to remove unnecessary packages, clean old cache files, remove temporary files, and to empty the trash."
 script = "system-cleanup.sh"

--- a/docs/content/userguide/walkthrough.md
+++ b/docs/content/userguide/walkthrough.md
@@ -203,6 +203,7 @@ https://github.com/ChrisTitusTech/dwm-titus
 
 - **Hyprland JaKooLit**: Install JaKooLit's Hyprland configuration
 - **Build Prerequisites**: This script is designed to handle the installation of various software dependencies across different Linux distributions
+- **Enable SSD TRIM**: Enable weekly SSD TRIM through systemd's fstrim.timer and run an initial trim. This is the recommended alternative to mounting with the continuous discard option. For more information visit: https://wiki.archlinux.org/title/Solid_state_drive#TRIM
 - **Full System Cleanup**: This script is designed to remove unnecessary packages, clean old cache files, remove temporary files, and to empty the trash.
 - **Full System Update**: This command updates your system to the latest packages available for your distro
 - **Full System Update (Topgrade)**: This command uses topgrade to update your system packages, configs, and more from various sources


### PR DESCRIPTION
## Type of Change
- [x] New feature

## Description

Adds a new System Setup entry, "Enable SSD TRIM". It turns on systemd's `fstrim.timer` (the recommended weekly TRIM, rather than the continuous `discard` mount option) and runs an initial `fstrim -av` so unused blocks are reclaimed right away instead of waiting for the first scheduled run.

The script only installs `util-linux` when `fstrim` is missing (covers the common package managers), exits early if `fstrim.timer` isn't available on the system, and is safe to re-run. I gave the entry a `command_exists systemctl` precondition so it only shows up on systemd systems.

This is useful mainly on Arch and other minimal/DIY installs, where the timer is not enabled out of the box. On distros that already ship it enabled (Ubuntu, recent Fedora) the script is a no-op beyond reconfirming the timer and running the immediate trim.

Changed files: `fstrim-setup.sh`, the matching `tab_data.toml` entry, and the regenerated walkthrough (`cargo xtask docgen`).

## Testing

Tested on Ubuntu 24.04 (aarch64), two consecutive runs.

First run trims the live filesystems:

```
fstrim is already installed
Enabling weekly fstrim.timer...
Running an initial trim on all supported mounted filesystems...
/boot/efi: 1 GiB (1118154752 bytes) trimmed on /dev/sda1
/: 48.2 GiB (51757043712 bytes) trimmed on /dev/sda2
Periodic SSD TRIM is active (weekly via fstrim.timer).
```

Second run, the root filesystem reports only the few blocks freed since (the FAT EFI partition always reports its full size):

```
fstrim is already installed
Enabling weekly fstrim.timer...
Running an initial trim on all supported mounted filesystems...
/boot/efi: 1 GiB (1118154752 bytes) trimmed on /dev/sda1
/: 904 KiB (925696 bytes) trimmed on /dev/sda2
Periodic SSD TRIM is active (weekly via fstrim.timer).
```

`shellcheck` passes.

## Issues / other PRs related
None.