### PR TITLE
feat: add EverQuest Legends MIDI setup

### DIFF
--- a/core/tabs/gaming/eq-legends-midi-start.sh
+++ b/core/tabs/gaming/eq-legends-midi-start.sh
@@ -12,11 +12,13 @@ else
 fi
 STATE_DIR="$STATE_HOME/linutil"
 PID_FILE="$RUNTIME_DIR/fluidsynth.pid"
-REFCOUNT_FILE="$RUNTIME_DIR/launch-count"
 LOCK_FILE="$RUNTIME_DIR/state.lock"
+PENDING_DIR="$RUNTIME_DIR/pending"
 LOG_FILE="$STATE_DIR/eq-legends-midi.log"
+STOP_HOOK="$HOOK_DIR/eq-midi-stop.sh"
 MIDI_CLIENT_NAME="EQ-Legends"
 MIDI_PORT_NAME="EQ-Legends"
+PENDING_TIMEOUT=60
 
 umask 077
 
@@ -56,13 +58,17 @@ owned_process_is_running() {
 	[ "$process_name" = "fluidsynth" ]
 }
 
-active_game_count() {
-	game_pids=$(pgrep -u "$(id -u)" -f '(^|[\\/])eqgame[.]exe([[:space:]]|$)' || true)
-	if [ -z "$game_pids" ]; then
-		printf "%s\n" 0
-	else
-		printf "%s\n" "$game_pids" | wc -l | tr -d '[:space:]'
-	fi
+managed_game_count() {
+	managed_count=0
+	game_pids=$(pgrep -u "$(id -u)" -f '(^|[\\/])([Ll]aunch[Pp]ad|eqgame)[.]exe([[:space:]]|$)' || true)
+	# Candidate PIDs are newline-delimited decimal values from pgrep.
+	# shellcheck disable=SC2086
+	for game_pid in $game_pids; do
+		if [ -r "/proc/$game_pid/environ" ] && tr '\000' '\n' <"/proc/$game_pid/environ" | grep -Fqx "WINEPREFIX=$WINEPREFIX"; then
+			managed_count=$((managed_count + 1))
+		fi
+	done
+	printf "%s\n" "$managed_count"
 }
 
 ensure_runtime_dir() {
@@ -84,17 +90,69 @@ acquire_lock() {
 	flock -w 15 9 || fail "timed out waiting for the FluidSynth lifecycle lock"
 }
 
-write_launch_count() {
-	printf "%s\n" "$1" >"$REFCOUNT_FILE"
+stop_child_process() {
+	child_pid="$1"
+	kill "$child_pid" 2>/dev/null || true
+	stop_attempt=0
+	while kill -0 "$child_pid" 2>/dev/null && [ "$stop_attempt" -lt 5 ]; do
+		stop_attempt=$((stop_attempt + 1))
+		sleep 1
+	done
+	if kill -0 "$child_pid" 2>/dev/null; then
+		kill -KILL "$child_pid" 2>/dev/null || true
+	fi
+	wait "$child_pid" 2>/dev/null || true
 }
+
+register_pending_launch() {
+	mkdir -p "$PENDING_DIR"
+	chmod 0700 "$PENDING_DIR"
+	pending_token=$(mktemp "$PENDING_DIR/launch.XXXXXX")
+	nohup "$0" --watch-pending "$pending_token" </dev/null >>"$LOG_FILE" 2>&1 9>&- &
+	watcher_pid=$!
+	watcher_start_time=$(process_start_time "$watcher_pid") || {
+		stop_child_process "$watcher_pid"
+		rm -f "$pending_token"
+		fail "unable to record the pending-launch watcher identity"
+	}
+	printf "%s\n%s\n%s\n" "$WINEPREFIX" "$watcher_pid" "$watcher_start_time" >"$pending_token"
+}
+
+watch_pending_launch() {
+	pending_token="$1"
+	case "$pending_token" in
+	"$PENDING_DIR"/launch.*) ;;
+	*) fail "invalid pending-launch token: $pending_token" ;;
+	esac
+
+	sleep "$PENDING_TIMEOUT"
+	while [ "$(managed_game_count)" -gt 0 ]; do
+		sleep 5
+	done
+
+	acquire_lock
+	rm -f "$pending_token"
+	exec 9>&-
+	"$STOP_HOOK" >/dev/null 2>&1 || true
+}
+
+command -v flock >/dev/null 2>&1 || fail "flock is not installed"
+command -v pgrep >/dev/null 2>&1 || fail "pgrep is not installed"
+command -v stat >/dev/null 2>&1 || fail "stat is not installed"
+# Lutris passes the configured Wine environment to both lifecycle hooks.
+[ -n "${WINEPREFIX:-}" ] || fail "WINEPREFIX was not provided by Lutris"
+
+if [ "${1:-}" = "--watch-pending" ]; then
+	[ "$#" -eq 2 ] || fail "invalid pending-launch watcher arguments"
+	ensure_runtime_dir
+	watch_pending_launch "$2"
+	exit 0
+fi
 
 command -v fluidsynth >/dev/null 2>&1 || fail "fluidsynth is not installed"
 command -v aconnect >/dev/null 2>&1 || fail "aconnect is not installed"
-command -v flock >/dev/null 2>&1 || fail "flock is not installed"
 command -v nohup >/dev/null 2>&1 || fail "nohup is not installed"
-command -v pgrep >/dev/null 2>&1 || fail "pgrep is not installed"
 command -v ps >/dev/null 2>&1 || fail "ps is not installed"
-command -v stat >/dev/null 2>&1 || fail "stat is not installed"
 [ -f "$SOUNDFONT" ] || fail "SoundFont not found: $SOUNDFONT"
 
 ensure_runtime_dir
@@ -124,8 +182,7 @@ fi
 
 if aconnect -l 2>/dev/null | grep -q "client [0-9][0-9]*: '$MIDI_CLIENT_NAME'"; then
 	[ -n "$owned_pid" ] || fail "an unmanaged $MIDI_CLIENT_NAME MIDI client is already running"
-	LAUNCH_COUNT=$(active_game_count)
-	write_launch_count $((LAUNCH_COUNT + 1))
+	register_pending_launch
 	exit 0
 fi
 
@@ -140,10 +197,9 @@ if [ -n "$owned_pid" ]; then
 	if owned_process_is_running "$owned_pid" "$owned_start_time"; then
 		kill -KILL "$owned_pid" 2>/dev/null || true
 	fi
-	rm -f "$PID_FILE" "$REFCOUNT_FILE"
+	rm -f "$PID_FILE"
 	fail "an owned FluidSynth process is running without a MIDI port; see $LOG_FILE"
 fi
-rm -f "$REFCOUNT_FILE"
 
 audio_drivers=$(fluidsynth -a help 2>&1 || true)
 midi_drivers=$(fluidsynth -m help 2>&1 || true)
@@ -168,8 +224,7 @@ nohup fluidsynth -i -a "$audio_driver" -m alsa_seq \
 	"$SOUNDFONT" 9>&- >"$LOG_FILE" 2>&1 &
 fluidsynth_pid=$!
 fluidsynth_start_time=$(process_start_time "$fluidsynth_pid") || {
-	kill "$fluidsynth_pid" 2>/dev/null || true
-	wait "$fluidsynth_pid" 2>/dev/null || true
+	stop_child_process "$fluidsynth_pid"
 	fail "unable to record the FluidSynth process identity; see $LOG_FILE"
 }
 printf "%s\n%s\n" "$fluidsynth_pid" "$fluidsynth_start_time" >"$PID_FILE"
@@ -177,13 +232,12 @@ printf "%s\n%s\n" "$fluidsynth_pid" "$fluidsynth_start_time" >"$PID_FILE"
 attempt=0
 while [ "$attempt" -lt 10 ]; do
 	if aconnect -l 2>/dev/null | grep -q "client [0-9][0-9]*: '$MIDI_CLIENT_NAME'"; then
-		LAUNCH_COUNT=$(active_game_count)
-		write_launch_count $((LAUNCH_COUNT + 1))
+		register_pending_launch
 		exit 0
 	fi
 
 	if ! owned_process_is_running "$fluidsynth_pid" "$fluidsynth_start_time"; then
-		rm -f "$PID_FILE" "$REFCOUNT_FILE"
+		rm -f "$PID_FILE"
 		tail -n 20 "$LOG_FILE" >&2 || true
 		fail "FluidSynth exited before its MIDI port became ready"
 	fi
@@ -192,9 +246,6 @@ while [ "$attempt" -lt 10 ]; do
 	sleep 1
 done
 
-if owned_process_is_running "$fluidsynth_pid" "$fluidsynth_start_time"; then
-	kill "$fluidsynth_pid" 2>/dev/null || true
-fi
-wait "$fluidsynth_pid" 2>/dev/null || true
-rm -f "$PID_FILE" "$REFCOUNT_FILE"
+stop_child_process "$fluidsynth_pid"
+rm -f "$PID_FILE"
 fail "FluidSynth started but its MIDI port did not become ready; see $LOG_FILE"

--- a/core/tabs/gaming/eq-legends-midi-start.sh
+++ b/core/tabs/gaming/eq-legends-midi-start.sh
@@ -12,43 +12,141 @@ else
 fi
 STATE_DIR="$STATE_HOME/linutil"
 PID_FILE="$RUNTIME_DIR/fluidsynth.pid"
+REFCOUNT_FILE="$RUNTIME_DIR/launch-count"
+LOCK_FILE="$RUNTIME_DIR/state.lock"
 LOG_FILE="$STATE_DIR/eq-legends-midi.log"
 MIDI_CLIENT_NAME="EQ-Legends"
 MIDI_PORT_NAME="EQ-Legends"
+
+umask 077
 
 fail() {
 	printf "%s\n" "eq-legends-midi: $*" >&2
 	exit 1
 }
 
+process_start_time() {
+	process_pid="$1"
+	[ -r "/proc/$process_pid/stat" ] || return 1
+	process_stat=$(sed -n '1p' "/proc/$process_pid/stat") || return 1
+	process_stat=${process_stat##*) }
+	# The remaining proc fields are whitespace-delimited numeric values.
+	# shellcheck disable=SC2086
+	set -- $process_stat
+	[ "$#" -ge 20 ] || return 1
+	shift 19
+	case "$1" in
+	'' | *[!0-9]*) return 1 ;;
+	esac
+	printf "%s\n" "$1"
+}
+
+process_matches_start_time() {
+	process_pid="$1"
+	expected_start_time="$2"
+	current_start_time=$(process_start_time "$process_pid") || return 1
+	[ "$current_start_time" = "$expected_start_time" ]
+}
+
+owned_process_is_running() {
+	process_pid="$1"
+	expected_start_time="$2"
+	process_matches_start_time "$process_pid" "$expected_start_time" || return 1
+	process_name=$(ps -p "$process_pid" -o comm= 2>/dev/null | tr -d '[:space:]' || true)
+	[ "$process_name" = "fluidsynth" ]
+}
+
+ensure_runtime_dir() {
+	if mkdir -m 0700 "$RUNTIME_DIR" 2>/dev/null; then
+		return 0
+	fi
+
+	[ -d "$RUNTIME_DIR" ] && [ ! -L "$RUNTIME_DIR" ] || fail "runtime path is unsafe: $RUNTIME_DIR"
+	runtime_owner=$(stat -c '%u' -- "$RUNTIME_DIR" 2>/dev/null) || fail "unable to inspect runtime path: $RUNTIME_DIR"
+	[ "$runtime_owner" = "$(id -u)" ] || fail "runtime path is not owned by the current user: $RUNTIME_DIR"
+	chmod 0700 "$RUNTIME_DIR"
+}
+
+acquire_lock() {
+	[ ! -L "$LOCK_FILE" ] || fail "runtime lock path is unsafe: $LOCK_FILE"
+	[ ! -e "$LOCK_FILE" ] || [ -f "$LOCK_FILE" ] || fail "runtime lock path is not a file: $LOCK_FILE"
+	exec 9>>"$LOCK_FILE"
+	chmod 0600 "$LOCK_FILE"
+	flock -w 15 9 || fail "timed out waiting for the FluidSynth lifecycle lock"
+}
+
+read_launch_count() {
+	LAUNCH_COUNT=0
+	[ -f "$REFCOUNT_FILE" ] || return 0
+	LAUNCH_COUNT=$(sed -n '1p' "$REFCOUNT_FILE")
+	case "$LAUNCH_COUNT" in
+	'' | *[!0-9]*) fail "invalid launch count in $REFCOUNT_FILE" ;;
+	esac
+	[ "$LAUNCH_COUNT" -gt 0 ] || fail "invalid launch count in $REFCOUNT_FILE"
+}
+
+write_launch_count() {
+	printf "%s\n" "$1" >"$REFCOUNT_FILE"
+}
+
 command -v fluidsynth >/dev/null 2>&1 || fail "fluidsynth is not installed"
 command -v aconnect >/dev/null 2>&1 || fail "aconnect is not installed"
