### PR TITLE
fix: keep EQ FluidSynth alive without a server

### DIFF
--- a/core/tabs/gaming/eq-legends-midi-start.sh
+++ b/core/tabs/gaming/eq-legends-midi-start.sh
@@ -13,6 +13,7 @@ fi
 STATE_DIR="$STATE_HOME/linutil"
 PID_FILE="$RUNTIME_DIR/fluidsynth.pid"
 LOCK_FILE="$RUNTIME_DIR/state.lock"
+SHELL_FIFO="$RUNTIME_DIR/fluidsynth.stdin"
 PENDING_DIR="$RUNTIME_DIR/pending"
 LOG_FILE="$STATE_DIR/eq-legends-midi.log"
 STOP_HOOK="$HOOK_DIR/eq-midi-stop.sh"
@@ -90,6 +91,20 @@ acquire_lock() {
 	flock -w 15 9 || fail "timed out waiting for the FluidSynth lifecycle lock"
 }
 
+remove_shell_fifo() {
+	[ ! -L "$SHELL_FIFO" ] || fail "runtime input path is unsafe: $SHELL_FIFO"
+	if [ -e "$SHELL_FIFO" ]; then
+		[ -p "$SHELL_FIFO" ] || fail "runtime input path is not a FIFO: $SHELL_FIFO"
+		rm -f "$SHELL_FIFO"
+	fi
+}
+
+prepare_shell_fifo() {
+	remove_shell_fifo
+	mkfifo -m 0600 "$SHELL_FIFO"
+	exec 8<>"$SHELL_FIFO"
+}
+
 stop_child_process() {
 	child_pid="$1"
 	kill "$child_pid" 2>/dev/null || true
@@ -152,6 +167,7 @@ fi
 command -v fluidsynth >/dev/null 2>&1 || fail "fluidsynth is not installed"
 command -v aconnect >/dev/null 2>&1 || fail "aconnect is not installed"
 command -v nohup >/dev/null 2>&1 || fail "nohup is not installed"
+command -v mkfifo >/dev/null 2>&1 || fail "mkfifo is not installed"
 command -v ps >/dev/null 2>&1 || fail "ps is not installed"
 [ -f "$SOUNDFONT" ] || fail "SoundFont not found: $SOUNDFONT"
 
@@ -198,6 +214,7 @@ if [ -n "$owned_pid" ]; then
 		kill -KILL "$owned_pid" 2>/dev/null || true
 	fi
 	rm -f "$PID_FILE"
+	remove_shell_fifo
 	fail "an owned FluidSynth process is running without a MIDI port; see $LOG_FILE"
 fi
 
@@ -218,13 +235,16 @@ fi
 
 [ -n "$audio_driver" ] || fail "no supported PipeWire, PulseAudio, or ALSA audio driver is available"
 
-nohup fluidsynth -i -a "$audio_driver" -m alsa_seq \
+prepare_shell_fifo
+nohup fluidsynth -a "$audio_driver" -m alsa_seq \
 	-o "midi.alsa_seq.id=$MIDI_CLIENT_NAME" \
 	-o "midi.portname=$MIDI_PORT_NAME" \
-	"$SOUNDFONT" 9>&- >"$LOG_FILE" 2>&1 &
+	"$SOUNDFONT" <&8 9>&- >"$LOG_FILE" 2>&1 &
 fluidsynth_pid=$!
+exec 8>&-
 fluidsynth_start_time=$(process_start_time "$fluidsynth_pid") || {
 	stop_child_process "$fluidsynth_pid"
+	remove_shell_fifo
 	fail "unable to record the FluidSynth process identity; see $LOG_FILE"
 }
 printf "%s\n%s\n" "$fluidsynth_pid" "$fluidsynth_start_time" >"$PID_FILE"
@@ -238,6 +258,7 @@ while [ "$attempt" -lt 10 ]; do
 
 	if ! owned_process_is_running "$fluidsynth_pid" "$fluidsynth_start_time"; then
 		rm -f "$PID_FILE"
+		remove_shell_fifo
 		tail -n 20 "$LOG_FILE" >&2 || true
 		fail "FluidSynth exited before its MIDI port became ready"
 	fi
@@ -248,4 +269,5 @@ done
 
 stop_child_process "$fluidsynth_pid"
 rm -f "$PID_FILE"
+remove_shell_fifo
 fail "FluidSynth started but its MIDI port did not become ready; see $LOG_FILE"

--- a/core/tabs/gaming/eq-legends-midi-start.sh
+++ b/core/tabs/gaming/eq-legends-midi-start.sh
@@ -101,8 +101,10 @@ remove_shell_fifo() {
 
 prepare_shell_fifo() {
 	remove_shell_fifo
+	trap 'remove_shell_fifo' 0
 	mkfifo -m 0600 "$SHELL_FIFO"
 	exec 8<>"$SHELL_FIFO"
+	trap - 0
 }
 
 stop_child_process() {

--- a/core/tabs/gaming/eq-legends-midi-stop.sh
+++ b/core/tabs/gaming/eq-legends-midi-stop.sh
@@ -7,6 +7,7 @@ else
 fi
 PID_FILE="$RUNTIME_DIR/fluidsynth.pid"
 LOCK_FILE="$RUNTIME_DIR/state.lock"
+SHELL_FIFO="$RUNTIME_DIR/fluidsynth.stdin"
 PENDING_DIR="$RUNTIME_DIR/pending"
 
 umask 077
@@ -89,6 +90,14 @@ acquire_lock() {
 	flock -w 15 9 || fail "timed out waiting for the FluidSynth lifecycle lock"
 }
 
+remove_shell_fifo() {
+	[ ! -L "$SHELL_FIFO" ] || fail "runtime input path is unsafe: $SHELL_FIFO"
+	if [ -e "$SHELL_FIFO" ]; then
+		[ -p "$SHELL_FIFO" ] || fail "runtime input path is not a FIFO: $SHELL_FIFO"
+		rm -f "$SHELL_FIFO"
+	fi
+}
+
 [ -e "$RUNTIME_DIR" ] || exit 0
 command -v flock >/dev/null 2>&1 || fail "flock is not installed"
 command -v pgrep >/dev/null 2>&1 || fail "pgrep is not installed"
@@ -102,6 +111,7 @@ runtime_owner=$(stat -c '%u' -- "$RUNTIME_DIR" 2>/dev/null) || fail "unable to i
 
 acquire_lock
 [ -f "$PID_FILE" ] || {
+	remove_shell_fifo
 	exit 0
 }
 
@@ -110,12 +120,14 @@ fluidsynth_start_time=$(sed -n '2p' "$PID_FILE")
 case "$fluidsynth_pid:$fluidsynth_start_time" in
 *[!0-9:]* | :* | *:)
 	rm -f "$PID_FILE"
+	remove_shell_fifo
 	exit 0
 	;;
 esac
 
 if ! process_matches_start_time "$fluidsynth_pid" "$fluidsynth_start_time"; then
 	rm -f "$PID_FILE"
+	remove_shell_fifo
 	exit 0
 fi
 
@@ -123,6 +135,7 @@ process_name=$(ps -p "$fluidsynth_pid" -o comm= 2>/dev/null | tr -d '[:space:]' 
 if [ "$process_name" != "fluidsynth" ]; then
 	printf "%s\n" "eq-legends-midi: refusing to stop unrelated process $fluidsynth_pid" >&2
 	rm -f "$PID_FILE"
+	remove_shell_fifo
 	exit 1
 fi
 
@@ -146,3 +159,4 @@ if owned_process_is_running "$fluidsynth_pid" "$fluidsynth_start_time"; then
 fi
 
 rm -f "$PID_FILE"
+remove_shell_fifo

--- a/core/tabs/gaming/eq-legends-midi.sh
+++ b/core/tabs/gaming/eq-legends-midi.sh
@@ -76,6 +76,7 @@ check_requirements() {
 	command_exists pgrep || fail "pgrep is required to ensure the Wine prefix is not in use."
 	command_exists sha256sum || fail "sha256sum is required to verify the downloaded SoundFont."
 	command_exists flock || fail "flock is required by the FluidSynth lifecycle hooks."
+	command_exists mkfifo || fail "mkfifo is required by the FluidSynth lifecycle hooks."
 	command_exists ps || fail "ps is required by the FluidSynth lifecycle hooks."
 	command_exists stat || fail "stat is required by the FluidSynth lifecycle hooks."
 	command_exists curl || fail "curl is required to download the SoundFont."

--- a/core/tabs/gaming/tab_data.toml
+++ b/core/tabs/gaming/tab_data.toml
@@ -244,7 +244,7 @@ multi_select = false
 [[data.preconditions]]
 matches = true
 data = "command_exists"
-values = ["curl", "flock", "lutris", "pgrep", "ps", "python3", "sha256sum", "stat"]
+values = ["curl", "flock", "lutris", "mkfifo", "pgrep", "ps", "python3", "sha256sum", "stat"]
 
 [[data.preconditions]]
 matches = false


### PR DESCRIPTION
Follow-up to #1364 after live Fedora 44 validation exposed a FluidSynth lifecycle issue.

## What changed

- Keep FluidSynth's local shell loop alive through a private mode-0600 FIFO instead of `--server`.
- Remove the FIFO alongside PID cleanup and reject unsafe runtime paths.
- Add `mkfifo` to installer and catalog prerequisites.

## Root cause

FluidSynth 2.5.4 exits normally when `--no-shell` is used without server mode. Server mode keeps it alive but opens TCP port 9800 on all interfaces. The private FIFO preserves the process without a network listener.

## Validation

- Live Fedora 44 installation against EverQuest Legends in native Lutris.
- Verified the ALSA `EQ-Legends` client and port while running.
- Verified no FluidSynth TCP listener.
- Verified watcher-driven shutdown at 65 seconds removed the process, PID file, FIFO, and launch tokens.
- `sh -n`, ShellCheck, checkbashisms, and shfmt pass for all three scripts.
- `cargo fmt --all --check`, `cargo test --no-fail-fast --package linutil_core`, `cargo clippy -- -Dwarnings`, `cargo xtask docgen`, and `git diff --check` pass.