### PR TITLE
Fix Dreamcast typo in Flaycast emulator entry

### DIFF
--- a/core/tabs/gaming/tab_data.toml
+++ b/core/tabs/gaming/tab_data.toml
@@ -107,7 +107,7 @@ task_list = "FM"
 
 [[data.entries.entries]]
 name = "Flycast"
-description = "A Dreamcase emulator. NO Games are included"
+description = "A Dreamcast emulator. NO Games are included"
 script = "emulators/sega/flycast.sh"
 task_list = "FM"
 


### PR DESCRIPTION

<!--
Read Contributing Guidelines before opening a PR.
https://github.com/ChrisTitusTech/linutil/blob/main/.github/CONTRIBUTING.md
-->

## Type of Change
- [ ] New feature
- [x ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Security patch
- [ ] UI/UX improvement

## Description
I was flipping through linutil, looking at the emulators, and noticed that the description, in the Flaycast emulator entry, that Dreamcast was misspelled. It says Dreamcase instead of Dreamcast

## Issues / other PRs related
<!--[What issue/discussion is related to this PR (if any)]-->
- Resolves #

## Screenshots (if applicable)