+command -v flock >/dev/null 2>&1 || fail "flock is not installed"
 command -v nohup >/dev/null 2>&1 || fail "nohup is not installed"
+command -v ps >/dev/null 2>&1 || fail "ps is not installed"
+command -v stat >/dev/null 2>&1 || fail "stat is not installed"
 [ -f "$SOUNDFONT" ] || fail "SoundFont not found: $SOUNDFONT"
 
-[ ! -L "$RUNTIME_DIR" ] || fail "runtime path must not be a symbolic link: $RUNTIME_DIR"
-mkdir -p "$RUNTIME_DIR" "$STATE_DIR"
-chmod 0700 "$RUNTIME_DIR"
+ensure_runtime_dir
+mkdir -p "$STATE_DIR"
+acquire_lock
 
-if aconnect -l 2>/dev/null | grep -q "client [0-9][0-9]*: '$MIDI_CLIENT_NAME'"; then
-	exit 0
-fi
-
+owned_pid=""
+owned_start_time=""
 if [ -f "$PID_FILE" ]; then
-	old_pid=$(sed -n '1p' "$PID_FILE")
-	case "$old_pid" in
-	'' | *[!0-9]*) rm -f "$PID_FILE" ;;
-	*)
-		if kill -0 "$old_pid" 2>/dev/null; then
-			old_command=$(ps -p "$old_pid" -o comm= 2>/dev/null | tr -d '[:space:]' || true)
-			if [ "$old_command" = "fluidsynth" ]; then
-				fail "an owned FluidSynth process is running without a MIDI port; see $LOG_FILE"
-			fi
-		fi
+	owned_pid=$(sed -n '1p' "$PID_FILE")
+	owned_start_time=$(sed -n '2p' "$PID_FILE")
+	case "$owned_pid:$owned_start_time" in
+	*[!0-9:]* | :* | *:)
 		rm -f "$PID_FILE"
+		owned_pid=""
+		owned_start_time=""
+		;;
+	*)
+		if ! owned_process_is_running "$owned_pid" "$owned_start_time"; then
+			rm -f "$PID_FILE"
+			owned_pid=""
+			owned_start_time=""
+		fi
 		;;
 	esac
 fi
+
+if aconnect -l 2>/dev/null | grep -q "client [0-9][0-9]*: '$MIDI_CLIENT_NAME'"; then
+	[ -n "$owned_pid" ] || fail "an unmanaged $MIDI_CLIENT_NAME MIDI client is already running"
+	read_launch_count
+	if [ "$LAUNCH_COUNT" -eq 0 ]; then
+		LAUNCH_COUNT=1
+	fi
+	write_launch_count $((LAUNCH_COUNT + 1))
+	exit 0
+fi
+
+if [ -n "$owned_pid" ]; then
+	printf "%s\n" "eq-legends-midi: reclaiming an owned FluidSynth process without a MIDI port; see $LOG_FILE" >&2
+	kill "$owned_pid" 2>/dev/null || true
+	stop_attempt=0
+	while owned_process_is_running "$owned_pid" "$owned_start_time" && [ "$stop_attempt" -lt 5 ]; do
+		stop_attempt=$((stop_attempt + 1))
+		sleep 1
+	done
+	if owned_process_is_running "$owned_pid" "$owned_start_time"; then
+		kill -KILL "$owned_pid" 2>/dev/null || true
+	fi
+	rm -f "$PID_FILE" "$REFCOUNT_FILE"
+	fail "an owned FluidSynth process is running without a MIDI port; see $LOG_FILE"
+fi
+rm -f "$REFCOUNT_FILE"
 
 audio_drivers=$(fluidsynth -a help 2>&1 || true)
 midi_drivers=$(fluidsynth -m help 2>&1 || true)
@@ -67,21 +165,27 @@ fi
 
 [ -n "$audio_driver" ] || fail "no supported PipeWire, PulseAudio, or ALSA audio driver is available"
 
-nohup fluidsynth -is -a "$audio_driver" -m alsa_seq \
+nohup fluidsynth -i -a "$audio_driver" -m alsa_seq \
 	-o "midi.alsa_seq.id=$MIDI_CLIENT_NAME" \
 	-o "midi.portname=$MIDI_PORT_NAME" \
-	"$SOUNDFONT" >"$LOG_FILE" 2>&1 &
+	"$SOUNDFONT" 9>&- >"$LOG_FILE" 2>&1 &
 fluidsynth_pid=$!
-printf "%s\n" "$fluidsynth_pid" >"$PID_FILE"
+fluidsynth_start_time=$(process_start_time "$fluidsynth_pid") || {
+	kill "$fluidsynth_pid" 2>/dev/null || true
+	wait "$fluidsynth_pid" 2>/dev/null || true
+	fail "unable to record the FluidSynth process identity; see $LOG_FILE"
+}
+printf "%s\n%s\n" "$fluidsynth_pid" "$fluidsynth_start_time" >"$PID_FILE"
 
 attempt=0
 while [ "$attempt" -lt 10 ]; do
 	if aconnect -l 2>/dev/null | grep -q "client [0-9][0-9]*: '$MIDI_CLIENT_NAME'"; then
+		write_launch_count 1
 		exit 0
 	fi
 
-	if ! kill -0 "$fluidsynth_pid" 2>/dev/null; then
-		rm -f "$PID_FILE"
+	if ! owned_process_is_running "$fluidsynth_pid" "$fluidsynth_start_time"; then
+		rm -f "$PID_FILE" "$REFCOUNT_FILE"
 		tail -n 20 "$LOG_FILE" >&2 || true
 		fail "FluidSynth exited before its MIDI port became ready"
 	fi
@@ -90,7 +194,9 @@ while [ "$attempt" -lt 10 ]; do
 	sleep 1
 done
 
-kill "$fluidsynth_pid" 2>/dev/null || true
+if owned_process_is_running "$fluidsynth_pid" "$fluidsynth_start_time"; then
+	kill "$fluidsynth_pid" 2>/dev/null || true
+fi
 wait "$fluidsynth_pid" 2>/dev/null || true
-rm -f "$PID_FILE"
+rm -f "$PID_FILE" "$REFCOUNT_FILE"
 fail "FluidSynth started but its MIDI port did not become ready; see $LOG_FILE"

--- a/core/tabs/gaming/eq-legends-midi-start.sh
+++ b/core/tabs/gaming/eq-legends-midi-start.sh
@@ -56,6 +56,15 @@ owned_process_is_running() {
 	[ "$process_name" = "fluidsynth" ]
 }
 
+active_game_count() {
+	game_pids=$(pgrep -u "$(id -u)" -f '(^|[\\/])eqgame[.]exe([[:space:]]|$)' || true)
+	if [ -z "$game_pids" ]; then
+		printf "%s\n" 0
+	else
+		printf "%s\n" "$game_pids" | wc -l | tr -d '[:space:]'
+	fi
+}
+
 ensure_runtime_dir() {
 	if mkdir -m 0700 "$RUNTIME_DIR" 2>/dev/null; then
 		return 0
@@ -75,16 +84,6 @@ acquire_lock() {
 	flock -w 15 9 || fail "timed out waiting for the FluidSynth lifecycle lock"
 }
 
-read_launch_count() {
-	LAUNCH_COUNT=0
-	[ -f "$REFCOUNT_FILE" ] || return 0
-	LAUNCH_COUNT=$(sed -n '1p' "$REFCOUNT_FILE")
-	case "$LAUNCH_COUNT" in
-	'' | *[!0-9]*) fail "invalid launch count in $REFCOUNT_FILE" ;;
-	esac
-	[ "$LAUNCH_COUNT" -gt 0 ] || fail "invalid launch count in $REFCOUNT_FILE"
-}
-
 write_launch_count() {
 	printf "%s\n" "$1" >"$REFCOUNT_FILE"
 }
@@ -93,6 +92,7 @@ command -v fluidsynth >/dev/null 2>&1 || fail "fluidsynth is not installed"
 command -v aconnect >/dev/null 2>&1 || fail "aconnect is not installed"
 command -v flock >/dev/null 2>&1 || fail "flock is not installed"
 command -v nohup >/dev/null 2>&1 || fail "nohup is not installed"
+command -v pgrep >/dev/null 2>&1 || fail "pgrep is not installed"
 command -v ps >/dev/null 2>&1 || fail "ps is not installed"
 command -v stat >/dev/null 2>&1 || fail "stat is not installed"
 [ -f "$SOUNDFONT" ] || fail "SoundFont not found: $SOUNDFONT"
@@ -124,10 +124,7 @@ fi
 
 if aconnect -l 2>/dev/null | grep -q "client [0-9][0-9]*: '$MIDI_CLIENT_NAME'"; then
 	[ -n "$owned_pid" ] || fail "an unmanaged $MIDI_CLIENT_NAME MIDI client is already running"
-	read_launch_count
-	if [ "$LAUNCH_COUNT" -eq 0 ]; then
-		LAUNCH_COUNT=1
-	fi
+	LAUNCH_COUNT=$(active_game_count)
 	write_launch_count $((LAUNCH_COUNT + 1))
 	exit 0
 fi
