### PR TITLE
feat(apps): discord forks

### DIFF
--- a/core/tabs/applications-setup/communication-apps/discord-setup.sh
+++ b/core/tabs/applications-setup/communication-apps/discord-setup.sh
@@ -34,5 +34,113 @@ installDiscord() {
     fi
 }
 
+installVesktop() {
+    if ! command_exists dev.vencord.Vesktop && ! command_exists vesktop; then
+        printf "%b\n" "${YELLOW}Installing Vesktop...${RC}"
+        case "$PACKAGER" in
+            apt-get|nala)
+                case "$ARCH" in
+                    x86_64) VESKTOP_DEB_URL="https://vencord.dev/download/vesktop/amd64/deb" ;;
+                    aarch64) VESKTOP_DEB_URL="https://vencord.dev/download/vesktop/arm64/deb" ;;
+                esac
+                # Ensure the downloaded .deb is removed even on failure under `set -e`.
+                trap 'rm -f vesktop.deb' EXIT
+                curl -fLo vesktop.deb "$VESKTOP_DEB_URL"
+                "$ESCALATION_TOOL" "$PACKAGER" install -y ./vesktop.deb
+                rm -f vesktop.deb
+                trap - EXIT
+                ;;
+            pacman)
+                "$AUR_HELPER" -S --needed --noconfirm vesktop-bin
+                ;;
+            dnf)
+                case "$ARCH" in
+                    x86_64) VESKTOP_RPM_URL="https://vencord.dev/download/vesktop/amd64/rpm" ;;
+                    aarch64) VESKTOP_RPM_URL="https://vencord.dev/download/vesktop/arm64/rpm" ;;
+                esac
+                "$ESCALATION_TOOL" "$PACKAGER" install -y "$VESKTOP_RPM_URL"
+                ;;
+            *)
+                checkFlatpak
+                "$ESCALATION_TOOL" flatpak install --noninteractive flathub dev.vencord.Vesktop
+                ;;
+        esac
+    else
+        printf "%b\n" "${GREEN}Vesktop is already installed.${RC}"
+    fi
+}
+
+installEquibop() {
+    if ! command_exists org.equicord.equibop && ! command_exists equibop; then
+        printf "%b\n" "${YELLOW}Installing Equibop...${RC}"
+        case "$PACKAGER" in
+            apt-get|nala)
+                latest_release=$(curl -s https://api.github.com/repos/Equicord/Equibop/releases/latest)
+                case "$ARCH" in
+                    x86_64) EQUIBOP_DEB_URL=$(printf '%s' "$latest_release" | grep -o 'https://[^"]*_amd64\.deb' | head -n1) ;;
+                    aarch64) EQUIBOP_DEB_URL=$(printf '%s' "$latest_release" | grep -o 'https://[^"]*_arm64\.deb' | head -n1) ;;
+                esac
+                if [ -z "$EQUIBOP_DEB_URL" ]; then
+                    printf "%b\n" "${RED}Failed to find an Equibop deb package for $ARCH${RC}"
+                    exit 1
+                fi
+                # Ensure the downloaded .deb is removed even on failure under `set -e`.
+                trap 'rm -f equibop.deb' EXIT
+                curl -fLo equibop.deb "$EQUIBOP_DEB_URL"
+                "$ESCALATION_TOOL" "$PACKAGER" install -y ./equibop.deb
+                rm -f equibop.deb
+                trap - EXIT
+                ;;
+            pacman)
+                "$AUR_HELPER" -S --needed --noconfirm equibop-bin
+                ;;
+            dnf)
+                latest_release=$(curl -s https://api.github.com/repos/Equicord/Equibop/releases/latest)
+                case "$ARCH" in
+                    x86_64) EQUIBOP_RPM_URL=$(printf '%s' "$latest_release" | grep -o 'https://[^"]*\.x86_64\.rpm' | head -n1) ;;
+                    aarch64) EQUIBOP_RPM_URL=$(printf '%s' "$latest_release" | grep -o 'https://[^"]*\.aarch64\.rpm' | head -n1) ;;
+                esac
+                if [ -z "$EQUIBOP_RPM_URL" ]; then
+                    printf "%b\n" "${RED}Failed to find an Equibop rpm package for $ARCH${RC}"
+                    exit 1
+                fi
+                "$ESCALATION_TOOL" "$PACKAGER" install -y "$EQUIBOP_RPM_URL"
+                ;;
+            *)
+                checkFlatpak
+                "$ESCALATION_TOOL" flatpak install --noninteractive flathub org.equicord.equibop
+                ;;
+        esac
+    else
+        printf "%b\n" "${GREEN}Equibop is already installed.${RC}"
+    fi
+}
+
+main() {
+
+    printf "%b\n" "${YELLOW}Choose a fork of Discord to install:${RC}"
+    printf "%b\n" "${YELLOW}1) Vanilla Discord${RC}"
+    printf "%b\n" "${YELLOW}2) Vesktop (Discord with plugins)${RC}"
+    printf "%b\n" "${YELLOW}3) Equicord  (Vesktop with more plugins)${RC}"
+    printf "%b" "Enter your choice [1-3]: "
+    read -r choice
+
+    case "$choice" in
+        1)
+            installDiscord
+            ;;
+        2)
+            installVesktop
+            ;;
+        3)
+            installEquibop
+            ;;
+        *)
+            printf "%b\n" "${RED}Invalid choice. Exiting.${RC}"
+            exit 1
+            ;;
+    esac
+}
 checkEnv
