### PR TITLE
fix: use DNF5-compatible config-manager syntax on Fedora >= 41

### DIFF
--- a/core/tabs/applications-setup/browsers/google-chrome.sh
+++ b/core/tabs/applications-setup/browsers/google-chrome.sh
@@ -21,7 +21,12 @@ installChrome() {
                 ;;
             dnf)
                 "$ESCALATION_TOOL" "$PACKAGER" install -y fedora-workstation-repositories
-                "$ESCALATION_TOOL" "$PACKAGER" config-manager --set-enabled google-chrome
+                fedora_version=$(rpm -E %fedora)
+                if [ "$fedora_version" -ge 41 ]; then
+                    "$ESCALATION_TOOL" "$PACKAGER" config-manager setopt google-chrome.enabled=1
+                else
+                    "$ESCALATION_TOOL" "$PACKAGER" config-manager --set-enabled google-chrome
+                fi
                 "$ESCALATION_TOOL" "$PACKAGER" install -y google-chrome-stable
                 ;;
             *)

--- a/core/tabs/system-setup/fedora/nvidia-proprietary-driver-setup.sh
+++ b/core/tabs/system-setup/fedora/nvidia-proprietary-driver-setup.sh
@@ -18,7 +18,12 @@ checkRepo() {
     printf "%b\n" "${YELLOW}Nvidia non-free repository is not enabled. Enabling now...${RC}"
 
     # Enable the repository
-    "$ESCALATION_TOOL" dnf config-manager --set-enabled "$REPO_ID"
+    fedora_version=$(rpm -E %fedora)
+    if [ "$fedora_version" -ge 41 ]; then
+        "$ESCALATION_TOOL" dnf config-manager setopt "${REPO_ID}.enabled=1"
+    else
+        "$ESCALATION_TOOL" dnf config-manager --set-enabled "$REPO_ID"
+    fi
 
     # Refreshing repository list
     "$ESCALATION_TOOL" dnf makecache


### PR DESCRIPTION
## Type of Change
  - [x] Bug fix
  
  ## Description
  
  DNF5 (shipped as default in Fedora 41+) removed the `--set-enabled` flag
  from `dnf config-manager`. Scripts that used it fail with:
  
  Unknown argument "--set-enabled" for command "config-manager". Add "--help" for more information about the
  arguments.
  
  The fix adds a Fedora version check (`rpm -E %fedora`) in the affected
  scripts: on Fedora >= 41, `config-manager setopt <repo>.enabled=1` is used;
  older releases keep the existing `--set-enabled` flag. This is the same
  pattern already used in `rpm-fusion-setup.sh`.
  
  **Affected scripts:**
  - `core/tabs/applications-setup/browsers/google-chrome.sh`
  - `core/tabs/system-setup/fedora/nvidia-proprietary-driver-setup.sh`
  
  **Tested on:** Fedora 44 (DNF5 5.4.1.0)
  
  ## Issues / other PRs related
  - Resolves #1366