@@ -180,7 +177,8 @@ printf "%s\n%s\n" "$fluidsynth_pid" "$fluidsynth_start_time" >"$PID_FILE"
 attempt=0
 while [ "$attempt" -lt 10 ]; do
 	if aconnect -l 2>/dev/null | grep -q "client [0-9][0-9]*: '$MIDI_CLIENT_NAME'"; then
-		write_launch_count 1
+		LAUNCH_COUNT=$(active_game_count)
+		write_launch_count $((LAUNCH_COUNT + 1))
 		exit 0
 	fi
 

--- a/core/tabs/gaming/eq-legends-midi-start.sh
+++ b/core/tabs/gaming/eq-legends-midi-start.sh
@@ -1,0 +1,96 @@
+#!/bin/sh -e
+
+HOOK_DIR=$(dirname -- "$0")
+HOOK_DIR=$(cd -- "$HOOK_DIR" && pwd)
+DATA_HOME=$(cd -- "$HOOK_DIR/../.." && pwd)
+STATE_HOME=${XDG_STATE_HOME:-"$HOME/.local/state"}
+SOUNDFONT="$DATA_HOME/sounds/sf2/SC-55 Roland SOUNDCanvas Up.sf2"
+if [ -n "${XDG_RUNTIME_DIR:-}" ]; then
+	RUNTIME_DIR="$XDG_RUNTIME_DIR/linutil-eq-midi"
+else
+	RUNTIME_DIR="${TMPDIR:-/tmp}/linutil-eq-midi-$(id -u)"
+fi
+STATE_DIR="$STATE_HOME/linutil"
+PID_FILE="$RUNTIME_DIR/fluidsynth.pid"
+LOG_FILE="$STATE_DIR/eq-legends-midi.log"
+MIDI_CLIENT_NAME="EQ-Legends"
+MIDI_PORT_NAME="EQ-Legends"
+
+fail() {
+	printf "%s\n" "eq-legends-midi: $*" >&2
+	exit 1
+}
+
+command -v fluidsynth >/dev/null 2>&1 || fail "fluidsynth is not installed"
+command -v aconnect >/dev/null 2>&1 || fail "aconnect is not installed"
+command -v nohup >/dev/null 2>&1 || fail "nohup is not installed"
+[ -f "$SOUNDFONT" ] || fail "SoundFont not found: $SOUNDFONT"
+
+[ ! -L "$RUNTIME_DIR" ] || fail "runtime path must not be a symbolic link: $RUNTIME_DIR"
+mkdir -p "$RUNTIME_DIR" "$STATE_DIR"
+chmod 0700 "$RUNTIME_DIR"
+
+if aconnect -l 2>/dev/null | grep -q "client [0-9][0-9]*: '$MIDI_CLIENT_NAME'"; then
+	exit 0
+fi
+
+if [ -f "$PID_FILE" ]; then
+	old_pid=$(sed -n '1p' "$PID_FILE")
+	case "$old_pid" in
+	'' | *[!0-9]*) rm -f "$PID_FILE" ;;
+	*)
+		if kill -0 "$old_pid" 2>/dev/null; then
+			old_command=$(ps -p "$old_pid" -o comm= 2>/dev/null | tr -d '[:space:]' || true)
+			if [ "$old_command" = "fluidsynth" ]; then
+				fail "an owned FluidSynth process is running without a MIDI port; see $LOG_FILE"
+			fi
+		fi
+		rm -f "$PID_FILE"
+		;;
+	esac
+fi
+
+audio_drivers=$(fluidsynth -a help 2>&1 || true)
+midi_drivers=$(fluidsynth -m help 2>&1 || true)
+printf "%s\n" "$midi_drivers" | grep -q "alsa_seq" || fail "FluidSynth lacks the required ALSA sequencer MIDI driver"
+
+audio_driver=""
+if [ -n "${XDG_RUNTIME_DIR:-}" ] && [ -S "$XDG_RUNTIME_DIR/pipewire-0" ] && printf "%s\n" "$audio_drivers" | grep -q "pipewire"; then
+	audio_driver="pipewire"
+elif {
+	[ -n "${PULSE_SERVER:-}" ] || { [ -n "${XDG_RUNTIME_DIR:-}" ] && [ -S "$XDG_RUNTIME_DIR/pulse/native" ]; }
+} && printf "%s\n" "$audio_drivers" | grep -q "pulseaudio"; then
+	audio_driver="pulseaudio"
+elif printf "%s\n" "$audio_drivers" | grep -q "alsa"; then
+	audio_driver="alsa"
+fi
+
+[ -n "$audio_driver" ] || fail "no supported PipeWire, PulseAudio, or ALSA audio driver is available"
+
+nohup fluidsynth -is -a "$audio_driver" -m alsa_seq \
+	-o "midi.alsa_seq.id=$MIDI_CLIENT_NAME" \
+	-o "midi.portname=$MIDI_PORT_NAME" \
+	"$SOUNDFONT" >"$LOG_FILE" 2>&1 &
+fluidsynth_pid=$!
+printf "%s\n" "$fluidsynth_pid" >"$PID_FILE"
+
+attempt=0
+while [ "$attempt" -lt 10 ]; do
+	if aconnect -l 2>/dev/null | grep -q "client [0-9][0-9]*: '$MIDI_CLIENT_NAME'"; then
+		exit 0
+	fi
+
+	if ! kill -0 "$fluidsynth_pid" 2>/dev/null; then
+		rm -f "$PID_FILE"
+		tail -n 20 "$LOG_FILE" >&2 || true
+		fail "FluidSynth exited before its MIDI port became ready"
+	fi
+
+	attempt=$((attempt + 1))
+	sleep 1
+done
+
+kill "$fluidsynth_pid" 2>/dev/null || true
+wait "$fluidsynth_pid" 2>/dev/null || true
+rm -f "$PID_FILE"
+fail "FluidSynth started but its MIDI port did not become ready; see $LOG_FILE"

--- a/core/tabs/gaming/eq-legends-midi-stop.sh
+++ b/core/tabs/gaming/eq-legends-midi-stop.sh
@@ -47,6 +47,15 @@ owned_process_is_running() {
 	[ "$process_name" = "fluidsynth" ]
 }
 
