### PR TITLE
Add Lynis Security Audit

### DIFF
--- a/core/tabs/security/lynis-audit.sh
+++ b/core/tabs/security/lynis-audit.sh
@@ -1,0 +1,142 @@
+#!/bin/sh -e
+
+. ../common-script.sh
+
+installLynis() {
+    if command_exists lynis; then
+        printf "%b\n" "${GREEN}Lynis is already installed.${RC}"
+        return 0
+    fi
+
+    printf "%b\n" "${YELLOW}Installing Lynis...${RC}"
+    case "$PACKAGER" in
+        pacman)
+            "$ESCALATION_TOOL" "$PACKAGER" -S --needed --noconfirm lynis
+            ;;
+        apt-get | nala | dnf | eopkg)
+            "$ESCALATION_TOOL" "$PACKAGER" install -y lynis
+            ;;
+        zypper)
+            "$ESCALATION_TOOL" "$PACKAGER" -n install lynis
+            ;;
+        apk)
+            "$ESCALATION_TOOL" "$PACKAGER" add lynis
+            ;;
+        xbps-install)
+            "$ESCALATION_TOOL" "$PACKAGER" -Sy lynis
+            ;;
+        *)
+            printf "%b\n" "${RED}Unsupported package manager: ${PACKAGER}${RC}"
+            exit 1
+            ;;
+    esac
+
+    if ! command_exists lynis; then
+        printf "%b\n" "${RED}Lynis installation failed.${RC}"
+        exit 1
+    fi
+}
+
+removeLynis() {
+    printf "%b\n" "${YELLOW}Removing Lynis...${RC}"
+    case "$PACKAGER" in
+        pacman)
+            "$ESCALATION_TOOL" "$PACKAGER" -Rns --noconfirm lynis
+            ;;
+        apt-get | nala | dnf | eopkg)
+            "$ESCALATION_TOOL" "$PACKAGER" remove -y lynis
+            ;;
+        zypper)
+            "$ESCALATION_TOOL" "$PACKAGER" -n remove lynis
+            ;;
+        apk)
+            "$ESCALATION_TOOL" "$PACKAGER" del lynis
+            ;;
+        xbps-install)
+            "$ESCALATION_TOOL" xbps-remove -Ry lynis
+            ;;
+        *)
+            printf "%b\n" "${RED}Unsupported package manager: ${PACKAGER}${RC}"
+            exit 1
+            ;;
+    esac
+
+    if command_exists lynis; then
+        printf "%b\n" "${RED}Lynis removal failed.${RC}"
+        exit 1
+    fi
+
+    printf "%b\n" "${GREEN}Lynis removed successfully.${RC}"
+}
+
+moveAuditResults() {
+    AUDIT_LOG_SOURCE="/var/log/lynis.log"
+    AUDIT_REPORT_SOURCE="/var/log/lynis-report.dat"
+
+    if [ ! -f "$AUDIT_LOG_SOURCE" ] || [ ! -f "$AUDIT_REPORT_SOURCE" ]; then
+        printf "%b\n" "${RED}Lynis audit log or report was not found in /var/log.${RC}"
+        exit 1
+    fi
+
+    AUDIT_TIMESTAMP=$(date '+%Y-%m-%d-%H-%M-%S')
+    AUDIT_COUNTER=1
+
+    while true; do
+        AUDIT_LOG_DESTINATION="$HOME/lynis-${AUDIT_TIMESTAMP}-${AUDIT_COUNTER}.log"
+        AUDIT_REPORT_DESTINATION="$HOME/lynis-report-${AUDIT_TIMESTAMP}-${AUDIT_COUNTER}.dat"
+
+        if [ ! -e "$AUDIT_LOG_DESTINATION" ] && [ ! -L "$AUDIT_LOG_DESTINATION" ] &&
+            [ ! -e "$AUDIT_REPORT_DESTINATION" ] && [ ! -L "$AUDIT_REPORT_DESTINATION" ]; then
+            break
+        fi
+
+        AUDIT_COUNTER=$((AUDIT_COUNTER + 1))
+    done
+
+    "$ESCALATION_TOOL" mv "$AUDIT_LOG_SOURCE" "$AUDIT_LOG_DESTINATION"
+    "$ESCALATION_TOOL" mv "$AUDIT_REPORT_SOURCE" "$AUDIT_REPORT_DESTINATION"
+    "$ESCALATION_TOOL" chown "$(id -u):$(id -g)" "$AUDIT_LOG_DESTINATION" "$AUDIT_REPORT_DESTINATION"
+
+    printf "\n%b\n" "${YELLOW}Audit log saved: ${AUDIT_LOG_DESTINATION}${RC}"
+    printf "%b\n" "${YELLOW}Audit report saved: ${AUDIT_REPORT_DESTINATION}${RC}"
+}
+
+promptRemoval() {
+    while true; do
+        printf "\n%b\n" "${YELLOW}Remove Lynis?${RC}"
+        printf "%b\n" "1 - Yes, Remove"
+        printf "%b\n" "2 - No, Keep"
+        printf "%b" "Enter your choice [1-2]: "
+
+        if ! read -r choice; then
+            printf "\n%b\n" "${RED}No choice received.${RC}"
+            exit 1
+        fi
+
+        case "$choice" in
+            1)
+                removeLynis
+                return 0
+                ;;
+            2)
+                printf "%b\n" "${GREEN}Lynis kept installed.${RC}"
+                return 0
+                ;;
+            *)
+                printf "%b\n" "${RED}Invalid choice. Enter 1 or 2.${RC}"
+                ;;
+        esac
+    done
+}
+
+checkEnv
+installLynis
+
+printf "%b\n" "${YELLOW}Running: lynis audit system${RC}"
+if ! "$ESCALATION_TOOL" lynis audit system; then
+    printf "%b\n" "${RED}Lynis security audit failed.${RC}"
+    exit 1
+fi
+
+moveAuditResults
+promptRemoval