-installDiscord
+main
+

--- a/core/tabs/applications-setup/communication-apps/discord-setup.sh
+++ b/core/tabs/applications-setup/communication-apps/discord-setup.sh
@@ -42,6 +42,7 @@ installVesktop() {
                 case "$ARCH" in
                     x86_64) VESKTOP_DEB_URL="https://vencord.dev/download/vesktop/amd64/deb" ;;
                     aarch64) VESKTOP_DEB_URL="https://vencord.dev/download/vesktop/arm64/deb" ;;
+                    *) printf "%b\n" "${RED}Unsupported architecture for Vesktop: $ARCH${RC}" && exit 1 ;;
                 esac
                 # Ensure the downloaded .deb is removed even on failure under `set -e`.
                 trap 'rm -f vesktop.deb' EXIT
@@ -57,6 +58,7 @@ installVesktop() {
                 case "$ARCH" in
                     x86_64) VESKTOP_RPM_URL="https://vencord.dev/download/vesktop/amd64/rpm" ;;
                     aarch64) VESKTOP_RPM_URL="https://vencord.dev/download/vesktop/arm64/rpm" ;;
+                    *) printf "%b\n" "${RED}Unsupported architecture for Vesktop: $ARCH${RC}" && exit 1 ;;
                 esac
                 "$ESCALATION_TOOL" "$PACKAGER" install -y "$VESKTOP_RPM_URL"
                 ;;
@@ -79,11 +81,8 @@ installEquibop() {
                 case "$ARCH" in
                     x86_64) EQUIBOP_DEB_URL=$(printf '%s' "$latest_release" | grep -o 'https://[^"]*_amd64\.deb' | head -n1) ;;
                     aarch64) EQUIBOP_DEB_URL=$(printf '%s' "$latest_release" | grep -o 'https://[^"]*_arm64\.deb' | head -n1) ;;
+                    *) printf "%b\n" "${RED}Unsupported architecture for Equibop: $ARCH${RC}" && exit 1 ;;
                 esac
-                if [ -z "$EQUIBOP_DEB_URL" ]; then
-                    printf "%b\n" "${RED}Failed to find an Equibop deb package for $ARCH${RC}"
-                    exit 1
-                fi
                 # Ensure the downloaded .deb is removed even on failure under `set -e`.
                 trap 'rm -f equibop.deb' EXIT
                 curl -fLo equibop.deb "$EQUIBOP_DEB_URL"
@@ -99,11 +98,8 @@ installEquibop() {
                 case "$ARCH" in
                     x86_64) EQUIBOP_RPM_URL=$(printf '%s' "$latest_release" | grep -o 'https://[^"]*\.x86_64\.rpm' | head -n1) ;;
                     aarch64) EQUIBOP_RPM_URL=$(printf '%s' "$latest_release" | grep -o 'https://[^"]*\.aarch64\.rpm' | head -n1) ;;
+                    *) printf "%b\n" "${RED}Unsupported architecture for Equibop: $ARCH${RC}" && exit 1 ;;
                 esac
-                if [ -z "$EQUIBOP_RPM_URL" ]; then
-                    printf "%b\n" "${RED}Failed to find an Equibop rpm package for $ARCH${RC}"
-                    exit 1
-                fi
                 "$ESCALATION_TOOL" "$PACKAGER" install -y "$EQUIBOP_RPM_URL"
                 ;;
             *)
@@ -121,7 +117,7 @@ main() {
     printf "%b\n" "${YELLOW}Choose a fork of Discord to install:${RC}"
     printf "%b\n" "${YELLOW}1) Vanilla Discord${RC}"
     printf "%b\n" "${YELLOW}2) Vesktop (Discord with plugins)${RC}"
-    printf "%b\n" "${YELLOW}3) Equicord  (Vesktop with more plugins)${RC}"
+    printf "%b\n" "${YELLOW}3) Equibop (Vesktop with more plugins)${RC}"
     printf "%b" "Enter your choice [1-3]: "
     read -r choice
 


### PR DESCRIPTION
<!--
Read Contributing Guidelines before opening a PR.
https://github.com/ChrisTitusTech/linutil/blob/main/.github/CONTRIBUTING.md
-->

## Type of Change
- [X] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Security patch
- [ ] UI/UX improvement

## Description
So, I asked in Discord, got a green light and done it. When Discord is selected, it shows choice of 3 - vanilla, Vesktop and Equibop. Selection mechanic was stolen from auto-cpufreq file, all the installation script were written by Sonnet, cause I'm lazy to search. Also I named Equibop wrong, since Equicord is a core of Equibop, whoops, won't change it, too lazy xd

Arch works fine, maybe needed to test RPM and DEB packages, just to be sure, but looks fine.

## Screenshots (if applicable)
<img width="460" height="225" alt="image" src="https://github.com/user-attachments/assets/fb02ff99-dd6c-44f2-a762-31cae3b942c8" />