+active_game_count() {
+	game_pids=$(pgrep -u "$(id -u)" -f '(^|[\\/])eqgame[.]exe([[:space:]]|$)' || true)
+	if [ -z "$game_pids" ]; then
+		printf "%s\n" 0
+	else
+		printf "%s\n" "$game_pids" | wc -l | tr -d '[:space:]'
+	fi
+}
+
 acquire_lock() {
 	[ ! -L "$LOCK_FILE" ] || fail "runtime lock path is unsafe: $LOCK_FILE"
 	[ ! -e "$LOCK_FILE" ] || [ -f "$LOCK_FILE" ] || fail "runtime lock path is not a file: $LOCK_FILE"
@@ -57,6 +66,7 @@ acquire_lock() {
 
 [ -e "$RUNTIME_DIR" ] || exit 0
 command -v flock >/dev/null 2>&1 || fail "flock is not installed"
+command -v pgrep >/dev/null 2>&1 || fail "pgrep is not installed"
 command -v ps >/dev/null 2>&1 || fail "ps is not installed"
 command -v stat >/dev/null 2>&1 || fail "stat is not installed"
 [ -d "$RUNTIME_DIR" ] && [ ! -L "$RUNTIME_DIR" ] || fail "runtime path is unsafe: $RUNTIME_DIR"
@@ -90,17 +100,9 @@ if [ "$process_name" != "fluidsynth" ]; then
 	exit 1
 fi
 
-launch_count=1
-if [ -f "$REFCOUNT_FILE" ]; then
-	launch_count=$(sed -n '1p' "$REFCOUNT_FILE")
-	case "$launch_count" in
-	'' | *[!0-9]*) fail "invalid launch count in $REFCOUNT_FILE" ;;
-	esac
-	[ "$launch_count" -gt 0 ] || fail "invalid launch count in $REFCOUNT_FILE"
-fi
-
-if [ "$launch_count" -gt 1 ]; then
-	printf "%s\n" $((launch_count - 1)) >"$REFCOUNT_FILE"
+launch_count=$(active_game_count)
+if [ "$launch_count" -gt 0 ]; then
+	printf "%s\n" "$launch_count" >"$REFCOUNT_FILE"
 	exit 0
 fi
 rm -f "$REFCOUNT_FILE"

--- a/core/tabs/gaming/eq-legends-midi-stop.sh
+++ b/core/tabs/gaming/eq-legends-midi-stop.sh
@@ -6,8 +6,8 @@ else
 	RUNTIME_DIR="${TMPDIR:-/tmp}/linutil-eq-midi-$(id -u)"
 fi
 PID_FILE="$RUNTIME_DIR/fluidsynth.pid"
-REFCOUNT_FILE="$RUNTIME_DIR/launch-count"
 LOCK_FILE="$RUNTIME_DIR/state.lock"
+PENDING_DIR="$RUNTIME_DIR/pending"
 
 umask 077
 
@@ -47,13 +47,38 @@ owned_process_is_running() {
 	[ "$process_name" = "fluidsynth" ]
 }
 
-active_game_count() {
-	game_pids=$(pgrep -u "$(id -u)" -f '(^|[\\/])eqgame[.]exe([[:space:]]|$)' || true)
-	if [ -z "$game_pids" ]; then
-		printf "%s\n" 0
-	else
-		printf "%s\n" "$game_pids" | wc -l | tr -d '[:space:]'
-	fi
+managed_game_count() {
+	managed_count=0
+	game_pids=$(pgrep -u "$(id -u)" -f '(^|[\\/])([Ll]aunch[Pp]ad|eqgame)[.]exe([[:space:]]|$)' || true)
+	# Candidate PIDs are newline-delimited decimal values from pgrep.
+	# shellcheck disable=SC2086
+	for game_pid in $game_pids; do
+		if [ -r "/proc/$game_pid/environ" ] && tr '\000' '\n' <"/proc/$game_pid/environ" | grep -Fqx "WINEPREFIX=$WINEPREFIX"; then
+			managed_count=$((managed_count + 1))
+		fi
+	done
+	printf "%s\n" "$managed_count"
+}
+
+pending_launch_count() {
+	pending_count=0
+	for pending_token in "$PENDING_DIR"/launch.*; do
+		[ -f "$pending_token" ] || continue
+		watcher_pid=$(sed -n '2p' "$pending_token")
+		watcher_start_time=$(sed -n '3p' "$pending_token")
+		case "$watcher_pid:$watcher_start_time" in
+		*[!0-9:]* | :* | *:)
+			pending_count=$((pending_count + 1))
+			continue
+			;;
+		esac
+		if ! process_matches_start_time "$watcher_pid" "$watcher_start_time"; then
+			rm -f "$pending_token"
+			continue
+		fi
+		pending_count=$((pending_count + 1))
+	done
+	printf "%s\n" "$pending_count"
 }
 
 acquire_lock() {
@@ -69,13 +94,14 @@ command -v flock >/dev/null 2>&1 || fail "flock is not installed"
 command -v pgrep >/dev/null 2>&1 || fail "pgrep is not installed"
 command -v ps >/dev/null 2>&1 || fail "ps is not installed"
 command -v stat >/dev/null 2>&1 || fail "stat is not installed"
+# Lutris passes the configured Wine environment to both lifecycle hooks.
+[ -n "${WINEPREFIX:-}" ] || fail "WINEPREFIX was not provided by Lutris"
 [ -d "$RUNTIME_DIR" ] && [ ! -L "$RUNTIME_DIR" ] || fail "runtime path is unsafe: $RUNTIME_DIR"
 runtime_owner=$(stat -c '%u' -- "$RUNTIME_DIR" 2>/dev/null) || fail "unable to inspect runtime path: $RUNTIME_DIR"
 [ "$runtime_owner" = "$(id -u)" ] || fail "runtime path is not owned by the current user: $RUNTIME_DIR"
 
 acquire_lock
 [ -f "$PID_FILE" ] || {
-	rm -f "$REFCOUNT_FILE"
 	exit 0
 }
 
@@ -83,29 +109,28 @@ fluidsynth_pid=$(sed -n '1p' "$PID_FILE")
 fluidsynth_start_time=$(sed -n '2p' "$PID_FILE")
 case "$fluidsynth_pid:$fluidsynth_start_time" in
 *[!0-9:]* | :* | *:)
-	rm -f "$PID_FILE" "$REFCOUNT_FILE"
+	rm -f "$PID_FILE"
 	exit 0
 	;;
 esac
 
 if ! process_matches_start_time "$fluidsynth_pid" "$fluidsynth_start_time"; then
-	rm -f "$PID_FILE" "$REFCOUNT_FILE"
+	rm -f "$PID_FILE"
 	exit 0
 fi
 
 process_name=$(ps -p "$fluidsynth_pid" -o comm= 2>/dev/null | tr -d '[:space:]' || true)
 if [ "$process_name" != "fluidsynth" ]; then
 	printf "%s\n" "eq-legends-midi: refusing to stop unrelated process $fluidsynth_pid" >&2
-	rm -f "$PID_FILE" "$REFCOUNT_FILE"
+	rm -f "$PID_FILE"
 	exit 1
 fi
 
-launch_count=$(active_game_count)
-if [ "$launch_count" -gt 0 ]; then
-	printf "%s\n" "$launch_count" >"$REFCOUNT_FILE"
+managed_count=$(managed_game_count)
+pending_count=$(pending_launch_count)
+if [ "$managed_count" -gt 0 ] || [ "$pending_count" -gt 0 ]; then
 	exit 0
 fi
-rm -f "$REFCOUNT_FILE"
 
 if owned_process_is_running "$fluidsynth_pid" "$fluidsynth_start_time"; then
 	kill "$fluidsynth_pid" 2>/dev/null || true

--- a/core/tabs/gaming/eq-legends-midi-stop.sh
+++ b/core/tabs/gaming/eq-legends-midi-stop.sh
@@ -68,7 +68,7 @@ pending_launch_count() {
 		watcher_start_time=$(sed -n '3p' "$pending_token")
 		case "$watcher_pid:$watcher_start_time" in
 		*[!0-9:]* | :* | *:)
-			pending_count=$((pending_count + 1))
+			rm -f "$pending_token"
 			continue
 			;;
 		esac

--- a/core/tabs/gaming/eq-legends-midi-stop.sh
+++ b/core/tabs/gaming/eq-legends-midi-stop.sh
@@ -1,0 +1,51 @@
+#!/bin/sh -e
+
+if [ -n "${XDG_RUNTIME_DIR:-}" ]; then
+	RUNTIME_DIR="$XDG_RUNTIME_DIR/linutil-eq-midi"
+else
+	RUNTIME_DIR="${TMPDIR:-/tmp}/linutil-eq-midi-$(id -u)"
+fi
+PID_FILE="$RUNTIME_DIR/fluidsynth.pid"
+
+[ ! -L "$RUNTIME_DIR" ] || {
+	printf "%s\n" "eq-legends-midi: refusing symbolic-link runtime path $RUNTIME_DIR" >&2
+	exit 1
+}
+[ -f "$PID_FILE" ] || exit 0
+
+fluidsynth_pid=$(sed -n '1p' "$PID_FILE")
+case "$fluidsynth_pid" in
+'' | *[!0-9]*)
+	rm -f "$PID_FILE"
+	exit 0
+	;;
+esac
+
+if ! kill -0 "$fluidsynth_pid" 2>/dev/null; then
+	rm -f "$PID_FILE"
+	exit 0
+fi
+
+process_name=$(ps -p "$fluidsynth_pid" -o comm= 2>/dev/null | tr -d '[:space:]' || true)
+if [ -z "$process_name" ] && ! kill -0 "$fluidsynth_pid" 2>/dev/null; then
+	rm -f "$PID_FILE"
+	exit 0
+fi
+if [ "$process_name" != "fluidsynth" ]; then
+	printf "%s\n" "eq-legends-midi: refusing to stop unrelated process $fluidsynth_pid" >&2
+	rm -f "$PID_FILE"
+	exit 1
+fi
+
+kill "$fluidsynth_pid"
+attempt=0
+while kill -0 "$fluidsynth_pid" 2>/dev/null && [ "$attempt" -lt 5 ]; do
+	attempt=$((attempt + 1))
+	sleep 1
+done
+
+if kill -0 "$fluidsynth_pid" 2>/dev/null; then
+	kill -KILL "$fluidsynth_pid" 2>/dev/null || true
+fi
+
+rm -f "$PID_FILE"

--- a/core/tabs/gaming/eq-legends-midi-stop.sh
+++ b/core/tabs/gaming/eq-legends-midi-stop.sh
@@ -6,45 +6,115 @@ else
 	RUNTIME_DIR="${TMPDIR:-/tmp}/linutil-eq-midi-$(id -u)"
 fi
 PID_FILE="$RUNTIME_DIR/fluidsynth.pid"
+REFCOUNT_FILE="$RUNTIME_DIR/launch-count"
+LOCK_FILE="$RUNTIME_DIR/state.lock"
 
-[ ! -L "$RUNTIME_DIR" ] || {
-	printf "%s\n" "eq-legends-midi: refusing symbolic-link runtime path $RUNTIME_DIR" >&2
+umask 077
+
+fail() {
+	printf "%s\n" "eq-legends-midi: $*" >&2
 	exit 1
 }
-[ -f "$PID_FILE" ] || exit 0
+
+process_start_time() {
+	process_pid="$1"
+	[ -r "/proc/$process_pid/stat" ] || return 1
+	process_stat=$(sed -n '1p' "/proc/$process_pid/stat") || return 1
+	process_stat=${process_stat##*) }
+	# The remaining proc fields are whitespace-delimited numeric values.
+	# shellcheck disable=SC2086
+	set -- $process_stat
+	[ "$#" -ge 20 ] || return 1
+	shift 19
+	case "$1" in
+	'' | *[!0-9]*) return 1 ;;
+	esac
+	printf "%s\n" "$1"
+}
+
+process_matches_start_time() {
+	process_pid="$1"
+	expected_start_time="$2"
+	current_start_time=$(process_start_time "$process_pid") || return 1
+	[ "$current_start_time" = "$expected_start_time" ]
+}
+
+owned_process_is_running() {
+	process_pid="$1"
+	expected_start_time="$2"
+	process_matches_start_time "$process_pid" "$expected_start_time" || return 1
+	process_name=$(ps -p "$process_pid" -o comm= 2>/dev/null | tr -d '[:space:]' || true)
+	[ "$process_name" = "fluidsynth" ]
+}
+
+acquire_lock() {
+	[ ! -L "$LOCK_FILE" ] || fail "runtime lock path is unsafe: $LOCK_FILE"
+	[ ! -e "$LOCK_FILE" ] || [ -f "$LOCK_FILE" ] || fail "runtime lock path is not a file: $LOCK_FILE"
+	exec 9>>"$LOCK_FILE"
+	chmod 0600 "$LOCK_FILE"
+	flock -w 15 9 || fail "timed out waiting for the FluidSynth lifecycle lock"
+}
+
+[ -e "$RUNTIME_DIR" ] || exit 0
+command -v flock >/dev/null 2>&1 || fail "flock is not installed"
+command -v ps >/dev/null 2>&1 || fail "ps is not installed"
+command -v stat >/dev/null 2>&1 || fail "stat is not installed"
+[ -d "$RUNTIME_DIR" ] && [ ! -L "$RUNTIME_DIR" ] || fail "runtime path is unsafe: $RUNTIME_DIR"
+runtime_owner=$(stat -c '%u' -- "$RUNTIME_DIR" 2>/dev/null) || fail "unable to inspect runtime path: $RUNTIME_DIR"
+[ "$runtime_owner" = "$(id -u)" ] || fail "runtime path is not owned by the current user: $RUNTIME_DIR"
+
+acquire_lock
+[ -f "$PID_FILE" ] || {
+	rm -f "$REFCOUNT_FILE"
+	exit 0
+}
 
 fluidsynth_pid=$(sed -n '1p' "$PID_FILE")
-case "$fluidsynth_pid" in
-'' | *[!0-9]*)
-	rm -f "$PID_FILE"
+fluidsynth_start_time=$(sed -n '2p' "$PID_FILE")
+case "$fluidsynth_pid:$fluidsynth_start_time" in
+*[!0-9:]* | :* | *:)
+	rm -f "$PID_FILE" "$REFCOUNT_FILE"
 	exit 0
 	;;
 esac
 
-if ! kill -0 "$fluidsynth_pid" 2>/dev/null; then
-	rm -f "$PID_FILE"
+if ! process_matches_start_time "$fluidsynth_pid" "$fluidsynth_start_time"; then
+	rm -f "$PID_FILE" "$REFCOUNT_FILE"
 	exit 0
 fi
 
 process_name=$(ps -p "$fluidsynth_pid" -o comm= 2>/dev/null | tr -d '[:space:]' || true)
-if [ -z "$process_name" ] && ! kill -0 "$fluidsynth_pid" 2>/dev/null; then
-	rm -f "$PID_FILE"
-	exit 0
-fi
 if [ "$process_name" != "fluidsynth" ]; then
 	printf "%s\n" "eq-legends-midi: refusing to stop unrelated process $fluidsynth_pid" >&2
-	rm -f "$PID_FILE"
+	rm -f "$PID_FILE" "$REFCOUNT_FILE"
 	exit 1
 fi
 
-kill "$fluidsynth_pid"
+launch_count=1
+if [ -f "$REFCOUNT_FILE" ]; then
+	launch_count=$(sed -n '1p' "$REFCOUNT_FILE")
+	case "$launch_count" in
+	'' | *[!0-9]*) fail "invalid launch count in $REFCOUNT_FILE" ;;
+	esac
+	[ "$launch_count" -gt 0 ] || fail "invalid launch count in $REFCOUNT_FILE"
+fi
+
+if [ "$launch_count" -gt 1 ]; then
+	printf "%s\n" $((launch_count - 1)) >"$REFCOUNT_FILE"
+	exit 0
+fi
+rm -f "$REFCOUNT_FILE"
+
+if owned_process_is_running "$fluidsynth_pid" "$fluidsynth_start_time"; then
+	kill "$fluidsynth_pid" 2>/dev/null || true
+fi
 attempt=0