--- a/core/tabs/security/tab_data.toml
+++ b/core/tabs/security/tab_data.toml
@@ -11,6 +11,13 @@ matches = true
 data = "command_exists"
 values = [ "firewall-cmd" ]
 [[data]]
+name = "Lynis Security Audit"
+description = "Install Lynis when needed, run an elevated system security audit with live results, then optionally remove Lynis."
+script = "lynis-audit.sh"
+task_list = "I MP RP"
+multi_select = false
+
+[[data]]
 name = "UFW Firewall Baselines (CTT)"
 description = "Developed to ease iptables firewall configuration, UFW provides a user friendly way to create an IPv4 or IPv6 host-based firewall. This command installs UFW and configures UFW based on CTT's recommended rules. For more information visit: https://christitus.com/linux-security-mistakes"
 script = "ufw-baselines.sh"
@@ -20,4 +27,3 @@ task_list = "I SS"
 matches = false
 data = "command_exists"
 values = [ "firewall-cmd" ]
-

--- a/docs/content/userguide/walkthrough.md
+++ b/docs/content/userguide/walkthrough.md
@@ -60,6 +60,7 @@ https://github.com/ChrisTitusTech/neovim
 ### Web Browsers
 
 - **Brave**: Brave is a free and open-source web browser developed by Brave Software, Inc. based on the Chromium web browser.
+- **Brave Origin**: Brave Origin is a minimalist version of Brave that strips out optional features like VPN, crypto wallet, Rewards, and Leo AI, keeping only core privacy protections and ad blocking.
 - **Chromium**: Chromium is an open-source web browser project started by Google, to provide the source code for the proprietary Google Chrome browser.
 - **Google Chrome**: Google Chrome is a fast, secure, and free web browser, built for the modern web.
 - **LibreWolf**: LibreWolf is a fork of Firefox, focused on privacy, security, and freedom.
@@ -151,6 +152,7 @@ https://github.com/AdnanHodzic/auto-cpufreq
 ## Security
 
 - **FirewallD Firewall Baselines (CTT)**: Configure FirewallD with CTT's recommended baseline rules for improved system security. For more information visit: https://christitus.com/linux-security-mistakes
+- **Lynis Security Audit**: Install Lynis when needed, run an elevated system security audit with live results, then optionally remove Lynis.
 - **UFW Firewall Baselines (CTT)**: Developed to ease iptables firewall configuration, UFW provides a user friendly way to create an IPv4 or IPv6 host-based firewall. This command installs UFW and configures UFW based on CTT's recommended rules. For more information visit: https://christitus.com/linux-security-mistakes
 
 ## System Setup


### PR DESCRIPTION
<!--
Read Contributing Guidelines before opening a PR.
https://github.com/ChrisTitusTech/linutil/blob/main/.github/CONTRIBUTING.md
-->

## Type of Change
- [X] New feature

## Summary

- Add Lynis Security Audit to the Security tab
- Install Lynis only if it is not already installed
- Runs `lynis audit system` with **elevated privileges** and display live progress
- Move the audit log and report to timestamped files in `$HOME`:
    - Log: `$HOME/lynis-<timestamp>-<counter>.log`
    - Report: `$HOME/lynis-report-<timestamp>-<counter>.dat`
- Allow user to remove or keep Lynis after the audit
- Update generated documentation

## Screenshot
<img width="805" height="410" alt="screenshot-2026-06-29_02-03-58" src="https://github.com/user-attachments/assets/c7449a08-d56d-4523-ba3e-6fed5e970572" />
