### PR TITLE
small Typo: Ranalama >> Ramalama

### DIFF
--- a/core/tabs/utils/tab_data.toml
+++ b/core/tabs/utils/tab_data.toml
@@ -155,7 +155,7 @@ script = "ollama.sh"
 task_list = "I SS"
 
 [[data]]
-name = "Ranalama"
+name = "Ramalama"
 description = "This utility is designed to manage ramalama in your system"
 script = "ramalama.sh"
 task_list = "I SS"


### PR DESCRIPTION
## Type of Change

This PR fixes the documentation issue reported in #1358: corrects `Ranalama` to `Ramalama` in `core/tabs/utils/tab_data.toml`.

Fixes #1358
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Security patch
- [ ] UI/UX improvement

## Description

## Issues / other PRs related

- Resolves #

## Screenshots (if applicable)

Fixes #1358