-while kill -0 "$fluidsynth_pid" 2>/dev/null && [ "$attempt" -lt 5 ]; do
+while owned_process_is_running "$fluidsynth_pid" "$fluidsynth_start_time" && [ "$attempt" -lt 5 ]; do
 	attempt=$((attempt + 1))
 	sleep 1
 done
 
-if kill -0 "$fluidsynth_pid" 2>/dev/null; then
+if owned_process_is_running "$fluidsynth_pid" "$fluidsynth_start_time"; then
 	kill -KILL "$fluidsynth_pid" 2>/dev/null || true
 fi
 

--- a/core/tabs/gaming/eq-legends-midi.sh
+++ b/core/tabs/gaming/eq-legends-midi.sh
@@ -225,7 +225,7 @@ find_game_config() {
 		;;
 	*)
 		printf "%b\n" "${YELLOW}Multiple EverQuest Legends configurations were found:${RC}"
-		nl -ba "$CANDIDATES_FILE"
+		nl -b a "$CANDIDATES_FILE"
 		printf "%s" "Select the configuration to update [1-$candidate_count]: "
 		read -r selection
 		case "$selection" in

--- a/core/tabs/gaming/eq-legends-midi.sh
+++ b/core/tabs/gaming/eq-legends-midi.sh
@@ -184,6 +184,10 @@ if updated_text == registry_text:
     raise SystemExit(0)
 
 try:
+    if backup_path.is_symlink():
+        raise OSError(f"Refusing symbolic-link backup path: {backup_path}")
+    if backup_path.exists() and not backup_path.is_file():
+        raise OSError(f"Backup path is not a file: {backup_path}")
     if not backup_path.exists():
         shutil.copy2(registry_path, backup_path)
     descriptor, temp_name = tempfile.mkstemp(
@@ -259,6 +263,10 @@ import yaml
 action, config_name, start_hook, stop_hook = sys.argv[1:]
 config_path = Path(config_name)
 
+if config_path.is_symlink():
+    print(f"Refusing symbolic-link Lutris configuration: {config_path}", file=sys.stderr)
+    raise SystemExit(1)
+
 try:
     with config_path.open("r", encoding="utf-8") as config_file:
         config = yaml.safe_load(config_file) or {}
@@ -290,19 +298,9 @@ for key, desired_value in desired_hooks.items():
         )
         raise SystemExit(1)
 
-if action == "check":
-    raise SystemExit(0)
-if action != "apply":
+if action not in ("check", "prepare", "apply"):
     print(f"Unknown configuration action: {action}", file=sys.stderr)
     raise SystemExit(1)
-
-backup_path = config_path.with_name(config_path.name + ".linutil-eq-midi.bak")
-if not backup_path.exists():
-    try:
-        shutil.copy2(config_path, backup_path)
-    except OSError as error:
-        print(f"Unable to back up {config_path}: {error}", file=sys.stderr)
-        raise SystemExit(1)
 
 system.update(desired_hooks)
 system["prelaunch_wait"] = True
@@ -310,6 +308,15 @@ config["system"] = system
 
 temp_name = None
 try:
+    if action in ("prepare", "apply"):
+        backup_path = config_path.with_name(config_path.name + ".linutil-eq-midi.bak")
+        if backup_path.is_symlink():
+            raise OSError(f"Refusing symbolic-link backup path: {backup_path}")
+        if backup_path.exists() and not backup_path.is_file():
+            raise OSError(f"Backup path is not a file: {backup_path}")
+        if not backup_path.exists():
+            shutil.copy2(config_path, backup_path)
+
     descriptor, temp_name = tempfile.mkstemp(
         prefix=config_path.name + ".", suffix=".tmp", dir=config_path.parent
     )
@@ -321,7 +328,16 @@ try:
             default_flow_style=False,
             sort_keys=False,
         )
+        temp_file.flush()
+        os.fsync(temp_file.fileno())
     os.chmod(temp_name, stat.S_IMODE(config_path.stat().st_mode))
+    if action in ("check", "prepare"):
+        os.unlink(temp_name)
+        temp_name = None
+        raise SystemExit(0)
+
+    if config_path.is_symlink():
+        raise OSError(f"Refusing symbolic-link Lutris configuration: {config_path}")
     os.replace(temp_name, config_path)
 except (OSError, yaml.YAMLError) as error:
     if temp_name:
@@ -449,6 +465,7 @@ main() {
 	install_soundfont
 	install_hooks
 	check_wine_prefix_idle
+	edit_lutris_config prepare
 	configure_midi_mapper
 	edit_lutris_config apply
 

--- a/core/tabs/gaming/eq-legends-midi.sh
+++ b/core/tabs/gaming/eq-legends-midi.sh
@@ -1,0 +1,434 @@
+#!/bin/sh -e
+
+SCRIPT_DIR=$(dirname -- "$0")
+SCRIPT_DIR=$(cd -- "$SCRIPT_DIR" && pwd)
+# shellcheck source=core/tabs/common-script.sh
+. "$SCRIPT_DIR/../common-script.sh"
+
+# Setup and SoundFont source: https://eqlwiki.com/Linux_Setup_Guide
+SOUNDFONT_NAME="SC-55 Roland SOUNDCanvas Up.sf2"
+SOUNDFONT_URL="https://archive.org/download/500-soundfonts-full-gm-sets/500_Soundfonts_Full_GM_Sets.zip/SC-55%20Roland%20SOUNDCanvas%20Up.sf2"
+SOUNDFONT_SHA256="ce26d477924b95da58b1b00bfd11c6f8580bf7ecf0b2c64db10dbfe4a9927714"
+
+DATA_HOME=${XDG_DATA_HOME:-"$HOME/.local/share"}
+CONFIG_HOME=${XDG_CONFIG_HOME:-"$HOME/.config"}
+HOOK_DIR="$DATA_HOME/lutris/scripts"
+SOUNDFONT_DIR="$DATA_HOME/sounds/sf2"
+SOUNDFONT_PATH="$SOUNDFONT_DIR/$SOUNDFONT_NAME"
+LUTRIS_GAMES_DIR="$CONFIG_HOME/lutris/games"
+START_HOOK="$HOOK_DIR/eq-midi-start.sh"
+STOP_HOOK="$HOOK_DIR/eq-midi-stop.sh"
+MIDI_CLIENT_NAME="EQ-Legends"
+MIDI_DEVICE_NAME="$MIDI_CLIENT_NAME - $MIDI_CLIENT_NAME"
+
+CANDIDATES_FILE=""
+DOWNLOAD_TMP=""
+HOOK_TMP=""
+CONFIG_PATH=""
+PREFIX_PATH=""
+
+cleanup() {
+	[ -z "$CANDIDATES_FILE" ] || rm -f "$CANDIDATES_FILE"
+	[ -z "$DOWNLOAD_TMP" ] || rm -f "$DOWNLOAD_TMP"
+	[ -z "$HOOK_TMP" ] || rm -f "$HOOK_TMP"
+}
+
+trap cleanup 0
+trap 'cleanup; exit 1' HUP INT TERM
+
+fail() {
+	printf "%b\n" "${RED}$*${RC}" >&2
+	exit 1
+}
+
+check_requirements() {
+	command_exists lutris || fail "Native Lutris is required. Flatpak Lutris is not supported by this fix."
+	command_exists python3 || fail "Python 3 is required by the native Lutris installation."
+	command_exists pgrep || fail "pgrep is required to ensure the Wine prefix is not in use."
+	command_exists sha256sum || fail "sha256sum is required to verify the downloaded SoundFont."
+
+	if ! python3 -c 'import yaml' >/dev/null 2>&1; then
+		fail "The Python YAML module used by Lutris is missing. Reinstall native Lutris, then retry."
+	fi
+
+	if command_exists pgrep && pgrep -u "$(id -u)" -f '(^|/)lutris([[:space:]]|$)' >/dev/null 2>&1; then
+		fail "Close Lutris before applying the EverQuest Legends MIDI fix."
+	fi
+
+	[ -d "$LUTRIS_GAMES_DIR" ] || fail "No native Lutris game configuration directory was found at $LUTRIS_GAMES_DIR."
+}
+
+find_wine_prefix() {
+	PREFIX_PATH=$(
+		python3 - "$CONFIG_PATH" <<'PYTHON'
+import os
+import sys
+from pathlib import Path
+
+import yaml
+
+config_path = Path(sys.argv[1])
+try:
+    with config_path.open("r", encoding="utf-8") as config_file:
+        config = yaml.safe_load(config_file) or {}
+except (OSError, yaml.YAMLError) as error:
+    print(f"Unable to read Lutris configuration {config_path}: {error}", file=sys.stderr)
+    raise SystemExit(1)
+
+game = config.get("game")
+prefix = game.get("prefix") if isinstance(game, dict) else None
+if not isinstance(prefix, str) or not prefix:
+    print(f"No Wine prefix is defined in {config_path}.", file=sys.stderr)
+    raise SystemExit(1)
+
+prefix_path = Path(os.path.expandvars(os.path.expanduser(prefix)))
+if not prefix_path.is_absolute():
+    print(f"The Wine prefix path is not absolute: {prefix_path}", file=sys.stderr)
+    raise SystemExit(1)
+if not prefix_path.is_dir():
+    print(f"The Wine prefix does not exist: {prefix_path}", file=sys.stderr)
+    raise SystemExit(1)
+
+print(prefix_path)
+PYTHON
+	) || fail "Unable to locate the EverQuest Legends Wine prefix."
+
+	printf "%b\n" "${CYAN}Using Wine prefix: $PREFIX_PATH${RC}"
+}
+
+check_wine_prefix_idle() {
+	if pgrep -u "$(id -u)" -f '(^|/)(wineserver|winedevice|eqgame)([.]exe)?([[:space:]]|$)' >/dev/null 2>&1; then
+		fail "Close all Wine applications before updating the EverQuest Legends MIDI mapper."
+	fi
+}
+
+configure_midi_mapper() {
+	python3 - "$PREFIX_PATH" "$MIDI_DEVICE_NAME" <<'PYTHON'
+import os
+import re
+import shutil
+import stat
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+prefix_path = Path(sys.argv[1])
+device_name = sys.argv[2]
+registry_path = prefix_path / "user.reg"
+backup_path = registry_path.with_name(registry_path.name + ".linutil-eq-midi.bak")
+target_key = r"Software\\Microsoft\\Windows\\CurrentVersion\\Multimedia\\MIDIMap"
+
+if registry_path.is_symlink():
+    print(f"Refusing symbolic-link Wine registry: {registry_path}", file=sys.stderr)
+    raise SystemExit(1)
+if not registry_path.is_file():
+    print(f"Wine user registry not found: {registry_path}", file=sys.stderr)
+    raise SystemExit(1)
+
+try:
+    registry_text = registry_path.read_text(encoding="utf-8")
+except OSError as error:
+    print(f"Unable to read {registry_path}: {error}", file=sys.stderr)
+    raise SystemExit(1)
+
+header_pattern = re.compile(r"^\[([^]]+)](?: [0-9]+)?$", re.MULTILINE)
+headers = list(header_pattern.finditer(registry_text))
+target_match = next((match for match in headers if match.group(1) == target_key), None)
+
+desired_values = {
+    "CurrentInstrument": f'"{device_name}"',
+    "UseScheme": "dword:00000000",
+    "szPname": f'"{device_name}"',
+}
+
+if target_match:
+    section_start = target_match.start()
+    next_header = next((match for match in headers if match.start() > section_start), None)
+    section_end = next_header.start() if next_header else len(registry_text)
+    section = registry_text[section_start:section_end]
+    section_body = section.rstrip("\n")
+    for value_name, encoded_value in desired_values.items():
+        value_pattern = re.compile(rf'^"{re.escape(value_name)}"=.*$', re.MULTILINE)
+        value_line = f'"{value_name}"={encoded_value}'
+        if value_pattern.search(section_body):
+            section_body = value_pattern.sub(value_line, section_body, count=1)
+        else:
+            section_body += "\n" + value_line
+    updated_text = registry_text[:section_start] + section_body + "\n\n" + registry_text[section_end:].lstrip("\n")
+else:
+    now = time.time()
+    unix_time = int(now)
+    windows_filetime = int((now + 11644473600) * 10000000)
+    value_lines = "\n".join(
+        f'"{value_name}"={encoded_value}'
+        for value_name, encoded_value in desired_values.items()
+    )
+    new_section = (
+        f"[{target_key}] {unix_time}\n"
+        f"#time={windows_filetime:x}\n"
+        f"{value_lines}\n\n"
+    )
+    insertion_match = next((match for match in headers if match.group(1) > target_key), None)
+    insertion_point = insertion_match.start() if insertion_match else len(registry_text)
+    prefix = registry_text[:insertion_point].rstrip("\n") + "\n\n"
+    suffix = registry_text[insertion_point:].lstrip("\n")
+    updated_text = prefix + new_section + suffix
+
+if updated_text == registry_text:
+    print(f"Wine MIDI mapper already targets {device_name}.")
+    raise SystemExit(0)
+
+try:
+    if not backup_path.exists():
+        shutil.copy2(registry_path, backup_path)
+    descriptor, temp_name = tempfile.mkstemp(
+        prefix=registry_path.name + ".", suffix=".tmp", dir=registry_path.parent
+    )
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as temp_file:
+            temp_file.write(updated_text)
+        os.chmod(temp_name, stat.S_IMODE(registry_path.stat().st_mode))
+        os.replace(temp_name, registry_path)
+    except BaseException:
+        try:
+            os.unlink(temp_name)
+        except FileNotFoundError:
+            pass
+        raise
+except OSError as error:
+    print(f"Unable to update {registry_path}: {error}", file=sys.stderr)
+    raise SystemExit(1)
+
+print(f"Wine MIDI mapper set to {device_name}.")
+print(f"Original Wine user registry: {backup_path}")
+PYTHON
+}
+
+find_game_config() {
+	CANDIDATES_FILE=$(mktemp)
+
+	for config_file in "$LUTRIS_GAMES_DIR"/*.yml "$LUTRIS_GAMES_DIR"/*.yaml; do
+		[ -f "$config_file" ] || continue
+		if grep -qi "EverQuest Legends" "$config_file" && grep -q "LaunchPad.exe" "$config_file"; then
+			printf "%s\n" "$config_file" >>"$CANDIDATES_FILE"
+		fi
+	done
+
+	candidate_count=$(wc -l <"$CANDIDATES_FILE" | tr -d '[:space:]')
+	case "$candidate_count" in
+	0)
+		fail "No EverQuest Legends configuration was found in native Lutris. Install the game first, then retry."
+		;;
+	1)
+		CONFIG_PATH=$(sed -n '1p' "$CANDIDATES_FILE")
+		;;
+	*)
+		printf "%b\n" "${YELLOW}Multiple EverQuest Legends configurations were found:${RC}"
+		nl -ba "$CANDIDATES_FILE"
+		printf "%s" "Select the configuration to update [1-$candidate_count]: "
+		read -r selection
+		case "$selection" in
+		'' | *[!0-9]*) fail "Invalid configuration selection." ;;
+		esac
+		[ "$selection" -ge 1 ] && [ "$selection" -le "$candidate_count" ] || fail "Invalid configuration selection."
+		CONFIG_PATH=$(sed -n "${selection}p" "$CANDIDATES_FILE")
+		;;
+	esac
+
+	printf "%b\n" "${CYAN}Using Lutris configuration: $CONFIG_PATH${RC}"
+}
+
+edit_lutris_config() {
+	action="$1"
+
+	python3 - "$action" "$CONFIG_PATH" "$START_HOOK" "$STOP_HOOK" <<'PYTHON'
+import os
+import shutil
+import stat
+import sys
+import tempfile
+from pathlib import Path
+
+import yaml
+
+action, config_name, start_hook, stop_hook = sys.argv[1:]
+config_path = Path(config_name)
+
+try:
+    with config_path.open("r", encoding="utf-8") as config_file:
+        config = yaml.safe_load(config_file) or {}
+except (OSError, yaml.YAMLError) as error:
+    print(f"Unable to read Lutris configuration {config_path}: {error}", file=sys.stderr)
+    raise SystemExit(1)
+
+if not isinstance(config, dict):
+    print(f"Lutris configuration {config_path} is not a YAML mapping.", file=sys.stderr)
+    raise SystemExit(1)
+
+system = config.get("system")
+if system is None:
+    system = {}
+elif not isinstance(system, dict):
+    print(f"The top-level system section in {config_path} is not a YAML mapping.", file=sys.stderr)
+    raise SystemExit(1)
+
+desired_hooks = {
+    "prelaunch_command": start_hook,
+    "postexit_command": stop_hook,
+}
+for key, desired_value in desired_hooks.items():
+    current_value = system.get(key)
+    if current_value not in (None, "", desired_value):
+        print(
+            f"Refusing to replace existing Lutris setting {key}: {current_value}",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+
+if action == "check":
+    raise SystemExit(0)
+if action != "apply":
+    print(f"Unknown configuration action: {action}", file=sys.stderr)
+    raise SystemExit(1)
+
+backup_path = config_path.with_name(config_path.name + ".linutil-eq-midi.bak")
+if not backup_path.exists():
+    try:
+        shutil.copy2(config_path, backup_path)
+    except OSError as error:
+        print(f"Unable to back up {config_path}: {error}", file=sys.stderr)
+        raise SystemExit(1)
+
+system.update(desired_hooks)
+system["prelaunch_wait"] = True
+config["system"] = system
+
+temp_name = None
+try:
+    descriptor, temp_name = tempfile.mkstemp(
+        prefix=config_path.name + ".", suffix=".tmp", dir=config_path.parent
+    )
+    with os.fdopen(descriptor, "w", encoding="utf-8") as temp_file:
+        yaml.safe_dump(
+            config,
+            temp_file,
+            allow_unicode=True,
+            default_flow_style=False,
+            sort_keys=False,
+        )
+    os.chmod(temp_name, stat.S_IMODE(config_path.stat().st_mode))
+    os.replace(temp_name, config_path)
+except (OSError, yaml.YAMLError) as error:
+    if temp_name:
+        try:
+            os.unlink(temp_name)
+        except FileNotFoundError:
+            pass
+    print(f"Unable to update {config_path}: {error}", file=sys.stderr)
+    raise SystemExit(1)
+PYTHON
+}
+
+install_dependencies() {
+	if command_exists fluidsynth aconnect; then
+		printf "%b\n" "${GREEN}FluidSynth and ALSA MIDI tools are already installed.${RC}"
+		return 0
+	fi
+
+	printf "%b\n" "${YELLOW}Installing FluidSynth and ALSA MIDI tools...${RC}"
+	case "$PACKAGER" in
+	pacman)
+		"$ESCALATION_TOOL" "$PACKAGER" -S --needed --noconfirm fluidsynth alsa-utils
+		;;
+	apt-get | nala)
+		"$ESCALATION_TOOL" "$PACKAGER" install -y fluidsynth alsa-utils
+		;;
+	dnf)
+		"$ESCALATION_TOOL" "$PACKAGER" install -y fluidsynth alsa-utils
+		;;
+	zypper)
+		"$ESCALATION_TOOL" "$PACKAGER" -n install fluidsynth alsa-utils
+		;;
+	apk)
+		"$ESCALATION_TOOL" "$PACKAGER" add fluidsynth alsa-utils
+		;;
+	xbps-install)
+		"$ESCALATION_TOOL" "$PACKAGER" -Sy fluidsynth alsa-utils
+		;;
+	eopkg)
+		"$ESCALATION_TOOL" "$PACKAGER" install -y fluidsynth alsa-utils
+		;;
+	*)
+		fail "Unsupported package manager: $PACKAGER"
+		;;
+	esac
+
+	command_exists fluidsynth aconnect || fail "FluidSynth or aconnect is still unavailable after package installation."
+}
+
+verify_soundfont() {
+	soundfont_file="$1"
+	actual_checksum=$(sha256sum "$soundfont_file" | awk '{print $1}')
+	[ "$actual_checksum" = "$SOUNDFONT_SHA256" ]
+}
+
+install_soundfont() {
+	if [ -f "$SOUNDFONT_PATH" ]; then
+		if verify_soundfont "$SOUNDFONT_PATH"; then
+			printf "%b\n" "${GREEN}The verified SC-55 SoundFont is already installed.${RC}"
+			return 0
+		fi
+		fail "The existing SoundFont failed checksum verification: $SOUNDFONT_PATH"
+	fi
+
+	mkdir -p "$SOUNDFONT_DIR"
+	DOWNLOAD_TMP=$(mktemp "$SOUNDFONT_DIR/.eq-legends-midi.XXXXXX")
+
+	printf "%b\n" "${YELLOW}Downloading the 177 MiB SC-55 SoundFont...${RC}"
+	curl --fail --location --retry 3 --continue-at - --output "$DOWNLOAD_TMP" "$SOUNDFONT_URL"
+
+	verify_soundfont "$DOWNLOAD_TMP" || fail "The downloaded SC-55 SoundFont failed checksum verification."
+	chmod 0644 "$DOWNLOAD_TMP"
+	mv "$DOWNLOAD_TMP" "$SOUNDFONT_PATH"
+	DOWNLOAD_TMP=""
+	printf "%b\n" "${GREEN}SC-55 SoundFont installed and verified.${RC}"
+}
+
+copy_hook() {
+	source_hook="$1"
+	target_hook="$2"
+
+	HOOK_TMP=$(mktemp "$HOOK_DIR/.eq-legends-midi-hook.XXXXXX")
+	cp "$source_hook" "$HOOK_TMP"
+	chmod 0755 "$HOOK_TMP"
+	mv "$HOOK_TMP" "$target_hook"
+	HOOK_TMP=""
+}
+
+install_hooks() {
+	mkdir -p "$HOOK_DIR"
+	copy_hook "$SCRIPT_DIR/eq-legends-midi-start.sh" "$START_HOOK"
+	copy_hook "$SCRIPT_DIR/eq-legends-midi-stop.sh" "$STOP_HOOK"
+}
+
+main() {
+	checkEnv
+	check_requirements
+	find_game_config
+	find_wine_prefix
+	check_wine_prefix_idle
+	edit_lutris_config check
+	install_dependencies
+	install_soundfont
+	install_hooks
+	configure_midi_mapper
+	edit_lutris_config apply
+
+	printf "%b\n" "${GREEN}EverQuest Legends MIDI support is configured.${RC}"
+	printf "%b\n" "${CYAN}FluidSynth will start as $MIDI_CLIENT_NAME before the game and stop after it exits.${RC}"
+	printf "%b\n" "${CYAN}Wine MIDI output is mapped to $MIDI_DEVICE_NAME.${RC}"
+	printf "%b\n" "${CYAN}Original Lutris configuration: ${CONFIG_PATH}.linutil-eq-midi.bak${RC}"
+}
+
+main "$@"

--- a/core/tabs/gaming/eq-legends-midi.sh
+++ b/core/tabs/gaming/eq-legends-midi.sh
@@ -41,6 +41,12 @@ fail() {
 	exit 1
 }
 
+check_lutris_idle() {
+	if pgrep -u "$(id -u)" -f '(^|/)lutris([[:space:]]|$)' >/dev/null 2>&1; then
+		fail "Close Lutris before applying the EverQuest Legends MIDI fix."
+	fi
+}
+
 check_requirements() {
 	command_exists lutris || fail "Native Lutris is required. Flatpak Lutris is not supported by this fix."
 	command_exists python3 || fail "Python 3 is required by the native Lutris installation."
@@ -55,9 +61,7 @@ check_requirements() {
 		fail "The Python YAML module used by Lutris is missing. Reinstall native Lutris, then retry."
 	fi
 
-	if pgrep -u "$(id -u)" -f '(^|/)lutris([[:space:]]|$)' >/dev/null 2>&1; then
-		fail "Close Lutris before applying the EverQuest Legends MIDI fix."
-	fi
+	check_lutris_idle
 
 	[ -d "$LUTRIS_GAMES_DIR" ] || fail "No native Lutris game configuration directory was found at $LUTRIS_GAMES_DIR."
 }
@@ -416,7 +420,7 @@ install_soundfont() {
 	printf "%b\n" "${GREEN}SC-55 SoundFont installed and verified.${RC}"
 }
 
-copy_hook() {
+prepare_hook_target() {
 	source_hook="$1"
 	target_hook="$2"
 	target_backup="$target_hook.linutil-eq-midi.bak"
@@ -429,7 +433,6 @@ copy_hook() {
 		target_checksum=$(sha256sum "$target_hook")
 		target_checksum=${target_checksum%% *}
 		if [ "$source_checksum" = "$target_checksum" ]; then
-			chmod 0755 "$target_hook"
 			return 0
 		fi
 
@@ -439,6 +442,22 @@ copy_hook() {
 			printf "%b\n" "${CYAN}Original hook backup: $target_backup${RC}"
 		elif [ ! -f "$target_backup" ]; then
 			fail "Refusing non-file hook backup path: $target_backup"
+		fi
+	fi
+}
+
+copy_hook() {
+	source_hook="$1"
+	target_hook="$2"
+
+	if [ -f "$target_hook" ]; then
+		source_checksum=$(sha256sum "$source_hook")
+		source_checksum=${source_checksum%% *}
+		target_checksum=$(sha256sum "$target_hook")
+		target_checksum=${target_checksum%% *}
+		if [ "$source_checksum" = "$target_checksum" ]; then
+			chmod 0755 "$target_hook"
+			return 0
 		fi
 	fi
 
@@ -451,6 +470,8 @@ copy_hook() {
 
 install_hooks() {
 	mkdir -p "$HOOK_DIR"
+	prepare_hook_target "$SCRIPT_DIR/eq-legends-midi-start.sh" "$START_HOOK"
+	prepare_hook_target "$SCRIPT_DIR/eq-legends-midi-stop.sh" "$STOP_HOOK"
 	copy_hook "$SCRIPT_DIR/eq-legends-midi-start.sh" "$START_HOOK"
 	copy_hook "$SCRIPT_DIR/eq-legends-midi-stop.sh" "$STOP_HOOK"
 }
@@ -465,7 +486,10 @@ main() {
 	install_soundfont
 	install_hooks
 	check_wine_prefix_idle
+	check_lutris_idle
 	edit_lutris_config prepare
+	check_lutris_idle
+	check_wine_prefix_idle
 	configure_midi_mapper
 	edit_lutris_config apply
 

--- a/core/tabs/gaming/eq-legends-midi.sh
+++ b/core/tabs/gaming/eq-legends-midi.sh
@@ -48,6 +48,7 @@ check_lutris_idle() {
 }
 
 check_requirements() {
+	command_exists apk && fail "Alpine Linux and other apk-based distributions are not supported by this fix."
 	command_exists lutris || fail "Native Lutris is required. Flatpak Lutris is not supported by this fix."
 	command_exists python3 || fail "Python 3 is required by the native Lutris installation."
 	command_exists pgrep || fail "pgrep is required to ensure the Wine prefix is not in use."
@@ -376,7 +377,7 @@ install_dependencies() {
 		"$ESCALATION_TOOL" "$PACKAGER" -n install fluidsynth alsa-utils
 		;;
 	apk)
-		"$ESCALATION_TOOL" "$PACKAGER" add fluidsynth alsa-utils
+		fail "Alpine Linux and other apk-based distributions are not supported by this fix."
 		;;
 	xbps-install)
 		"$ESCALATION_TOOL" "$PACKAGER" -Sy fluidsynth alsa-utils
@@ -489,6 +490,7 @@ main() {
 	check_lutris_idle
 	edit_lutris_config prepare
 	check_lutris_idle
+	find_wine_prefix
 	check_wine_prefix_idle
 	configure_midi_mapper
 	edit_lutris_config apply

--- a/core/tabs/gaming/eq-legends-midi.sh
+++ b/core/tabs/gaming/eq-legends-midi.sh
@@ -15,7 +15,8 @@ CONFIG_HOME=${XDG_CONFIG_HOME:-"$HOME/.config"}
 HOOK_DIR="$DATA_HOME/lutris/scripts"
 SOUNDFONT_DIR="$DATA_HOME/sounds/sf2"
 SOUNDFONT_PATH="$SOUNDFONT_DIR/$SOUNDFONT_NAME"
-LUTRIS_GAMES_DIR="$CONFIG_HOME/lutris/games"
+LUTRIS_DATA_GAMES_DIR="$DATA_HOME/lutris/games"
+LUTRIS_CONFIG_GAMES_DIR="$CONFIG_HOME/lutris/games"
 START_HOOK="$HOOK_DIR/eq-midi-start.sh"
 STOP_HOOK="$HOOK_DIR/eq-midi-stop.sh"
 MIDI_CLIENT_NAME="EQ-Legends"
@@ -26,6 +27,7 @@ DOWNLOAD_TMP=""
 HOOK_TMP=""
 CONFIG_PATH=""
 PREFIX_PATH=""
+PYTHON_BIN=""
 
 cleanup() {
 	[ -z "$CANDIDATES_FILE" ] || rm -f "$CANDIDATES_FILE"
@@ -47,10 +49,30 @@ check_lutris_idle() {
 	fi
 }
 
+select_python() {
+	lutris_path=$(command -v lutris)
+	lutris_python=$(sed -n '1s/^#!//p' "$lutris_path")
+	path_python=$(command -v python3 2>/dev/null || true)
+
+	for python_candidate in "$lutris_python" "$path_python" /usr/bin/python3; do
+		[ -n "$python_candidate" ] || continue
+		case "$python_candidate" in
+		*[[:space:]]*) continue ;;
+		esac
+		[ -x "$python_candidate" ] || continue
+		if "$python_candidate" -c 'import yaml' >/dev/null 2>&1; then
+			PYTHON_BIN="$python_candidate"
+			return 0
+		fi
+	done
+
+	fail "The Python YAML module used by Lutris is missing. Install your distribution's PyYAML package or reinstall native Lutris, then retry."
+}
+
 check_requirements() {
 	command_exists apk && fail "Alpine Linux and other apk-based distributions are not supported by this fix."
 	command_exists lutris || fail "Native Lutris is required. Flatpak Lutris is not supported by this fix."
-	command_exists python3 || fail "Python 3 is required by the native Lutris installation."
+	select_python
 	command_exists pgrep || fail "pgrep is required to ensure the Wine prefix is not in use."
 	command_exists sha256sum || fail "sha256sum is required to verify the downloaded SoundFont."
 	command_exists flock || fail "flock is required by the FluidSynth lifecycle hooks."
@@ -58,18 +80,16 @@ check_requirements() {
 	command_exists stat || fail "stat is required by the FluidSynth lifecycle hooks."
 	command_exists curl || fail "curl is required to download the SoundFont."
 
-	if ! python3 -c 'import yaml' >/dev/null 2>&1; then
-		fail "The Python YAML module used by Lutris is missing. Reinstall native Lutris, then retry."
-	fi
-
 	check_lutris_idle
 
-	[ -d "$LUTRIS_GAMES_DIR" ] || fail "No native Lutris game configuration directory was found at $LUTRIS_GAMES_DIR."
+	if [ ! -d "$LUTRIS_DATA_GAMES_DIR" ] && [ ! -d "$LUTRIS_CONFIG_GAMES_DIR" ]; then
+		fail "No native Lutris game configuration directory was found at $LUTRIS_DATA_GAMES_DIR or $LUTRIS_CONFIG_GAMES_DIR."
+	fi
 }
 
 find_wine_prefix() {
 	PREFIX_PATH=$(
-		python3 - "$CONFIG_PATH" <<'PYTHON'
+		"$PYTHON_BIN" - "$CONFIG_PATH" <<'PYTHON'
 import os
 import sys
 from pathlib import Path
@@ -112,7 +132,7 @@ check_wine_prefix_idle() {
 }
 
 configure_midi_mapper() {
-	python3 - "$PREFIX_PATH" "$MIDI_DEVICE_NAME" <<'PYTHON'
+	"$PYTHON_BIN" - "$PREFIX_PATH" "$MIDI_DEVICE_NAME" <<'PYTHON'
 import os
 import re
 import shutil
@@ -221,12 +241,10 @@ PYTHON
 find_game_config() {
 	CANDIDATES_FILE=$(mktemp)
 
-	for config_file in "$LUTRIS_GAMES_DIR"/*.yml "$LUTRIS_GAMES_DIR"/*.yaml; do
-		[ -f "$config_file" ] || continue
-		if grep -qi "EverQuest Legends" "$config_file" && grep -q "LaunchPad.exe" "$config_file"; then
-			printf "%s\n" "$config_file" >>"$CANDIDATES_FILE"
-		fi
-	done
+	find_game_candidates "$LUTRIS_DATA_GAMES_DIR"
+	if [ "$LUTRIS_CONFIG_GAMES_DIR" != "$LUTRIS_DATA_GAMES_DIR" ]; then
+		find_game_candidates "$LUTRIS_CONFIG_GAMES_DIR"
+	fi
 
 	candidate_count=$(wc -l <"$CANDIDATES_FILE" | tr -d '[:space:]')
 	case "$candidate_count" in
@@ -252,10 +270,22 @@ find_game_config() {
 	printf "%b\n" "${CYAN}Using Lutris configuration: $CONFIG_PATH${RC}"
 }
 
+find_game_candidates() {
+	games_dir="$1"
+	[ -d "$games_dir" ] || return 0
+
+	for config_file in "$games_dir"/*.yml "$games_dir"/*.yaml; do
+		[ -f "$config_file" ] || continue
+		if grep -qi "EverQuest Legends" "$config_file" && grep -q "LaunchPad.exe" "$config_file"; then
+			printf "%s\n" "$config_file" >>"$CANDIDATES_FILE"
+		fi
+	done
+}
+
 edit_lutris_config() {
 	action="$1"
 
-	python3 - "$action" "$CONFIG_PATH" "$START_HOOK" "$STOP_HOOK" <<'PYTHON'
+	"$PYTHON_BIN" - "$action" "$CONFIG_PATH" "$START_HOOK" "$STOP_HOOK" <<'PYTHON'
 import os
 import shutil
 import stat

--- a/core/tabs/gaming/eq-legends-midi.sh
+++ b/core/tabs/gaming/eq-legends-midi.sh
@@ -46,12 +46,16 @@ check_requirements() {
 	command_exists python3 || fail "Python 3 is required by the native Lutris installation."
 	command_exists pgrep || fail "pgrep is required to ensure the Wine prefix is not in use."
 	command_exists sha256sum || fail "sha256sum is required to verify the downloaded SoundFont."
+	command_exists flock || fail "flock is required by the FluidSynth lifecycle hooks."
+	command_exists ps || fail "ps is required by the FluidSynth lifecycle hooks."
+	command_exists stat || fail "stat is required by the FluidSynth lifecycle hooks."
+	command_exists curl || fail "curl is required to download the SoundFont."
 
 	if ! python3 -c 'import yaml' >/dev/null 2>&1; then
 		fail "The Python YAML module used by Lutris is missing. Reinstall native Lutris, then retry."
 	fi
 
-	if command_exists pgrep && pgrep -u "$(id -u)" -f '(^|/)lutris([[:space:]]|$)' >/dev/null 2>&1; then
+	if pgrep -u "$(id -u)" -f '(^|/)lutris([[:space:]]|$)' >/dev/null 2>&1; then
 		fail "Close Lutris before applying the EverQuest Legends MIDI fix."
 	fi
 
@@ -97,7 +101,7 @@ PYTHON
 }
 
 check_wine_prefix_idle() {
-	if pgrep -u "$(id -u)" -f '(^|/)(wineserver|winedevice|eqgame)([.]exe)?([[:space:]]|$)' >/dev/null 2>&1; then
+	if pgrep -u "$(id -u)" -f '(^|[\\/])(wineserver(64)?|winedevice([.]exe)?|eqgame([.]exe)?)([[:space:]]|$)' >/dev/null 2>&1; then
 		fail "Close all Wine applications before updating the EverQuest Legends MIDI mapper."
 	fi
 }
@@ -336,6 +340,7 @@ install_dependencies() {
 		return 0
 	fi
 
+	checkEnv
 	printf "%b\n" "${YELLOW}Installing FluidSynth and ALSA MIDI tools...${RC}"
 	case "$PACKAGER" in
 	pacman)
@@ -386,7 +391,7 @@ install_soundfont() {
 	DOWNLOAD_TMP=$(mktemp "$SOUNDFONT_DIR/.eq-legends-midi.XXXXXX")
 
 	printf "%b\n" "${YELLOW}Downloading the 177 MiB SC-55 SoundFont...${RC}"
-	curl --fail --location --retry 3 --continue-at - --output "$DOWNLOAD_TMP" "$SOUNDFONT_URL"
+	curl --fail --location --retry 3 --output "$DOWNLOAD_TMP" "$SOUNDFONT_URL"
 
 	verify_soundfont "$DOWNLOAD_TMP" || fail "The downloaded SC-55 SoundFont failed checksum verification."
 	chmod 0644 "$DOWNLOAD_TMP"
@@ -398,6 +403,28 @@ install_soundfont() {
 copy_hook() {
 	source_hook="$1"
 	target_hook="$2"
+	target_backup="$target_hook.linutil-eq-midi.bak"
+
+	[ ! -L "$target_hook" ] || fail "Refusing symbolic-link hook path: $target_hook"
+	if [ -e "$target_hook" ]; then
+		[ -f "$target_hook" ] || fail "Refusing non-file hook path: $target_hook"
+		source_checksum=$(sha256sum "$source_hook")
+		source_checksum=${source_checksum%% *}
+		target_checksum=$(sha256sum "$target_hook")
+		target_checksum=${target_checksum%% *}
+		if [ "$source_checksum" = "$target_checksum" ]; then
+			chmod 0755 "$target_hook"
+			return 0
+		fi
+
+		[ ! -L "$target_backup" ] || fail "Refusing symbolic-link hook backup path: $target_backup"
+		if [ ! -e "$target_backup" ]; then
+			cp -p "$target_hook" "$target_backup"
+			printf "%b\n" "${CYAN}Original hook backup: $target_backup${RC}"
+		elif [ ! -f "$target_backup" ]; then
+			fail "Refusing non-file hook backup path: $target_backup"
+		fi
+	fi
 
 	HOOK_TMP=$(mktemp "$HOOK_DIR/.eq-legends-midi-hook.XXXXXX")
 	cp "$source_hook" "$HOOK_TMP"
@@ -413,7 +440,6 @@ install_hooks() {
 }
 
 main() {
-	checkEnv
 	check_requirements
 	find_game_config
 	find_wine_prefix
@@ -422,6 +448,7 @@ main() {
 	install_dependencies
 	install_soundfont
 	install_hooks
+	check_wine_prefix_idle
 	configure_midi_mapper
 	edit_lutris_config apply
 

--- a/core/tabs/gaming/tab_data.toml
+++ b/core/tabs/gaming/tab_data.toml
@@ -244,7 +244,7 @@ multi_select = false
 [[data.preconditions]]
 matches = true
 data = "command_exists"
-values = ["lutris", "python3"]
+values = ["curl", "flock", "lutris", "pgrep", "ps", "python3", "sha256sum", "stat"]
 
 [[data]]
 name = "Fallout 76 INI and Mods"

--- a/core/tabs/gaming/tab_data.toml
+++ b/core/tabs/gaming/tab_data.toml
@@ -246,6 +246,11 @@ matches = true
 data = "command_exists"
 values = ["curl", "flock", "lutris", "pgrep", "ps", "python3", "sha256sum", "stat"]
 
+[[data.preconditions]]
+matches = false
+data = "command_exists"
+values = ["apk"]
+
 [[data]]
 name = "Fallout 76 INI and Mods"
 description = "Installs a custom Fallout76Custom.ini and mods from ChrisTitusTech/fallout76-configs via Steam. Improves performance and stability with quality of life tweaks."

--- a/core/tabs/gaming/tab_data.toml
+++ b/core/tabs/gaming/tab_data.toml
@@ -235,6 +235,18 @@ script = "diablo2-titus-mod.sh"
 task_list = "FM"
 
 [[data]]
+name = "EverQuest Legends MIDI Fix"
+description = "Configures native Lutris to start a stable FluidSynth MIDI device, maps Wine to it, and loads the SC-55 SoundCanvas bank for EverQuest Legends music. Downloads a verified 177 MiB SoundFont and preserves the original Lutris and Wine registry configuration."
+script = "eq-legends-midi.sh"
+task_list = "I MP FM"
+multi_select = false
+
+[[data.preconditions]]
+matches = true
+data = "command_exists"
+values = ["lutris", "python3"]
+
+[[data]]
 name = "Fallout 76 INI and Mods"
 description = "Installs a custom Fallout76Custom.ini and mods from ChrisTitusTech/fallout76-configs via Steam. Improves performance and stability with quality of life tweaks."
 script = "fallout76-titus-mod.sh"

--- a/docs/content/userguide/walkthrough.md
+++ b/docs/content/userguide/walkthrough.md
@@ -149,6 +149,7 @@ https://github.com/AdnanHodzic/auto-cpufreq
 - **Heroic**: Manage Heroic launcher installation with Install, Uninstall, or Abort actions.
 - **Arc Raiders Titus Mods**: Applies optimized game configuration files from ChrisTitusTech/arc-raiders. Sets Engine.ini to read-only to prevent the game from overwriting the settings, disables motion blur, and enables VRR optimizations.
 - **Diablo II Resurrected Loot Filter**: Installs a loot filter for Diablo II Resurrected from ChrisTitusTech/d2r-loot-filter. Highlights high runes and other valuable items. Works on Battle.net and single player. After install, add launch option: -mod lootfilter -txt
+- **EverQuest Legends MIDI Fix**: Configures native Lutris to start a stable FluidSynth MIDI device, maps Wine to it, and loads the SC-55 SoundCanvas bank for EverQuest Legends music. Downloads a verified 177 MiB SoundFont and preserves the original Lutris and Wine registry configuration.
 - **Fallout 76 INI and Mods**: Installs a custom Fallout76Custom.ini and mods from ChrisTitusTech/fallout76-configs via Steam. Improves performance and stability with quality of life tweaks.
 - **Starfield Titus INI and Mods**: Installs custom Starfield mods from ChrisTitusTech/starfield-config via steam.
 


### PR DESCRIPTION
## Summary

- add an interactive Gaming utility for native Lutris EverQuest Legends installations
- install and verify the SC-55 SoundCanvas SoundFont and manage FluidSynth lifecycle hooks
- give FluidSynth a stable ALSA MIDI name and map the selected Wine prefix to it
- preserve existing Lutris configuration and Wine user registry with backups

## Why

Wine selects MIDI device 0 when no mapper is configured. On systems with hardware MIDI ports, EverQuest can silently route music to an unused hardware synth instead of FluidSynth.

## Validation

- `sh -n` on all three shell scripts
- `shellcheck` on all three shell scripts
- `checkbashisms` on all three shell scripts
- `shfmt -d` on all three shell scripts
- `cargo fmt --all --check`
- `cargo test --no-fail-fast --package linutil_core` (6 passed)
- `cargo clippy -- -Dwarnings`
- `cargo xtask docgen`
- `git diff --check`
- isolated Wine registry first-run and idempotency test
- live Fedora 44 test with native Lutris 0.5.22 and GE-Proton 11-3: confirmed the old route to Emu10k1 Port 0, then verified the stable EQ-Legends FluidSynth client and Wine mapper registry values
- GitHub Actions on `8344696`: typo checks, ShellCheck, shell formatting, bashism checks, CodeQL, and Nix all passed

## Limitations

- CodeRabbit CLI was unavailable locally; the remote CodeRabbit review is used instead.
- Audible in-game confirmation after the final mapper change remains a manual follow-up; the registry values and ALSA routing were verified.